### PR TITLE
feat: add diagnostics and improve delegation loading

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+NEXT_PUBLIC_SUPABASE_URL="https://your-supabase-project.supabase.co"
+NEXT_PUBLIC_SUPABASE_ANON_KEY="public-anon-key"
+NEXT_PUBLIC_SITE_URL="http://localhost:3000"
+# Uncomment during local development to override redirect URL
+# NEXT_PUBLIC_DEV_SUPABASE_REDIRECT_URL="http://localhost:3000/auth/callback"

--- a/app/diagnostico/page.tsx
+++ b/app/diagnostico/page.tsx
@@ -1,0 +1,10 @@
+import { AppLayout } from "@/components/app-layout"
+import { DiagnosticCenter } from "@/components/diagnostics/diagnostic-center"
+
+export default function DiagnosticoPage() {
+  return (
+    <AppLayout>
+      <DiagnosticCenter />
+    </AppLayout>
+  )
+}

--- a/components/auth/login-form.tsx
+++ b/components/auth/login-form.tsx
@@ -1,7 +1,6 @@
 "use client"
 
-import { useActionState } from "react"
-import { useFormStatus } from "react-dom"
+import { useFormState, useFormStatus } from "react-dom"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
@@ -30,7 +29,7 @@ function SubmitButton() {
 
 export default function LoginForm() {
   const router = useRouter()
-  const [state, formAction] = useActionState(signIn, null)
+  const [state, formAction] = useFormState(signIn, null)
 
   // Handle successful login by redirecting
   useEffect(() => {

--- a/components/auth/sign-up-form.tsx
+++ b/components/auth/sign-up-form.tsx
@@ -1,7 +1,6 @@
 "use client"
 
-import { useActionState } from "react"
-import { useFormStatus } from "react-dom"
+import { useFormState, useFormStatus } from "react-dom"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
@@ -27,7 +26,7 @@ function SubmitButton() {
 }
 
 export default function SignUpForm() {
-  const [state, formAction] = useActionState(signUp, null)
+  const [state, formAction] = useFormState(signUp, null)
 
   return (
     <Card className="w-full max-w-md">

--- a/components/diagnostics/diagnostic-center.tsx
+++ b/components/diagnostics/diagnostic-center.tsx
@@ -1,0 +1,85 @@
+"use client"
+
+import { useState } from "react"
+import { supabase } from "@/lib/supabase/client"
+import { useAuth } from "@/contexts/auth-context"
+import { Card } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { LoadingSpinner } from "@/components/ui/loading-spinner"
+
+interface Status {
+  db: string
+  lastChecked: string | null
+  env: Record<string, string | undefined>
+}
+
+export function DiagnosticCenter() {
+  const { user } = useAuth()
+  const [status, setStatus] = useState<Status>({
+    db: "No verificado",
+    lastChecked: null,
+    env: {
+      NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL,
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    },
+  })
+  const [checking, setChecking] = useState(false)
+
+  const checkConnection = async () => {
+    setChecking(true)
+    try {
+      const { error } = await supabase.from("movimiento").select("id").limit(1)
+      setStatus({
+        env: status.env,
+        lastChecked: new Date().toLocaleString(),
+        db: error ? `Error: ${error.message}` : "Conectado",
+      })
+    } catch (err) {
+      setStatus({
+        env: status.env,
+        lastChecked: new Date().toLocaleString(),
+        db: err instanceof Error ? `Error: ${err.message}` : "Error desconocido",
+      })
+    } finally {
+      setChecking(false)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-3xl font-bold tracking-tight">Centro de Diagnóstico</h1>
+        <Button onClick={checkConnection} disabled={checking}>
+          {checking ? <LoadingSpinner size="sm" className="mr-2" /> : null}
+          Revisar estado
+        </Button>
+      </div>
+
+      <Card className="p-6 space-y-4">
+        <div>
+          <h2 className="text-xl font-semibold mb-2">Usuario</h2>
+          <p className="text-sm text-muted-foreground">
+            {user ? `${user.email} (${user.id})` : "No autenticado"}
+          </p>
+        </div>
+
+        <div>
+          <h2 className="text-xl font-semibold mb-2">Variables de Entorno</h2>
+          <pre className="bg-muted p-4 rounded-md overflow-auto text-sm">
+{JSON.stringify(status.env, null, 2)}
+          </pre>
+        </div>
+
+        <div>
+          <h2 className="text-xl font-semibold mb-2">Base de Datos</h2>
+          <p className="text-sm">
+            Estado: <span className="font-medium">{status.db}</span>
+          </p>
+          {status.lastChecked && (
+            <p className="text-xs text-muted-foreground">Última revisión: {status.lastChecked}</p>
+          )}
+        </div>
+      </Card>
+    </div>
+  )
+}

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -14,6 +14,7 @@ import {
   Settings,
   Users,
   Zap,
+  Activity,
   Menu,
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
@@ -89,6 +90,13 @@ const navigation = [
     icon: Settings,
     count: null,
     enabled: false,
+  },
+  {
+    name: "Diagnóstico",
+    href: "/diagnostico",
+    icon: Activity,
+    count: null,
+    enabled: true,
   },
 ]
 

--- a/hooks/use-delegaciones.ts
+++ b/hooks/use-delegaciones.ts
@@ -2,57 +2,56 @@
 
 import { useState, useEffect } from "react"
 import { supabase } from "@/lib/supabase/client"
+import { useAuth } from "@/contexts/auth-context"
 import type { Delegacion } from "@/lib/types/database"
 
 export function useDelegaciones() {
   const [delegaciones, setDelegaciones] = useState<Delegacion[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const { user } = useAuth()
 
-  useEffect(() => {
-    async function fetchDelegaciones() {
-      try {
-        setLoading(true)
-
-        const {
-          data: { user },
-        } = await supabase.auth.getUser()
-
-        if (!user) {
-          setError("Usuario no autenticado")
-          return
-        }
-
-        const { data, error } = await supabase
-          .from("membresia")
-          .select(`
-            delegacion_id,
-            delegacion:delegacion_id (
-              id,
-              organizacion_id,
-              codigo,
-              nombre,
-              creado_en
-            )
-          `)
-          .eq("usuario_id", user.id)
-
-        if (error) {
-          setError(error.message)
-          return
-        }
-
-        const delegacionesData = data?.map((item) => item.delegacion).filter(Boolean) as Delegacion[]
-        setDelegaciones(delegacionesData || [])
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "Error desconocido")
-      } finally {
-        setLoading(false)
-      }
+  const fetchDelegaciones = async () => {
+    if (!user) {
+      setDelegaciones([])
+      setLoading(false)
+      return
     }
 
+    try {
+      setLoading(true)
+
+      const { data, error } = await supabase
+        .from("membresia")
+        .select(`
+          delegacion_id,
+          delegacion:delegacion_id (
+            id,
+            organizacion_id,
+            codigo,
+            nombre,
+            creado_en
+          )
+        `)
+        .eq("usuario_id", user.id)
+
+      if (error) {
+        setError(error.message)
+        return
+      }
+
+      const delegacionesData = data?.map((item) => item.delegacion).filter(Boolean) as Delegacion[]
+      setDelegaciones(delegacionesData || [])
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Error desconocido")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
     fetchDelegaciones()
-  }, [])
+  }, [user])
 
   return { delegaciones, loading, error }
 }

--- a/hooks/use-delegations.ts
+++ b/hooks/use-delegations.ts
@@ -2,25 +2,25 @@
 
 import { useState, useEffect } from "react"
 import { supabase } from "@/lib/supabase/client"
+import { useAuth } from "@/contexts/auth-context"
 import type { Delegacion } from "@/lib/types/database"
 
 export function useDelegations() {
   const [delegations, setDelegations] = useState<Delegacion[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const { user } = useAuth()
 
   const fetchDelegations = async () => {
+    if (!user) {
+      setDelegations([])
+      setLoading(false)
+      return
+    }
+
     try {
       setLoading(true)
       setError(null)
-
-      const {
-        data: { user },
-        error: userError,
-      } = await supabase.auth.getUser()
-      if (userError || !user) {
-        throw new Error("Usuario no autenticado")
-      }
 
       const { data, error } = await supabase
         .from("membresia")
@@ -49,7 +49,7 @@ export function useDelegations() {
 
   useEffect(() => {
     fetchDelegations()
-  }, [])
+  }, [user])
 
   return { delegations, loading, error, refetch: fetchDelegations }
 }

--- a/hooks/use-movimientos.ts
+++ b/hooks/use-movimientos.ts
@@ -55,6 +55,8 @@ export function useMovimientos(delegacionId: string | null, filters?: Movimiento
         `)
         .eq("cuenta.delegacion_id", delegacionId)
         .order("fecha", { ascending: false })
+        // Limit results to prevent UI freezing with large datasets
+        .limit(100)
 
       if (filters?.fechaDesde) {
         query = query.gte("fecha", filters.fechaDesde)

--- a/hooks/use-user-delegaciones.ts
+++ b/hooks/use-user-delegaciones.ts
@@ -2,56 +2,54 @@
 
 import { useState, useEffect } from "react"
 import { supabase } from "@/lib/supabase/client"
+import { useAuth } from "@/contexts/auth-context"
 import type { Delegacion } from "@/lib/types/database"
 
 export function useUserDelegaciones() {
   const [delegaciones, setDelegaciones] = useState<Delegacion[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const { user } = useAuth()
 
-  useEffect(() => {
-    const fetchDelegaciones = async () => {
-      try {
-        setLoading(true)
-        setError(null)
-
-        // Get current user
-        const {
-          data: { user },
-          error: userError,
-        } = await supabase.auth.getUser()
-        if (userError || !user) {
-          throw new Error("Usuario no autenticado")
-        }
-
-        // Get user's delegaciones through membresia
-        const { data, error } = await supabase
-          .from("membresia")
-          .select(`
-            delegacion_id,
-            delegacion:delegacion_id (
-              id,
-              organizacion_id,
-              codigo,
-              nombre,
-              creado_en
-            )
-          `)
-          .eq("usuario_id", user.id)
-
-        if (error) throw error
-
-        const userDelegaciones = data?.map((item) => item.delegacion).filter(Boolean) || []
-        setDelegaciones(userDelegaciones)
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "Error desconocido")
-      } finally {
-        setLoading(false)
-      }
+  const fetchDelegaciones = async () => {
+    if (!user) {
+      setDelegaciones([])
+      setLoading(false)
+      return
     }
 
-    fetchDelegaciones()
-  }, [])
+    try {
+      setLoading(true)
+      setError(null)
 
-  return { delegaciones, loading, error, refetch: () => fetchDelegaciones() }
+      const { data, error } = await supabase
+        .from("membresia")
+        .select(`
+          delegacion_id,
+          delegacion:delegacion_id (
+            id,
+            organizacion_id,
+            codigo,
+            nombre,
+            creado_en
+          )
+        `)
+        .eq("usuario_id", user.id)
+
+      if (error) throw error
+
+      const userDelegaciones = data?.map((item) => item.delegacion).filter(Boolean) || []
+      setDelegaciones(userDelegaciones)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Error desconocido")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    fetchDelegaciones()
+  }, [user])
+
+  return { delegaciones, loading, error, refetch: fetchDelegaciones }
 }

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,11 +1,18 @@
 import { createBrowserClient } from "@supabase/ssr"
 import type { Database } from "@/lib/types/database"
 
-export function createClient() {
-  return createBrowserClient<Database>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error(
+    "Supabase environment variables are missing. Check NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY.",
   )
 }
 
-export const supabase = createClient()
+export const supabase = createBrowserClient<Database>(supabaseUrl, supabaseAnonKey)
+
+export function createClient() {
+  return supabase
+}
+

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -4,25 +4,29 @@ import type { Database } from "@/lib/types/database"
 
 export function createClient() {
   const cookieStore = cookies()
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 
-  return createServerClient<Database>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      cookies: {
-        getAll() {
-          return cookieStore.getAll()
-        },
-        setAll(cookiesToSet) {
-          try {
-            cookiesToSet.forEach(({ name, value, options }) => cookieStore.set(name, value, options))
-          } catch {
-            // The `setAll` method was called from a Server Component.
-            // This can be ignored if you have middleware refreshing
-            // user sessions.
-          }
-        },
+  if (!supabaseUrl || !supabaseAnonKey) {
+    throw new Error(
+      "Supabase environment variables are missing. Check NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY.",
+    )
+  }
+
+  return createServerClient<Database>(supabaseUrl, supabaseAnonKey, {
+    cookies: {
+      getAll() {
+        return cookieStore.getAll()
+      },
+      setAll(cookiesToSet) {
+        try {
+          cookiesToSet.forEach(({ name, value, options }) => cookieStore.set(name, value, options))
+        } catch {
+          // The `setAll` method was called from a Server Component.
+          // This can be ignored if you have middleware refreshing
+          // user sessions.
+        }
       },
     },
-  )
+  })
 }


### PR DESCRIPTION
## Summary
- add a diagnostics center to inspect auth, environment variables and database connectivity
- expose diagnostics from a new sidebar entry
- defer delegation queries until a user session exists
- limit transaction fetches to 100 records to keep the UI responsive

## Testing
- `pnpm build` *(fails: Supabase environment variables are missing)*
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_689e2baf63ac832693bdd6306c91d597