### PR TITLE
feat: import bank excel files

### DIFF
--- a/components/transactions/transaction-import-panel.tsx
+++ b/components/transactions/transaction-import-panel.tsx
@@ -1,0 +1,217 @@
+"use client"
+
+import { useState } from "react"
+import Image from "next/image"
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet"
+import { Button } from "@/components/ui/button"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { LoadingSpinner } from "@/components/ui/loading-spinner"
+import { useAuth } from "@/contexts/auth-context"
+import { DatabaseService } from "@/lib/services/database"
+import { supabase } from "@/lib/supabase/client"
+import type { Cuenta } from "@/lib/types/database"
+import { parseSabadell, parseCaixabank, RowParseError, type ImportedTransaction } from "@/lib/utils/bank-import"
+
+interface TransactionImportPanelProps {
+  accounts: Cuenta[]
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onImported: (count: number) => void
+}
+
+type Origin = "manual" | "sabadell" | "caixabank"
+
+const ENABLE_DUPLICATE_CHECK = true // Set to false to skip duplicate detection
+
+export function TransactionImportPanel({ accounts, open, onOpenChange, onImported }: TransactionImportPanelProps) {
+  const { user } = useAuth()
+  const [origin, setOrigin] = useState<Origin | null>(null)
+  const [fileName, setFileName] = useState<string>("")
+  const [transactions, setTransactions] = useState<ImportedTransaction[]>([])
+  const [accountId, setAccountId] = useState<string>("")
+  const [error, setError] = useState<{ message: string; code: string } | null>(null)
+  const [status, setStatus] = useState<"idle" | "parsing" | "uploading" | "success">("idle")
+  const [duplicates, setDuplicates] = useState<ImportedTransaction[]>([])
+
+  const handleFile = async (file: File) => {
+    setError(null)
+    setTransactions([])
+    setDuplicates([])
+    setStatus("parsing")
+    try {
+      const buffer = await file.arrayBuffer()
+      let parsed: ImportedTransaction[] = []
+      if (origin === "sabadell") parsed = parseSabadell(buffer)
+      else if (origin === "caixabank") parsed = parseCaixabank(buffer)
+      else parsed = []
+      setTransactions(parsed)
+      setFileName(file.name)
+    } catch (err) {
+      if (err instanceof RowParseError) {
+        setError({ message: `Error en la fila ${err.row}: ${err.message}`, code: err.code })
+      } else {
+        setError({ message: "No se pudo procesar el archivo", code: "PARSE" })
+      }
+    } finally {
+      setStatus("idle")
+    }
+  }
+
+  const handleImport = async () => {
+    if (!accountId || transactions.length === 0) return
+    setStatus("uploading")
+    try {
+      if (ENABLE_DUPLICATE_CHECK) {
+        const dups: ImportedTransaction[] = []
+        for (const t of transactions) {
+          const { data } = await supabase
+            .from("movimiento")
+            .select("id")
+            .eq("cuenta_id", accountId)
+            .eq("fecha", t.fecha)
+            .eq("concepto", t.concepto)
+            .eq("importe", t.importe)
+            .limit(1)
+          if (data && data.length > 0) dups.push(t)
+        }
+        if (dups.length) setDuplicates(dups)
+      }
+
+      const inserts = transactions.map((t) => ({
+        cuenta_id: accountId,
+        fecha: t.fecha,
+        concepto: t.concepto,
+        descripcion: t.descripcion || null,
+        importe: t.importe,
+        creado_por: user?.id || ""
+      }))
+      await DatabaseService.insertMovimientos(inserts)
+      setStatus("success")
+      onImported(inserts.length)
+    } catch (err) {
+      setError({ message: "Error al importar los datos", code: "UPLOAD" })
+      setStatus("idle")
+    }
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="w-full sm:max-w-lg overflow-y-auto">
+        <SheetHeader className="space-y-3 pb-6 border-b">
+          <SheetTitle className="text-xl">Importar transacciones</SheetTitle>
+        </SheetHeader>
+
+        <div className="space-y-6 mt-6">
+          <section className="space-y-4">
+            <h4 className="font-medium">Origen de los datos</h4>
+            <div className="grid grid-cols-3 gap-2">
+              <button
+                type="button"
+                onClick={() => setOrigin("manual")}
+                className={`border rounded-md p-3 text-sm ${origin === "manual" ? "border-primary" : "border-muted"}`}
+              >
+                Excel manual
+              </button>
+              <button
+                type="button"
+                onClick={() => setOrigin("sabadell")}
+                className={`border rounded-md p-3 flex items-center justify-center ${origin === "sabadell" ? "border-primary" : "border-muted"}`}
+              >
+                <Image src="/bank-logos/sabadell.png" alt="Sabadell" width={80} height={24} />
+              </button>
+              <button
+                type="button"
+                onClick={() => setOrigin("caixabank")}
+                className={`border rounded-md p-3 flex items-center justify-center ${origin === "caixabank" ? "border-primary" : "border-muted"}`}
+              >
+                <Image src="/bank-logos/caixabank.png" alt="Caixabank" width={80} height={24} />
+              </button>
+            </div>
+            {origin === "manual" && (
+              <p className="text-sm text-muted-foreground">Funcionalidad disponible próximamente.</p>
+            )}
+            {(origin === "sabadell" || origin === "caixabank") && (
+              <div className="mt-4">
+                <label
+                  htmlFor="import-file"
+                  className="flex flex-col items-center justify-center w-full h-32 border-2 border-dashed rounded-md cursor-pointer text-sm text-muted-foreground hover:bg-muted/50"
+                  onDragOver={(e) => e.preventDefault()}
+                  onDrop={(e) => {
+                    e.preventDefault()
+                    const f = e.dataTransfer.files?.[0]
+                    if (f) handleFile(f)
+                  }}
+                >
+                  {fileName ? <span className="text-center px-2">{fileName}</span> : <span>Arrastra o haz click para subir</span>}
+                </label>
+                <input
+                  id="import-file"
+                  type="file"
+                  accept=".xls,.xlsx"
+                  className="hidden"
+                  onChange={(e) => {
+                    const f = e.target.files?.[0]
+                    if (f) handleFile(f)
+                  }}
+                />
+              </div>
+            )}
+          </section>
+
+          <section className="space-y-4">
+            <h4 className="font-medium">Cuenta de destino</h4>
+            <Select value={accountId} onValueChange={setAccountId}>
+              <SelectTrigger>
+                <SelectValue placeholder="Selecciona cuenta" />
+              </SelectTrigger>
+              <SelectContent>
+                {accounts.map((acc) => (
+                  <SelectItem key={acc.id} value={acc.id}>
+                    {acc.nombre}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </section>
+
+          {error && (
+            <div className="text-sm text-red-600">
+              {error.message}
+              <div className="text-xs mt-1">
+                <code>{error.code}</code>
+              </div>
+            </div>
+          )}
+
+          {duplicates.length > 0 && (
+            <div className="text-sm text-amber-600">
+              Se detectaron {duplicates.length} posibles duplicados
+            </div>
+          )}
+
+          {status === "uploading" && (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <LoadingSpinner size="sm" /> Importando...
+            </div>
+          )}
+
+          {status === "success" && (
+            <div className="text-sm text-green-600">
+              Se han importado {transactions.length} transacciones
+            </div>
+          )}
+
+          <Button
+            className="w-full"
+            disabled={
+              origin === "manual" || !accountId || transactions.length === 0 || status === "uploading" || status === "parsing"
+            }
+            onClick={handleImport}
+          >
+            Importar
+          </Button>
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/components/transactions/transaction-manager.tsx
+++ b/components/transactions/transaction-manager.tsx
@@ -5,6 +5,7 @@ import { TransactionFiltersComponent } from "./transaction-filters"
 import { TransactionList } from "./transaction-list"
 import { TransactionDetail } from "./transaction-detail"
 import { TransactionCreatePanel } from "./transaction-create-panel"
+import { TransactionImportPanel } from "./transaction-import-panel"
 import { DateRangeFilter } from "./date-range-filter"
 import { useDelegationContext } from "@/contexts/delegation-context"
 import { useMovimientos } from "@/hooks/use-movimientos"
@@ -45,6 +46,7 @@ export function TransactionManager({ onTransactionCountChange }: TransactionMana
   const [filtersOpen, setFiltersOpen] = useState(false)
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
   const [createFormOpen, setCreateFormOpen] = useState(false)
+  const [importOpen, setImportOpen] = useState(false)
 
   const currentDelegation = getCurrentDelegation()
   const organizacionId = currentDelegation?.organizacion_id
@@ -54,6 +56,7 @@ export function TransactionManager({ onTransactionCountChange }: TransactionMana
     loading,
     error,
     updateCategoria,
+    refetch,
   } = useMovimientos(selectedDelegation, {
     fechaDesde: filters.dateFrom,
     fechaHasta: filters.dateTo,
@@ -243,6 +246,7 @@ export function TransactionManager({ onTransactionCountChange }: TransactionMana
                 size="sm"
                 className="flex-shrink-0 bg-transparent"
                 title="Importar transacciones"
+                onClick={() => setImportOpen(true)}
               >
                 <Upload className="h-4 w-4" />
                 <span className="hidden lg:ml-2 lg:inline">Importar</span>
@@ -327,6 +331,15 @@ export function TransactionManager({ onTransactionCountChange }: TransactionMana
         open={createFormOpen}
         onOpenChange={setCreateFormOpen}
         onCreate={handleCreateMovement}
+      />
+
+      <TransactionImportPanel
+        accounts={accounts as unknown as Cuenta[]}
+        open={importOpen}
+        onOpenChange={setImportOpen}
+        onImported={async () => {
+          await refetch()
+        }}
       />
     </div>
   )

--- a/lib/services/database.ts
+++ b/lib/services/database.ts
@@ -1,5 +1,5 @@
 import { supabase } from "@/lib/supabase/client"
-import type { Categoria } from "@/lib/types/database"
+import type { Categoria, Database } from "@/lib/types/database"
 
 export class DatabaseService {
   private static getClient() {
@@ -10,6 +10,13 @@ export class DatabaseService {
   static async updateMovimientoCategoria(movimientoId: string, categoriaId: string | null): Promise<void> {
     const supabase = this.getClient()
     const { error } = await supabase.from("movimiento").update({ categoria_id: categoriaId }).eq("id", movimientoId)
+
+    if (error) throw error
+  }
+
+  static async insertMovimientos(movimientos: Database["public"]["Tables"]["movimiento"]["Insert"][]): Promise<void> {
+    const supabase = this.getClient()
+    const { error } = await supabase.from("movimiento").insert(movimientos)
 
     if (error) throw error
   }

--- a/lib/utils/bank-import.ts
+++ b/lib/utils/bank-import.ts
@@ -1,0 +1,121 @@
+import * as XLSX from "xlsx"
+import { format, parse } from "date-fns"
+
+export interface ImportedTransaction {
+  fecha: string
+  concepto: string
+  descripcion?: string
+  importe: number
+}
+
+export class RowParseError extends Error {
+  row: number
+  code: string
+  constructor(message: string, row: number, code: string) {
+    super(message)
+    this.row = row
+    this.code = code
+    this.name = "RowParseError"
+  }
+}
+
+const normalizeConcept = (text: string) =>
+  text
+    .trim()
+    .split(/\s+/)
+    .map((w) => (w.length <= 2 ? w.toLowerCase() : w[0].toUpperCase() + w.slice(1).toLowerCase()))
+    .join(" ")
+
+const parseImporte = (value: any): number => {
+  if (typeof value === "number") return value
+  if (typeof value === "string") {
+    const cleaned = value.replace(/\./g, "").replace(/,/g, ".")
+    const num = parseFloat(cleaned)
+    if (!isNaN(num)) return num
+  }
+  return NaN
+}
+
+export function parseSabadell(buffer: ArrayBuffer): ImportedTransaction[] {
+  const wb = XLSX.read(buffer, { type: "array", cellDates: true })
+  const sheet = wb.Sheets[wb.SheetNames[0]]
+  const rows = XLSX.utils.sheet_to_json<any>(sheet, { header: "A", raw: false })
+  const data = rows.slice(8) // start from row 9
+  const result: ImportedTransaction[] = []
+
+  data.forEach((row, idx) => {
+    const excelRow = idx + 9
+    if (!row.A && !row.B && !row.D) return
+    const fechaVal = row.A
+    const conceptoVal = row.B
+    const importeVal = row.D
+
+    if (!fechaVal || !conceptoVal || importeVal === undefined) {
+      throw new RowParseError("Fila incompleta", excelRow, "SBD_INCOMPLETE")
+    }
+
+    const fecha = typeof fechaVal === "object"
+      ? format(fechaVal as Date, "yyyy-MM-dd")
+      : format(parse(String(fechaVal), "dd/MM/yyyy", new Date()), "yyyy-MM-dd")
+
+    const importe = parseImporte(importeVal)
+    if (isNaN(importe)) {
+      throw new RowParseError("Importe inválido", excelRow, "SBD_AMOUNT")
+    }
+
+    result.push({
+      fecha,
+      concepto: normalizeConcept(String(conceptoVal)),
+      importe,
+    })
+  })
+
+  return result
+}
+
+export function parseCaixabank(buffer: ArrayBuffer): ImportedTransaction[] {
+  const wb = XLSX.read(buffer, { type: "array", cellDates: true })
+  const sheet = wb.Sheets[wb.SheetNames[0]]
+  const rows = XLSX.utils.sheet_to_json<any>(sheet, { header: "A", raw: false })
+  const data = rows.slice(3) // start from row 4
+  const result: ImportedTransaction[] = []
+
+  data.forEach((row, idx) => {
+    const excelRow = idx + 4
+    if (!row.A && !row.C && !row.E) return
+    const fechaVal = row.A
+    const conceptoVal = row.C
+    const descVal = row.D
+    const importeVal = row.E
+    const extra1 = row.F
+    const extra2 = row.G
+
+    if (!fechaVal || !conceptoVal || importeVal === undefined) {
+      throw new RowParseError("Fila incompleta", excelRow, "CXB_INCOMPLETE")
+    }
+
+    const fecha = typeof fechaVal === "object"
+      ? format(fechaVal as Date, "yyyy-MM-dd")
+      : format(parse(String(fechaVal), "dd/M/yyyy", new Date()), "yyyy-MM-dd")
+
+    const importe = parseImporte(importeVal)
+    if (isNaN(importe)) {
+      throw new RowParseError("Importe inválido", excelRow, "CXB_AMOUNT")
+    }
+
+    const extras = [extra1, extra2].filter((t) => typeof t === "string" && !/^\d+$/.test(t))
+    const descripcionParts = [] as string[]
+    if (descVal) descripcionParts.push(String(descVal))
+    if (extras.length) descripcionParts.push(extras.join("\n"))
+    const descripcion = descripcionParts.length ? descripcionParts.join("\n") : undefined
+
+    result.push({
+      fecha,
+      concepto: normalizeConcept(String(conceptoVal)),
+      descripcion,
+      importe,
+    })
+  })
+
+  return result
+}

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "react-resizable-panels": "^2.1.7",
     "recharts": "2.15.0",
     "sonner": "^1.7.1",
+    "xlsx": "^0.18.5",
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "1.1.2",


### PR DESCRIPTION
## Summary
- add transaction import panel with Sabadell and Caixabank Excel parsing
- support inserting parsed movements and duplicate detection
- extend database service and add xlsx dependency

## Testing
- `pnpm lint` *(fails: ELIFECYCLE Command failed with exit code 1)*
- `pnpm build` *(fails: Failed to fetch font `Geist`)*

------
https://chatgpt.com/codex/tasks/task_e_68a50a9e93948326becd9d01a6c06de5