### PR TITLE
Link transactions to delegations and ensure edits persist

### DIFF
--- a/components/transactions/transaction-import-panel.tsx
+++ b/components/transactions/transaction-import-panel.tsx
@@ -523,6 +523,7 @@ export function TransactionImportPanel({
         const trx = parsed[i]
         const insertData: any = {
           cuenta_id: accountId,
+          delegacion_id: delegacionId!,
           fecha: trx.fecha,
           concepto: trx.concepto,
           descripcion: trx.descripcion,
@@ -656,6 +657,7 @@ export function TransactionImportPanel({
       
       const insertData: any = {
         cuenta_id: accountId,
+        delegacion_id: delegacionId!,
         fecha: transaction.fecha,
         concepto: transaction.concepto,
         descripcion: uniqueDescription,

--- a/components/transactions/transaction-list.tsx
+++ b/components/transactions/transaction-list.tsx
@@ -160,7 +160,7 @@ export function TransactionList({
               )}
               onClick={(e) => handleTransactionClick(movement, e)}
               data-account-id={movement.cuenta_id}
-              data-delegation-id={account?.delegacion_id}
+              data-delegation-id={movement.delegacion_id}
             >
               <div className="flex items-start gap-3">
                 <AccountTooltip account={account}>

--- a/components/transactions/transaction-manager.tsx
+++ b/components/transactions/transaction-manager.tsx
@@ -25,7 +25,7 @@ import {
 import { toast } from "sonner"
 import { LoadingSpinner } from "@/components/ui/loading-spinner"
 import { exportMovementsToExcel } from "@/lib/utils/export-to-excel"
-import type { MovimientoConRelaciones, Categoria, Cuenta } from "@/lib/types/database"
+import type { MovimientoConRelaciones, Movimiento, Categoria, Cuenta } from "@/lib/types/database"
 import { TransactionImportPanel } from "./transaction-import-panel"
 import { DebugDelegationInfo } from "@/components/debug/debug-delegation-info"
 
@@ -71,7 +71,8 @@ export function TransactionManager({ onTransactionCountChange }: TransactionMana
     movimientos: movements,
     loading,
     error,
-    updateCategoria,
+    updateMovimiento,
+    createMovimiento,
     refetch,
     loadMore,
     hasMore,
@@ -111,13 +112,10 @@ export function TransactionManager({ onTransactionCountChange }: TransactionMana
     setDetailOpen(true)
   }
 
-  const handleMovementUpdate = async (movementId: string, patch: Partial<MovimientoConRelaciones>) => {
+  const handleMovementUpdate = async (movementId: string, patch: Partial<Movimiento>) => {
     try {
-      if (patch.categoria_id !== undefined) {
-        await updateCategoria(movementId, patch.categoria_id)
-      }
+      await updateMovimiento(movementId, patch)
 
-      // Update selected movement if it's the one being edited
       if (selectedMovement?.id === movementId) {
         setSelectedMovement((prev) => (prev ? { ...prev, ...patch } : null))
       }
@@ -129,11 +127,8 @@ export function TransactionManager({ onTransactionCountChange }: TransactionMana
 
   const handleCreateMovement = async (data: Partial<MovimientoConRelaciones>) => {
     try {
-      // Aquí implementarías la lógica para crear un nuevo movimiento
-      console.log("Creating new movement:", data)
-      // Por ahora solo cerramos el formulario
+      await createMovimiento(data)
       setCreateFormOpen(false)
-      // TODO: Implementar createMovement en useMovimientos
     } catch (error) {
       console.error("Error creating movement:", error)
       throw error

--- a/hooks/use-transacciones.ts
+++ b/hooks/use-transacciones.ts
@@ -71,6 +71,7 @@ export function useTransacciones({
           metodo,
           notas,
           cuenta_id,
+          delegacion_id,
           categoria_id,
           creado_en,
           cuenta:cuenta_id (

--- a/lib/services/server-database.ts
+++ b/lib/services/server-database.ts
@@ -109,7 +109,7 @@ export class ServerDatabaseService {
           creado_en
         )
       `)
-      .eq("cuenta.delegacion_id", delegacionId)
+      .eq("delegacion_id", delegacionId)
       .order("fecha", { ascending: false })
 
     if (filters?.fechaDesde) {

--- a/lib/types/database.ts
+++ b/lib/types/database.ts
@@ -89,6 +89,7 @@ export type Database = {
         Row: {
           id: string
           cuenta_id: string
+          delegacion_id: string
           fecha: string
           concepto: string
           descripcion: string | null
@@ -108,6 +109,7 @@ export type Database = {
         Insert: {
           id?: string
           cuenta_id: string
+          delegacion_id: string
           fecha: string
           concepto: string
           descripcion?: string | null
@@ -127,6 +129,7 @@ export type Database = {
         Update: {
           id?: string
           cuenta_id?: string
+          delegacion_id?: string
           fecha?: string
           concepto?: string
           descripcion?: string | null


### PR DESCRIPTION
## Summary
- add `delegacion_id` to movimiento types and queries
- attach delegation when importing or manually creating transactions
- allow updating and creating movements with generic helpers so inline edits persist

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for ESLint configuration)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a654070bfc83269c9dd692d5671b5f