### PR TITLE
Filtrar transacciones por delegación con paginación infinita

### DIFF
--- a/components/transactions/transaction-manager.tsx
+++ b/components/transactions/transaction-manager.tsx
@@ -70,9 +70,13 @@ export function TransactionManager({ onTransactionCountChange }: TransactionMana
   const {
     movimientos: movements,
     loading,
+    loadingMore,
     error,
     updateCategoria,
     refetch,
+    hasMore,
+    total,
+    loadMore,
   } = useMovimientos(selectedDelegation, {
     fechaDesde: filters.dateFrom,
     fechaHasta: filters.dateTo,
@@ -154,9 +158,9 @@ export function TransactionManager({ onTransactionCountChange }: TransactionMana
 
   useEffect(() => {
     if (onTransactionCountChange) {
-      onTransactionCountChange(movements.length)
+      onTransactionCountChange(total)
     }
-  }, [movements.length, onTransactionCountChange])
+  }, [total, onTransactionCountChange])
 
   if (delegationsLoading) {
     return (
@@ -355,13 +359,16 @@ export function TransactionManager({ onTransactionCountChange }: TransactionMana
             accounts={accounts as unknown as Cuenta[]}
             categories={categories as unknown as Categoria[]}
             loading={loading}
+            loadingMore={loadingMore}
             error={error}
-            total={movements.length}
+            total={total}
+            hasMore={hasMore}
             onMovementClick={(movement) => handleMovementClick(movement as unknown as MovimientoConRelaciones)}
             onMovementUpdate={async (movementId, patch) => {
               const fullPatch: Partial<MovimientoConRelaciones> = patch
               await handleMovementUpdate(movementId, fullPatch)
             }}
+            onLoadMore={loadMore}
           />
         </div>
       </div>

--- a/hooks/use-movimientos.ts
+++ b/hooks/use-movimientos.ts
@@ -19,145 +19,137 @@ interface MovimientosFilters {
 export function useMovimientos(delegacionId: string | null, filters?: MovimientosFilters) {
   const [movimientos, setMovimientos] = useState<MovimientoConRelaciones[]>([])
   const [loading, setLoading] = useState(true)
+  const [loadingMore, setLoadingMore] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [page, setPage] = useState(0)
+  const [hasMore, setHasMore] = useState(true)
+  const [total, setTotal] = useState(0)
+  const pageSize = 100
 
   const fetchIdRef = useRef(0)
   const lastQueryKeyRef = useRef<string | null>(null)
 
-  const fetchMovimientos = useCallback(async (forceRefresh = false) => {
-    const queryKey = [
-      delegacionId || "",
-      filters?.fechaDesde || "",
-      filters?.fechaHasta || "",
-      (filters?.categoriaIds || []).join(","),
-      filters?.cuentaId || "",
-      filters?.busqueda || "",
-      filters?.amountFrom || "",
-      filters?.amountTo || "",
-      filters?.uncategorized || "",
-    ].join("|")
+  const fetchMovimientos = useCallback(
+    async (pageArg = 0, append = false, forceRefresh = false) => {
+      const queryKey = [
+        delegacionId || "",
+        filters?.fechaDesde || "",
+        filters?.fechaHasta || "",
+        (filters?.categoriaIds || []).join(","),
+        filters?.cuentaId || "",
+        filters?.busqueda || "",
+        filters?.amountFrom || "",
+        filters?.amountTo || "",
+        filters?.uncategorized || "",
+      ].join("|")
 
-    if (!forceRefresh && lastQueryKeyRef.current === queryKey) {
-      return
-    }
-    lastQueryKeyRef.current = queryKey
-    const fetchId = ++fetchIdRef.current
-    if (!delegacionId) {
-      setMovimientos([])
-      setLoading(false)
-      return
-    }
+      if (!forceRefresh && !append && lastQueryKeyRef.current === queryKey) {
+        return
+      }
+      lastQueryKeyRef.current = queryKey
+      const fetchId = ++fetchIdRef.current
 
-    try {
-      setLoading(true)
-      setError(null)
-
-      console.log(`🔍 useMovimientos: Fetching movements for delegacion: ${delegacionId}`)
-      
-      let query = supabase
-        .from("movimiento")
-        .select(`
-          *,
-          cuenta:cuenta_id (
-            *,
-            delegacion:delegacion_id (
-              id,
-              organizacion_id,
-              codigo,
-              nombre,
-              creado_en
-            )
-          ),
-          categoria:categoria_id (
-            id,
-            organizacion_id,
-            nombre,
-            tipo,
-            emoji,
-            orden,
-            categoria_padre_id,
-            creado_en
-          )
-        `)
-        .eq("cuenta.delegacion_id", delegacionId)
-        .order("fecha", { ascending: false })
-        .order("creado_en", { ascending: false })
-        // Limit results to prevent UI freezing with large datasets
-        .limit(200)
-
-      if (filters?.fechaDesde) {
-        query = query.gte("fecha", filters.fechaDesde)
-      }
-      if (filters?.fechaHasta) {
-        query = query.lte("fecha", filters.fechaHasta)
-      }
-      if (filters?.categoriaIds && filters.categoriaIds.length > 0) {
-        query = query.in("categoria_id", filters.categoriaIds)
-      }
-      if (filters?.uncategorized) {
-        query = query.is("categoria_id", null)
-      }
-      if (filters?.cuentaId) {
-        query = query.eq("cuenta_id", filters.cuentaId)
-      }
-      if (filters?.busqueda) {
-        query = query.or(`concepto.ilike.%${filters.busqueda}%,descripcion.ilike.%${filters.busqueda}%`)
-      }
-      if (filters?.amountFrom !== undefined) {
-        query = query.gte("importe", filters.amountFrom)
-      }
-      if (filters?.amountTo !== undefined) {
-        query = query.lte("importe", filters.amountTo)
-      }
-
-      const { data, error } = await query
-
-      if (fetchId !== fetchIdRef.current) {
+      if (!delegacionId) {
+        setMovimientos([])
+        setLoading(false)
+        setHasMore(false)
+        setTotal(0)
         return
       }
 
-      if (error) throw error
-      console.log(`✅ useMovimientos: Fetched ${data?.length || 0} movimientos for delegation ${delegacionId}`)
-      console.log(`🏪 useMovimientos: Filtered accounts in results:`, data?.map(m => ({ 
-        movId: m.id, 
-        cuentaId: m.cuenta_id, 
-        cuentaNombre: m.cuenta?.nombre,
-        delegacionId: m.cuenta?.delegacion_id,
-        delegacionNombre: m.cuenta?.delegacion?.nombre 
-      })).slice(0, 3))
-      setMovimientos(data || [])
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Error desconocido")
-    } finally {
-      setLoading(false)
-    }
-  }, [
-    delegacionId,
-    filters?.fechaDesde,
-    filters?.fechaHasta,
-    filters?.categoriaIds,
-    filters?.cuentaId,
-    filters?.busqueda,
-    filters?.amountFrom,
-    filters?.amountTo,
-    filters?.uncategorized,
-  ])
+      try {
+        append ? setLoadingMore(true) : setLoading(true)
+        setError(null)
+
+        let query = supabase
+          .from("movimiento")
+          .select(
+            `
+            *,
+            cuenta:cuenta_id (*),
+            categoria:categoria_id (*)
+            `,
+            { count: "exact" },
+          )
+          .eq("delegacion_id", delegacionId)
+          .order("fecha", { ascending: false })
+          .order("creado_en", { ascending: false })
+          .range(pageArg * pageSize, pageArg * pageSize + pageSize - 1)
+
+        if (filters?.fechaDesde) {
+          query = query.gte("fecha", filters.fechaDesde)
+        }
+        if (filters?.fechaHasta) {
+          query = query.lte("fecha", filters.fechaHasta)
+        }
+        if (filters?.categoriaIds && filters.categoriaIds.length > 0) {
+          query = query.in("categoria_id", filters.categoriaIds)
+        }
+        if (filters?.uncategorized) {
+          query = query.is("categoria_id", null)
+        }
+        if (filters?.cuentaId) {
+          query = query.eq("cuenta_id", filters.cuentaId)
+        }
+        if (filters?.busqueda) {
+          query = query.or(`concepto.ilike.%${filters.busqueda}%,descripcion.ilike.%${filters.busqueda}%`)
+        }
+        if (filters?.amountFrom !== undefined) {
+          query = query.gte("importe", filters.amountFrom)
+        }
+        if (filters?.amountTo !== undefined) {
+          query = query.lte("importe", filters.amountTo)
+        }
+
+        const { data, error, count } = await query
+
+        if (fetchId !== fetchIdRef.current) {
+          return
+        }
+
+        if (error) throw error
+        setTotal(count || 0)
+        if (append) {
+          setMovimientos((prev) => [...prev, ...(data || [])])
+        } else {
+          setMovimientos(data || [])
+        }
+        setHasMore((data?.length || 0) === pageSize)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Error desconocido")
+      } finally {
+        append ? setLoadingMore(false) : setLoading(false)
+      }
+    },
+    [
+      delegacionId,
+      filters?.fechaDesde,
+      filters?.fechaHasta,
+      filters?.categoriaIds,
+      filters?.cuentaId,
+      filters?.busqueda,
+      filters?.amountFrom,
+      filters?.amountTo,
+      filters?.uncategorized,
+      pageSize,
+    ],
+  )
 
   useEffect(() => {
-    let cancelled = false
-    const timeoutId = setTimeout(() => {
-      if (!cancelled) {
-        fetchMovimientos()
-      }
-    }, 80)
-    return () => {
-      cancelled = true
-      clearTimeout(timeoutId)
-    }
+    setPage(0)
+    setHasMore(true)
+    fetchMovimientos(0, false, true)
   }, [fetchMovimientos])
 
   // Revalidate on focus
-  useRevalidateOnFocus(fetchMovimientos)
+  useRevalidateOnFocus(() => fetchMovimientos(0, false, true))
+
+  const loadMore = useCallback(() => {
+    if (loadingMore || !hasMore) return
+    const nextPage = page + 1
+    setPage(nextPage)
+    fetchMovimientos(nextPage, true, true)
+  }, [fetchMovimientos, hasMore, loadingMore, page])
 
   const updateCategoria = async (movimientoId: string, categoriaId: string | null) => {
     try {
@@ -177,11 +169,14 @@ export function useMovimientos(delegacionId: string | null, filters?: Movimiento
   return {
     movimientos,
     loading,
+    loadingMore,
     error,
+    hasMore,
+    total,
+    loadMore,
     refetch: () => {
-      // Forzar invalidación completa de la cache
       lastQueryKeyRef.current = null
-      return fetchMovimientos(true)
+      return fetchMovimientos(0, false, true)
     },
     updateCategoria,
   }

--- a/hooks/use-transacciones-original.ts
+++ b/hooks/use-transacciones-original.ts
@@ -52,7 +52,7 @@ export function useTransacciones({
         .order("creado_en", { ascending: false })
 
       if (delegacionId) {
-        query = query.eq("cuenta.delegacion_id", delegacionId)
+        query = query.eq("delegacion_id", delegacionId)
       }
 
       if (fechaInicio) {

--- a/hooks/use-transacciones.ts
+++ b/hooks/use-transacciones.ts
@@ -71,6 +71,7 @@ export function useTransacciones({
           metodo,
           notas,
           cuenta_id,
+          delegacion_id,
           categoria_id,
           creado_en,
           cuenta:cuenta_id (
@@ -92,7 +93,7 @@ export function useTransacciones({
         .limit(50) // Reduced from 100 to improve performance
 
       if (delegacionId) {
-        query = query.eq("cuenta.delegacion_id", delegacionId)
+        query = query.eq("delegacion_id", delegacionId)
       }
 
       if (fechaInicio) {

--- a/lib/services/server-database.ts
+++ b/lib/services/server-database.ts
@@ -109,7 +109,7 @@ export class ServerDatabaseService {
           creado_en
         )
       `)
-      .eq("cuenta.delegacion_id", delegacionId)
+      .eq("delegacion_id", delegacionId)
       .order("fecha", { ascending: false })
 
     if (filters?.fechaDesde) {

--- a/lib/types/database.ts
+++ b/lib/types/database.ts
@@ -89,6 +89,7 @@ export type Database = {
         Row: {
           id: string
           cuenta_id: string
+          delegacion_id: string
           fecha: string
           concepto: string
           descripcion: string | null
@@ -108,6 +109,7 @@ export type Database = {
         Insert: {
           id?: string
           cuenta_id: string
+          delegacion_id: string
           fecha: string
           concepto: string
           descripcion?: string | null
@@ -127,6 +129,7 @@ export type Database = {
         Update: {
           id?: string
           cuenta_id?: string
+          delegacion_id?: string
           fecha?: string
           concepto?: string
           descripcion?: string | null


### PR DESCRIPTION
## Summary
- Añade `delegacion_id` al tipo de movimiento y a la lógica de consultas
- Actualiza los hooks y servicios para filtrar por delegación y soportar paginado
- Implementa infinite scroll y contador global en la lista de transacciones

## Testing
- `pnpm lint` *(falla: configuración interactiva de ESLint requerida)*
- `pnpm build` *(warnings de Edge Runtime; la ejecución se interrumpió)*

------
https://chatgpt.com/codex/tasks/task_e_68a5fa6b22a4832681e8b895357d5c2a