### PR TITLE
Add Excel download for transactions

### DIFF
--- a/contexts/app-providers.tsx
+++ b/contexts/app-providers.tsx
@@ -4,6 +4,7 @@ import type React from "react"
 import { AuthProvider } from "./auth-context"
 import { DelegationProvider } from "./delegation-context"
 import { ConnectionMonitor } from "@/components/connection-monitor"
+import { Toaster } from "sonner"
 
 interface AppProvidersProps {
   children: React.ReactNode
@@ -15,6 +16,7 @@ export function AppProviders({ children }: AppProvidersProps) {
       <DelegationProvider>
         <ConnectionMonitor />
         {children}
+        <Toaster richColors />
       </DelegationProvider>
     </AuthProvider>
   )

--- a/lib/utils/export-to-excel.ts
+++ b/lib/utils/export-to-excel.ts
@@ -1,0 +1,38 @@
+import type { MovimientoConRelaciones, Cuenta, Categoria } from "@/lib/types/database"
+import { formatDate } from "./format"
+
+export async function exportMovementsToExcel(
+  movements: MovimientoConRelaciones[],
+  accounts: Cuenta[],
+  categories: Categoria[],
+) {
+  try {
+    // @ts-ignore - optional dependency
+    const XLSX = (await import("xlsx")).default
+
+    const data = movements.map((m) => ({
+      Fecha: formatDate(m.fecha),
+      Cuenta:
+        m.cuenta?.nombre || accounts.find((a) => a.id === m.cuenta_id)?.nombre || "",
+      Concepto: m.concepto,
+      Categoría:
+        m.categoria?.nombre ||
+        categories.find((c) => c.id === m.categoria_id)?.nombre ||
+        "",
+      Importe: m.importe,
+      Descripción: m.descripcion ?? "",
+      Contacto: m.contraparte ?? "",
+      Método: m.metodo ?? "",
+      Notas: m.notas ?? "",
+    }))
+
+    const worksheet = XLSX.utils.json_to_sheet(data)
+    const workbook = XLSX.utils.book_new()
+    XLSX.utils.book_append_sheet(workbook, worksheet, "Transacciones")
+    const fileName = `transacciones-${new Date().toISOString().split("T")[0]}.xlsx`
+    XLSX.writeFile(workbook, fileName)
+  } catch (error) {
+    console.error("Excel export failed", error)
+    throw error
+  }
+}


### PR DESCRIPTION
## Summary
- export filtered transactions to Excel with feedback
- show toasts globally and download button states

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68a50bc0c7208326922cd3b22e0e5517