### PR TITLE
feat: support category subcategories

### DIFF
--- a/components/categories/category-edit-form.tsx
+++ b/components/categories/category-edit-form.tsx
@@ -15,6 +15,7 @@ interface CategoryEditFormProps {
   category: Categoria
   onSave: (patch: Partial<Categoria>) => Promise<void>
   onCancel: () => void
+  parentCategory?: Categoria | null
 }
 
 // Colores predefinidos para categorías
@@ -25,7 +26,8 @@ const DEFAULT_COLORS = [
   "#A9DFBF", "#F9E79F", "#D5A6BD", "#A3E4D7", "#FFB6C1"
 ]
 
-export function CategoryEditForm({ category, onSave, onCancel }: CategoryEditFormProps) {
+export function CategoryEditForm({ category, onSave, onCancel, parentCategory }: CategoryEditFormProps) {
+  const isSubcategory = !!parentCategory
   const [formData, setFormData] = useState({
     nombre: category.nombre,
     emoji: category.emoji || "📁",
@@ -65,7 +67,7 @@ export function CategoryEditForm({ category, onSave, onCancel }: CategoryEditFor
       <div className="flex justify-center">
         <Card className="relative">
           <CardContent className="p-6">
-            <div 
+            <div
               className="flex h-16 w-16 items-center justify-center rounded-lg text-2xl"
               style={{ backgroundColor: formData.color }}
             >
@@ -74,6 +76,12 @@ export function CategoryEditForm({ category, onSave, onCancel }: CategoryEditFor
           </CardContent>
         </Card>
       </div>
+
+      {isSubcategory && (
+        <p className="text-sm text-center text-muted-foreground">
+          Subcategoría de <span className="font-medium">{parentCategory?.nombre}</span>
+        </p>
+      )}
 
       {/* Emoji and Color Pickers */}
       <div className="grid grid-cols-2 gap-4">
@@ -85,15 +93,27 @@ export function CategoryEditForm({ category, onSave, onCancel }: CategoryEditFor
             className="w-full justify-start"
           />
         </div>
-        
-        <div className="space-y-2">
-          <Label>Color</Label>
-          <ColorPicker
-            value={formData.color}
-            onChange={(color) => setFormData({ ...formData, color })}
-            className="w-full"
-          />
-        </div>
+        {isSubcategory ? (
+          <div className="space-y-2">
+            <Label>Color</Label>
+            <div
+              className="h-10 w-full rounded-md border"
+              style={{ backgroundColor: formData.color }}
+            />
+            <p className="text-xs text-muted-foreground">
+              Hereda el color de {parentCategory?.nombre}
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            <Label>Color</Label>
+            <ColorPicker
+              value={formData.color}
+              onChange={(color) => setFormData({ ...formData, color })}
+              className="w-full"
+            />
+          </div>
+        )}
       </div>
 
       {/* Category Name */}
@@ -111,7 +131,11 @@ export function CategoryEditForm({ category, onSave, onCancel }: CategoryEditFor
       {/* Category Type */}
       <div className="space-y-2">
         <Label>Tipo *</Label>
-        <Select value={formData.tipo} onValueChange={(value) => setFormData({ ...formData, tipo: value })}>
+        <Select
+          value={formData.tipo}
+          onValueChange={(value) => setFormData({ ...formData, tipo: value })}
+          disabled={isSubcategory}
+        >
           <SelectTrigger>
             <SelectValue />
           </SelectTrigger>
@@ -121,6 +145,11 @@ export function CategoryEditForm({ category, onSave, onCancel }: CategoryEditFor
             <SelectItem value="mixto">Mixto</SelectItem>
           </SelectContent>
         </Select>
+        {isSubcategory && (
+          <p className="text-xs text-muted-foreground">
+            Hereda el tipo de {parentCategory?.nombre}
+          </p>
+        )}
       </div>
 
       {/* Action Buttons */}

--- a/components/categories/category-list.tsx
+++ b/components/categories/category-list.tsx
@@ -12,22 +12,9 @@ import { useCategorias } from "@/hooks/use-categorias"
 import { useMovimientos } from "@/hooks/use-movimientos"
 import { useDelegationContext } from "@/contexts/delegation-context"
 import { DatabaseService } from "@/lib/services/database"
-import { GripVertical, Search, Edit, Trash2, Plus, Building2, Wallet } from "lucide-react"
+import { GripVertical, Search, Edit, Trash2, Plus } from "lucide-react"
 import { AmountDisplay } from "@/components/amount-display"
 import type { Categoria } from "@/lib/types/database"
-
-const getCategoryTypeColor = (tipo: string) => {
-  switch (tipo) {
-    case "ingreso":
-      return "bg-green-100 text-green-800 hover:bg-green-200"
-    case "gasto":
-      return "bg-red-100 text-red-800 hover:bg-red-200"
-    case "mixto":
-      return "bg-blue-100 text-blue-800 hover:bg-blue-200"
-    default:
-      return "bg-gray-100 text-gray-800 hover:bg-gray-200"
-  }
-}
 
 interface CategoryCardProps {
   category: Categoria
@@ -36,30 +23,42 @@ interface CategoryCardProps {
   onEdit: (category: Categoria) => void
   onSearch: (category: Categoria) => void
   onDelete: (category: Categoria) => void
+  onCreateSub?: (category: Categoria) => void
+  isSubcategory?: boolean
 }
 
-function CategoryCard({ category, index, balance, onEdit, onSearch, onDelete }: CategoryCardProps) {
+function CategoryCard({ category, index, balance, onEdit, onSearch, onDelete, onCreateSub, isSubcategory = false }: CategoryCardProps) {
   return (
     <Draggable draggableId={category.id} index={index}>
       {(provided, snapshot) => (
         <Card
           ref={provided.innerRef}
           {...provided.draggableProps}
-          className={cn("transition-shadow hover:shadow-md", snapshot.isDragging && "shadow-lg rotate-2")}
+          className={cn(
+            "transition-shadow hover:shadow-md",
+            snapshot.isDragging && "shadow-lg rotate-2",
+            isSubcategory && "ml-6"
+          )}
         >
-          <CardContent className="p-6">
+          <CardContent className={cn(isSubcategory ? "p-4" : "p-6")}> 
             <div className="flex items-center gap-4">
               {/* Drag Handle */}
               <div
                 {...provided.dragHandleProps}
-                className="flex h-8 w-8 items-center justify-center rounded text-muted-foreground hover:bg-muted cursor-grab active:cursor-grabbing"
+                className={cn(
+                  "flex items-center justify-center rounded text-muted-foreground hover:bg-muted cursor-grab active:cursor-grabbing",
+                  isSubcategory ? "h-6 w-6" : "h-8 w-8"
+                )}
               >
-                <GripVertical className="h-4 w-4" />
+                <GripVertical className={cn(isSubcategory ? "h-3 w-3" : "h-4 w-4")}/>
               </div>
 
               {/* Category Icon */}
               <div
-                className="flex h-16 w-16 items-center justify-center rounded-xl text-2xl shadow-sm"
+                className={cn(
+                  "flex items-center justify-center rounded-xl text-2xl shadow-sm",
+                  isSubcategory ? "h-10 w-10 text-xl" : "h-16 w-16"
+                )}
                 style={{ backgroundColor: category.color || "#e5e7eb" }}
               >
                 {category.emoji || "📁"}
@@ -68,7 +67,7 @@ function CategoryCard({ category, index, balance, onEdit, onSearch, onDelete }: 
               {/* Category Info */}
               <div className="flex-1 min-w-0">
                 <div className="flex items-center gap-2 mb-2">
-                  <h3 className="font-semibold text-lg truncate">{category.nombre}</h3>
+                  <h3 className={cn("font-semibold truncate", isSubcategory ? "text-base" : "text-lg")}>{category.nombre}</h3>
                 </div>
                 <div className="flex items-center gap-2">
                   <AmountDisplay amount={balance} size="sm" />
@@ -77,6 +76,17 @@ function CategoryCard({ category, index, balance, onEdit, onSearch, onDelete }: 
 
               {/* Action Buttons */}
               <div className="flex items-center gap-1">
+                {onCreateSub && !isSubcategory && (
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-9 w-9 text-gray-600 hover:bg-gray-50"
+                    onClick={() => onCreateSub(category)}
+                    title="Añadir subcategoría"
+                  >
+                    <Plus className="h-4 w-4" />
+                  </Button>
+                )}
                 <Button
                   variant="ghost"
                   size="icon"
@@ -119,6 +129,7 @@ export function CategoryList() {
   const [editingCategory, setEditingCategory] = useState<Categoria | null>(null)
   const [editSheetOpen, setEditSheetOpen] = useState(false)
   const [createSheetOpen, setCreateSheetOpen] = useState(false)
+  const [newSubParent, setNewSubParent] = useState<Categoria | null>(null)
 
   // Get organization ID from selected delegation
   const currentDelegation = getCurrentDelegation()
@@ -139,6 +150,13 @@ export function CategoryList() {
 
   const handleCreate = () => {
     setEditingCategory(null)
+    setNewSubParent(null)
+    setCreateSheetOpen(true)
+  }
+
+  const handleCreateSub = (parent: Categoria) => {
+    setEditingCategory(null)
+    setNewSubParent(parent)
     setCreateSheetOpen(true)
   }
 
@@ -164,25 +182,39 @@ export function CategoryList() {
   const handleSaveCategory = async (patch: Partial<Categoria>) => {
     try {
       if (editingCategory) {
-        // Update existing category
         await updateCategoria(editingCategory.id, patch)
       } else if (organizacionId) {
-        // Create new category
-        const maxOrder = Math.max(...categories.map((c) => c.orden), 0)
-        await DatabaseService.createCategoria({
-          organizacion_id: organizacionId,
-          nombre: patch.nombre!,
-          tipo: patch.tipo!,
-          emoji: patch.emoji || "📁",
-          color: patch.color || "#4ECDC4",
-          orden: maxOrder + 1,
-          categoria_padre_id: null,
-        })
+        if (newSubParent) {
+          const siblings = categories.filter((c) => c.categoria_padre_id === newSubParent.id)
+          const maxOrder = Math.max(...siblings.map((c) => c.orden), 0)
+          await DatabaseService.createCategoria({
+            organizacion_id: organizacionId,
+            nombre: patch.nombre!,
+            tipo: newSubParent.tipo,
+            emoji: patch.emoji || "📁",
+            color: newSubParent.color,
+            orden: maxOrder + 1,
+            categoria_padre_id: newSubParent.id,
+          })
+        } else {
+          const roots = categories.filter((c) => !c.categoria_padre_id)
+          const maxOrder = Math.max(...roots.map((c) => c.orden), 0)
+          await DatabaseService.createCategoria({
+            organizacion_id: organizacionId,
+            nombre: patch.nombre!,
+            tipo: patch.tipo!,
+            emoji: patch.emoji || "📁",
+            color: patch.color || "#4ECDC4",
+            orden: maxOrder + 1,
+            categoria_padre_id: null,
+          })
+        }
       }
 
       setEditSheetOpen(false)
       setCreateSheetOpen(false)
       setEditingCategory(null)
+      setNewSubParent(null)
     } catch (error) {
       console.error("Error saving category:", error)
       alert("Error al guardar la categoría")
@@ -190,21 +222,40 @@ export function CategoryList() {
   }
 
   const handleDragEnd = async (result: any) => {
-    if (!result.destination) return
+    const { source, destination, draggableId } = result
+    if (!destination) return
 
-    const items = Array.from(sortedCategories)
-    const [reorderedItem] = items.splice(result.source.index, 1)
-    items.splice(result.destination.index, 0, reorderedItem)
+    const sourceParentId = source.droppableId === "root" ? null : source.droppableId
+    const destParentId = destination.droppableId === "root" ? null : destination.droppableId
 
-    // Update order for all affected categories
+    const moved = categories.find((c) => c.id === draggableId)
+    if (!moved) return
+
+    const sourceGroup = categories
+      .filter((c) => (c.categoria_padre_id || null) === sourceParentId && c.id !== draggableId)
+      .sort((a, b) => a.orden - b.orden)
+
+    const destGroup = categories
+      .filter((c) => (c.categoria_padre_id || null) === destParentId && c.id !== draggableId)
+      .sort((a, b) => a.orden - b.orden)
+
+    destGroup.splice(destination.index, 0, moved)
+
     try {
-      const updates = items.map((item, index) => ({
-        id: item.id,
-        orden: index + 1,
-      }))
-
-      for (const update of updates) {
-        await updateCategoria(update.id, { orden: update.orden })
+      for (const [index, cat] of sourceGroup.entries()) {
+        await updateCategoria(cat.id, { orden: index + 1 })
+      }
+      const parent = destParentId ? categories.find((c) => c.id === destParentId) : null
+      for (const [index, cat] of destGroup.entries()) {
+        const patch: Partial<Categoria> = { orden: index + 1 }
+        if (cat.id === draggableId) {
+          patch.categoria_padre_id = destParentId
+          if (parent) {
+            patch.color = parent.color
+            patch.tipo = parent.tipo
+          }
+        }
+        await updateCategoria(cat.id, patch)
       }
     } catch (error) {
       console.error("Error reordering categories:", error)
@@ -239,12 +290,20 @@ export function CategoryList() {
   }
 
   // Filter categories by search term
-  const filteredCategories = categories.filter((category) =>
-    category.nombre.toLowerCase().includes(searchTerm.toLowerCase()),
-  )
+  const filterText = searchTerm.toLowerCase()
+  const matched = categories.filter((c) => c.nombre.toLowerCase().includes(filterText))
+  const matchedParentIds = new Set(matched.map((c) => c.categoria_padre_id).filter(Boolean) as string[])
 
-  // Sort by order
-  const sortedCategories = [...filteredCategories].sort((a, b) => a.orden - b.orden)
+  const rootCategories = categories
+    .filter((c) => !c.categoria_padre_id)
+    .filter((c) => (filterText ? matchedParentIds.has(c.id) || c.nombre.toLowerCase().includes(filterText) : true))
+    .sort((a, b) => a.orden - b.orden)
+
+  const getSubcategories = (parentId: string) =>
+    categories
+      .filter((c) => c.categoria_padre_id === parentId)
+      .filter((c) => (filterText ? c.nombre.toLowerCase().includes(filterText) : true))
+      .sort((a, b) => a.orden - b.orden)
 
   return (
     <div className="space-y-6">
@@ -272,7 +331,7 @@ export function CategoryList() {
       </div>
 
       {/* Categories List */}
-      {sortedCategories.length === 0 ? (
+      {rootCategories.length === 0 ? (
         <div className="flex items-center justify-center py-12">
           <div className="text-center">
             <p className="text-muted-foreground mb-4">
@@ -288,19 +347,40 @@ export function CategoryList() {
         </div>
       ) : (
         <DragDropContext onDragEnd={handleDragEnd}>
-          <Droppable droppableId="categories">
+          <Droppable droppableId="root" type="CATEGORY">
             {(provided) => (
               <div {...provided.droppableProps} ref={provided.innerRef} className="space-y-4">
-                {sortedCategories.map((category, index) => (
-                  <CategoryCard
-                    key={category.id}
-                    category={category}
-                    index={index}
-                    balance={getCategoryBalance(category.id)}
-                    onEdit={handleEdit}
-                    onSearch={handleSearch}
-                    onDelete={handleDelete}
-                  />
+                {rootCategories.map((category, index) => (
+                  <div key={category.id}>
+                    <CategoryCard
+                      category={category}
+                      index={index}
+                      balance={getCategoryBalance(category.id)}
+                      onEdit={handleEdit}
+                      onSearch={handleSearch}
+                      onDelete={handleDelete}
+                      onCreateSub={handleCreateSub}
+                    />
+                    <Droppable droppableId={category.id} type="CATEGORY">
+                      {(subProvided) => (
+                        <div {...subProvided.droppableProps} ref={subProvided.innerRef} className="mt-2 space-y-2">
+                          {getSubcategories(category.id).map((sub, subIndex) => (
+                            <CategoryCard
+                              key={sub.id}
+                              category={sub}
+                              index={subIndex}
+                              balance={getCategoryBalance(sub.id)}
+                              onEdit={handleEdit}
+                              onSearch={handleSearch}
+                              onDelete={handleDelete}
+                              isSubcategory
+                            />
+                          ))}
+                          {subProvided.placeholder}
+                        </div>
+                      )}
+                    </Droppable>
+                  </div>
                 ))}
                 {provided.placeholder}
               </div>
@@ -318,6 +398,9 @@ export function CategoryList() {
           {editingCategory && (
             <CategoryEditForm
               category={editingCategory}
+              parentCategory={
+                categories.find((c) => c.id === editingCategory.categoria_padre_id) || null
+              }
               onSave={handleSaveCategory}
               onCancel={() => setEditSheetOpen(false)}
             />
@@ -336,13 +419,14 @@ export function CategoryList() {
               id: "",
               organizacion_id: organizacionId || "",
               nombre: "",
-              tipo: "gasto",
+              tipo: newSubParent ? newSubParent.tipo : "gasto",
               emoji: "📁",
-              color: "#4ECDC4",
+              color: newSubParent ? newSubParent.color : "#4ECDC4",
               orden: 0,
-              categoria_padre_id: null,
+              categoria_padre_id: newSubParent ? newSubParent.id : null,
               creado_en: "",
             }}
+            parentCategory={newSubParent}
             onSave={handleSaveCategory}
             onCancel={() => setCreateSheetOpen(false)}
           />

--- a/components/categories/category-list.tsx
+++ b/components/categories/category-list.tsx
@@ -256,7 +256,25 @@ export function CategoryList() {
           }
         }
         await updateCategoria(cat.id, patch)
-      }
+      await Promise.all(
+        sourceGroup.map((cat, index) =>
+          updateCategoria(cat.id, { orden: index + 1 })
+        )
+      )
+      const parent = destParentId ? categories.find((c) => c.id === destParentId) : null
+      await Promise.all(
+        destGroup.map((cat, index) => {
+          const patch: Partial<Categoria> = { orden: index + 1 }
+          if (cat.id === draggableId) {
+            patch.categoria_padre_id = destParentId
+            if (parent) {
+              patch.color = parent.color
+              patch.tipo = parent.tipo
+            }
+          }
+          return updateCategoria(cat.id, patch)
+        })
+      )
     } catch (error) {
       console.error("Error reordering categories:", error)
     }

--- a/components/transactions/category-chip.tsx
+++ b/components/transactions/category-chip.tsx
@@ -31,6 +31,14 @@ export function CategoryChip({ category, categories, onCategoryChange }: Categor
     }
   }
 
+  const getCategoryDisplayName = (category: Categoria) => {
+    if (category.categoria_padre_id) {
+      const parent = categories.find((c) => c.id === category.categoria_padre_id)
+      return `${parent?.nombre || ""} > ${category.nombre}`
+    }
+    return category.nombre
+  }
+
   const handleCategoryRemove = (categoryId: string) => {
     onCategoryChange(null)
   }
@@ -44,7 +52,7 @@ export function CategoryChip({ category, categories, onCategoryChange }: Categor
           onClick={() => setOpen(true)}
         >
           {category.emoji && <span className="text-xs">{category.emoji}</span>}
-          <span className="text-xs font-medium">{category.nombre}</span>
+          <span className="text-xs font-medium">{getCategoryDisplayName(category)}</span>
         </Badge>
 
         <Button


### PR DESCRIPTION
## Summary
- allow editing subcategories while inheriting color and type from their parent
- show categories hierarchically with drag-and-drop for subcategories and nested selection UI

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Supabase environment variables are missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a65d30e2ec8326af03dff3b8a0a555