### PR TITLE
Refactor transaction components for maintainability

### DIFF
--- a/components/transactions/transaction-detail.tsx
+++ b/components/transactions/transaction-detail.tsx
@@ -2,9 +2,9 @@
 
 import type React from "react"
 
-import { useState, useEffect, useCallback } from "react"
+import { useState, useEffect } from "react"
 import { format } from "date-fns"
-import { CalendarIcon, AlertTriangle, Building2, Wallet, Check, Loader2, Upload } from "lucide-react"
+import { CalendarIcon, AlertTriangle, Building2, Wallet, Check, Loader2 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -17,13 +17,9 @@ import { Tabs, TabsContent } from "@/components/ui/tabs"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { CategorySelector } from "./category-selector"
 import { BankAvatar } from "@/components/bank-avatar"
-import { FileAttachmentDropzone } from "@/components/ui/file-attachment-dropzone"
-import { FileList } from "./file-list"
 import { TabWithCounter } from "./tab-with-counter"
-import { AddFileButton } from "./add-file-button"
 import { formatCurrency } from "@/lib/utils/format"
-import { useMovimientoArchivos } from "@/hooks/use-movimiento-archivos"
-import { supabase } from "@/lib/supabase/client"
+import { TransactionFiles } from "./transaction-files"
 import type { Movimiento, Cuenta, Categoria } from "@/lib/types/database"
 
 interface TransactionDetailProps {
@@ -50,59 +46,11 @@ export function TransactionDetail({
   const [isAmountEditing, setIsAmountEditing] = useState(false)
   const [isSaving, setIsSaving] = useState(false)
   const [lastSaved, setLastSaved] = useState<Date | null>(null)
-  const [uploadingFile, setUploadingFile] = useState(false)
   const [activeTab, setActiveTab] = useState<"datos" | "archivos">("datos")
+  const [fileCount, setFileCount] = useState(0)
 
-  // Hook para gestionar archivos del movimiento
   const account = accounts.find((acc) => acc.id === movement?.cuenta_id)
   const selectedCategory = categories.find((cat) => cat.id === formData.categoria_id)
-
-  // Estado para el código de delegación
-  const [delegacionCodigo, setDelegacionCodigo] = useState<string | null>(null)
-
-  // Obtener código de delegación cuando cambie la cuenta
-  useEffect(() => {
-    const getDelegacionCodigo = async () => {
-      if (!account?.delegacion_id) {
-        setDelegacionCodigo(null)
-        return
-      }
-
-      try {
-        const { data, error } = await supabase
-          .from("delegacion")
-          .select("codigo")
-          .eq("id", account.delegacion_id)
-          .single()
-
-        if (error || !data?.codigo) {
-          console.error("Error getting delegation code:", error)
-          setDelegacionCodigo("SIN-CODIGO")
-          return
-        }
-
-        setDelegacionCodigo(data.codigo)
-      } catch (error) {
-        console.error("Error getting delegation code:", error)
-        setDelegacionCodigo("SIN-CODIGO")
-      }
-    }
-
-    getDelegacionCodigo()
-  }, [account?.delegacion_id])
-
-  const {
-    archivos,
-    facturas,
-    otrosDocumentos,
-    loading: archivosLoading,
-    uploading: archivosUploading,
-    error: archivosError,
-    uploadFile,
-    deleteFile,
-    updateFileDescription,
-    refetch: refetchArchivos
-  } = useMovimientoArchivos(movement?.id || null, delegacionCodigo || undefined)
 
   const hasChanges =
     JSON.stringify(formData) !==
@@ -171,18 +119,6 @@ export function TransactionDetail({
     setShowAmountConfirm(false)
     setPendingAmount("")
     setIsAmountEditing(false)
-  }
-
-  // Funciones para manejo de archivos
-  const handleFileUpload = async (file: File, bucketType: 'facturas' | 'documentos') => {
-    setUploadingFile(true)
-    try {
-      await uploadFile(file, bucketType)
-    } catch (error) {
-      console.error("Error uploading file:", error)
-    } finally {
-      setUploadingFile(false)
-    }
   }
 
   return (
@@ -281,7 +217,7 @@ export function TransactionDetail({
               />
               <TabWithCounter
                 label="Archivos"
-                count={archivos.length}
+                count={fileCount}
                 isActive={activeTab === "archivos"}
                 onClick={() => setActiveTab("archivos")}
                 className="flex-1"
@@ -397,100 +333,11 @@ export function TransactionDetail({
             </TabsContent>
 
             <TabsContent value="archivos" className="space-y-6 mt-6">
-              {archivosError && (
-                <Alert className="border-red-200 bg-red-50">
-                  <AlertTriangle className="h-4 w-4 text-red-600" />
-                  <AlertDescription className="text-red-800">
-                    {archivosError}
-                  </AlertDescription>
-                </Alert>
-              )}
-
-              <div className="space-y-6">
-                {/* Sección de Facturas */}
-                <div>
-                  <h3 className="text-sm font-medium text-muted-foreground mb-3">FACTURA</h3>
-                  
-                  {/* Si no hay facturas, mostrar dropzone normal */}
-                  {facturas.length === 0 ? (
-                    <FileAttachmentDropzone
-                      onFileSelect={(file) => handleFileUpload(file, 'facturas')}
-                      bucketType="facturas"
-                      title="Arrastra la factura aquí"
-                      disabled={uploadingFile || archivosUploading}
-                      className="mb-4"
-                    />
-                  ) : (
-                    /* Si ya hay facturas, mostrar botón para añadir más */
-                    <div className="space-y-3">
-                      <AddFileButton
-                        onFileSelect={(file) => handleFileUpload(file, 'facturas')}
-                        bucketType="facturas"
-                        title="Arrastra otra factura aquí"
-                        disabled={uploadingFile || archivosUploading}
-                      />
-                    </div>
-                  )}
-
-                  {/* Lista de facturas */}
-                  {facturas.length > 0 && (
-                    <FileList
-                      archivos={facturas}
-                      onDelete={deleteFile}
-                      onUpdateDescription={updateFileDescription}
-                      title="Facturas subidas"
-                      emptyMessage="No hay facturas adjuntas"
-                      loading={archivosLoading}
-                    />
-                  )}
-                </div>
-
-                {/* Sección de Otros Documentos */}
-                <div>
-                  <h3 className="text-sm font-medium text-muted-foreground mb-3">OTROS ARCHIVOS</h3>
-                  
-                  {/* Si no hay otros documentos, mostrar dropzone normal */}
-                  {otrosDocumentos.length === 0 ? (
-                    <FileAttachmentDropzone
-                      onFileSelect={(file) => handleFileUpload(file, 'documentos')}
-                      bucketType="documentos"
-                      title="Arrastra el archivo aquí"
-                      disabled={uploadingFile || archivosUploading}
-                      className="mb-4"
-                    />
-                  ) : (
-                    /* Si ya hay documentos, mostrar botón para añadir más */
-                    <div className="space-y-3">
-                      <AddFileButton
-                        onFileSelect={(file) => handleFileUpload(file, 'documentos')}
-                        bucketType="documentos"
-                        title="Arrastra otro archivo aquí"
-                        disabled={uploadingFile || archivosUploading}
-                      />
-                    </div>
-                  )}
-
-                  {/* Lista de otros documentos */}
-                  {otrosDocumentos.length > 0 && (
-                    <FileList
-                      archivos={otrosDocumentos}
-                      onDelete={deleteFile}
-                      onUpdateDescription={updateFileDescription}
-                      title="Otros documentos"
-                      emptyMessage="No hay otros archivos adjuntos"
-                      loading={archivosLoading}
-                    />
-                  )}
-                </div>
-
-                {/* Indicador de carga global */}
-                {(uploadingFile || archivosUploading) && (
-                  <div className="flex items-center gap-2 text-sm text-blue-600 bg-blue-50 rounded-lg p-3">
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                    <span>Subiendo archivo...</span>
-                  </div>
-                )}
-              </div>
+              <TransactionFiles
+                movementId={movement?.id || null}
+                delegacionId={account?.delegacion_id}
+                onCountChange={setFileCount}
+              />
             </TabsContent>
           </Tabs>
         </div>

--- a/components/transactions/transaction-files.tsx
+++ b/components/transactions/transaction-files.tsx
@@ -1,0 +1,165 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { AddFileButton } from "./add-file-button"
+import { FileAttachmentDropzone } from "@/components/ui/file-attachment-dropzone"
+import { FileList } from "./file-list"
+import { AlertTriangle, Loader2 } from "lucide-react"
+import { useMovimientoArchivos } from "@/hooks/use-movimiento-archivos"
+import { supabase } from "@/lib/supabase/client"
+
+interface TransactionFilesProps {
+  movementId: string | null
+  delegacionId?: string | null
+  onCountChange?: (count: number) => void
+}
+
+export function TransactionFiles({ movementId, delegacionId, onCountChange }: TransactionFilesProps) {
+  const [delegacionCodigo, setDelegacionCodigo] = useState<string | null>(null)
+  const [uploadingFile, setUploadingFile] = useState(false)
+
+  useEffect(() => {
+    const getDelegacionCodigo = async () => {
+      if (!delegacionId) {
+        setDelegacionCodigo(null)
+        return
+      }
+
+      try {
+        const { data, error } = await supabase
+          .from("delegacion")
+          .select("codigo")
+          .eq("id", delegacionId)
+          .single()
+
+        if (error || !data?.codigo) {
+          console.error("Error getting delegation code:", error)
+          setDelegacionCodigo("SIN-CODIGO")
+          return
+        }
+
+        setDelegacionCodigo(data.codigo)
+      } catch (error) {
+        console.error("Error getting delegation code:", error)
+        setDelegacionCodigo("SIN-CODIGO")
+      }
+    }
+
+    getDelegacionCodigo()
+  }, [delegacionId])
+
+  const {
+    archivos,
+    facturas,
+    otrosDocumentos,
+    loading: archivosLoading,
+    uploading: archivosUploading,
+    error: archivosError,
+    uploadFile,
+    deleteFile,
+    updateFileDescription,
+  } = useMovimientoArchivos(movementId || null, delegacionCodigo || undefined)
+
+  useEffect(() => {
+    onCountChange?.(archivos.length)
+  }, [archivos, onCountChange])
+
+  const handleFileUpload = async (file: File, bucketType: "facturas" | "documentos") => {
+    setUploadingFile(true)
+    try {
+      await uploadFile(file, bucketType)
+    } catch (error) {
+      console.error("Error uploading file:", error)
+    } finally {
+      setUploadingFile(false)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      {archivosError && (
+        <Alert className="border-red-200 bg-red-50">
+          <AlertTriangle className="h-4 w-4 text-red-600" />
+          <AlertDescription className="text-red-800">{archivosError}</AlertDescription>
+        </Alert>
+      )}
+
+      <div className="space-y-6">
+        <div>
+          <h3 className="text-sm font-medium text-muted-foreground mb-3">FACTURA</h3>
+          {facturas.length === 0 ? (
+            <FileAttachmentDropzone
+              onFileSelect={(file) => handleFileUpload(file, "facturas")}
+              bucketType="facturas"
+              title="Arrastra la factura aquí"
+              disabled={uploadingFile || archivosUploading}
+              className="mb-4"
+            />
+          ) : (
+            <div className="space-y-3">
+              <AddFileButton
+                onFileSelect={(file) => handleFileUpload(file, "facturas")}
+                bucketType="facturas"
+                title="Arrastra otra factura aquí"
+                disabled={uploadingFile || archivosUploading}
+              />
+            </div>
+          )}
+
+          {facturas.length > 0 && (
+            <FileList
+              archivos={facturas}
+              onDelete={deleteFile}
+              onUpdateDescription={updateFileDescription}
+              title="Facturas subidas"
+              emptyMessage="No hay facturas adjuntas"
+              loading={archivosLoading}
+            />
+          )}
+        </div>
+
+        <div>
+          <h3 className="text-sm font-medium text-muted-foreground mb-3">OTROS ARCHIVOS</h3>
+          {otrosDocumentos.length === 0 ? (
+            <FileAttachmentDropzone
+              onFileSelect={(file) => handleFileUpload(file, "documentos")}
+              bucketType="documentos"
+              title="Arrastra el archivo aquí"
+              disabled={uploadingFile || archivosUploading}
+              className="mb-4"
+            />
+          ) : (
+            <div className="space-y-3">
+              <AddFileButton
+                onFileSelect={(file) => handleFileUpload(file, "documentos")}
+                bucketType="documentos"
+                title="Arrastra otro archivo aquí"
+                disabled={uploadingFile || archivosUploading}
+              />
+            </div>
+          )}
+
+          {otrosDocumentos.length > 0 && (
+            <FileList
+              archivos={otrosDocumentos}
+              onDelete={deleteFile}
+              onUpdateDescription={updateFileDescription}
+              title="Otros documentos"
+              emptyMessage="No hay otros archivos adjuntos"
+              loading={archivosLoading}
+            />
+          )}
+        </div>
+
+        {(uploadingFile || archivosUploading) && (
+          <div className="flex items-center gap-2 text-sm text-blue-600 bg-blue-50 rounded-lg p-3">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            <span>Subiendo archivo...</span>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+

--- a/components/transactions/transaction-list-row.tsx
+++ b/components/transactions/transaction-list-row.tsx
@@ -1,0 +1,149 @@
+"use client"
+
+import { useState, memo } from "react"
+import { BankAvatar } from "./bank-avatar"
+import { CategoryChip } from "./category-chip"
+import { AmountDisplay } from "@/components/ui/amount-display"
+import { AccountTooltip } from "./account-tooltip"
+import { TransactionRowIndicators } from "./transaction-row-indicators"
+import { formatDate } from "@/lib/utils/format"
+import { Input } from "@/components/ui/input"
+import { LoadingSpinner } from "@/components/ui/loading-spinner"
+import { cn } from "@/lib/utils"
+import type { Movimiento, MovimientoConRelaciones, Cuenta, Categoria } from "@/lib/types/database"
+
+interface TransactionListRowProps {
+  movement: MovimientoConRelaciones
+  account?: Cuenta
+  category?: Categoria
+  categories: Categoria[]
+  onMovementUpdate: (movementId: string, patch: Partial<Movimiento>) => Promise<void>
+  onClick: (movement: MovimientoConRelaciones, e: React.MouseEvent) => void
+}
+
+export const TransactionListRow = memo(function TransactionListRow({
+  movement,
+  account,
+  category,
+  categories,
+  onMovementUpdate,
+  onClick,
+}: TransactionListRowProps) {
+  const [isUpdating, setIsUpdating] = useState(false)
+  const [editing, setEditing] = useState(false)
+  const [conceptValue, setConceptValue] = useState(movement.concepto)
+
+  const handleCategoryChange = async (categoryId: string | null) => {
+    setIsUpdating(true)
+    try {
+      await onMovementUpdate(movement.id, { categoria_id: categoryId })
+    } catch (error) {
+      console.error("Error updating category:", error)
+    } finally {
+      setIsUpdating(false)
+    }
+  }
+
+  const handleConceptClick = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    setEditing(true)
+  }
+
+  const handleConceptSave = async () => {
+    if (conceptValue.trim() !== "") {
+      try {
+        await onMovementUpdate(movement.id, { concepto: conceptValue.trim() })
+      } catch (error) {
+        console.error("Error updating concept:", error)
+      }
+    }
+    setEditing(false)
+  }
+
+  const handleConceptCancel = () => {
+    setConceptValue(movement.concepto)
+    setEditing(false)
+  }
+
+  return (
+    <div className="relative" data-testid="transaction-row">
+      <div
+        className={cn(
+          "bg-card rounded-lg border border-border/50 p-3 hover:bg-muted/50 hover:border-border transition-all duration-200 cursor-pointer shadow-sm hover:shadow-md",
+          !category && "border-l-4 border-l-amber-400/60 bg-amber-50/30 dark:bg-amber-950/10"
+        )}
+        onClick={(e) => onClick(movement, e)}
+        data-account-id={movement.cuenta_id}
+        data-delegation-id={account?.delegacion_id}
+      >
+        <div className="flex items-start gap-3">
+          <AccountTooltip account={account}>
+            <div
+              className="rounded-full p-0.5 cursor-pointer hover:scale-105 transition-transform flex-shrink-0 shadow-sm"
+              style={{ backgroundColor: account?.color || "#4ECDC4" }}
+              data-testid="account-info"
+              title={`Cuenta: ${account?.nombre || 'Sin nombre'} - Delegación ID: ${account?.delegacion_id || 'Sin delegación'}`}
+            >
+              <BankAvatar account={account} />
+            </div>
+          </AccountTooltip>
+
+          <div className="flex-1 min-w-0">
+            <div className="flex items-start justify-between gap-3">
+              <div className="flex-1 min-w-0">
+                {editing ? (
+                  <Input
+                    value={conceptValue}
+                    onChange={(e) => setConceptValue(e.target.value)}
+                    onBlur={handleConceptSave}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") handleConceptSave()
+                      else if (e.key === "Escape") handleConceptCancel()
+                    }}
+                    className="text-sm font-semibold h-6 px-2"
+                    autoFocus
+                  />
+                ) : (
+                  <div className="flex items-center gap-2 mb-1">
+                    <h3
+                      className="font-semibold text-sm leading-tight cursor-pointer hover:text-primary line-clamp-1 transition-colors flex-1"
+                      onClick={handleConceptClick}
+                    >
+                      {movement.concepto}
+                    </h3>
+                    <TransactionRowIndicators description={movement.descripcion} fileCount={movement.archivos?.length || 0} />
+                  </div>
+                )}
+
+                <div onClick={(e) => e.stopPropagation()}>
+                  {isUpdating ? (
+                    <div className="flex items-center gap-2">
+                      <LoadingSpinner size="sm" />
+                      <span className="text-xs text-muted-foreground hidden sm:inline">Actualizando...</span>
+                    </div>
+                  ) : (
+                    <CategoryChip
+                      category={category as unknown as Categoria}
+                      categories={categories as unknown as Categoria[]}
+                      onCategoryChange={(categoryId) => handleCategoryChange(categoryId)}
+                    />
+                  )}
+                </div>
+              </div>
+
+              <div className="flex-shrink-0 text-right min-w-0">
+                <div className="mb-0.5">
+                  <AmountDisplay amount={movement.importe} size="sm" />
+                </div>
+                <div className="text-xs text-muted-foreground bg-muted/30 px-2 py-0.5 rounded-md whitespace-nowrap inline-block">
+                  {formatDate(movement.fecha)}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+})
+

--- a/components/transactions/transaction-list-row.tsx
+++ b/components/transactions/transaction-list-row.tsx
@@ -123,8 +123,8 @@ export const TransactionListRow = memo(function TransactionListRow({
                     </div>
                   ) : (
                     <CategoryChip
-                      category={category as unknown as Categoria}
-                      categories={categories as unknown as Categoria[]}
+                      category={category}
+                      categories={categories}
                       onCategoryChange={(categoryId) => handleCategoryChange(categoryId)}
                     />
                   )}

--- a/components/transactions/transaction-list.tsx
+++ b/components/transactions/transaction-list.tsx
@@ -1,19 +1,15 @@
 "use client"
 
-import type React from "react"
-
-import { useState, useEffect, useRef } from "react"
+import { useEffect, useRef, useMemo } from "react"
 import { LoadingSpinner } from "@/components/ui/loading-spinner"
 import { ErrorMessage } from "@/components/ui/error-message"
-import { BankAvatar } from "./bank-avatar"
-import { CategoryChip } from "./category-chip"
-import { AmountDisplay } from "@/components/ui/amount-display"
-import { AccountTooltip } from "./account-tooltip"
-import { TransactionRowIndicators } from "./transaction-row-indicators"
-import { formatDate } from "@/lib/utils/format"
-import { Input } from "@/components/ui/input"
-import { cn } from "@/lib/utils"
-import type { Movimiento, Cuenta, Categoria, MovimientoConRelaciones } from "@/lib/types/database"
+import { TransactionListRow } from "./transaction-list-row"
+import type {
+  Movimiento,
+  Cuenta,
+  Categoria,
+  MovimientoConRelaciones,
+} from "@/lib/types/database"
 
 interface TransactionListProps {
   movements: MovimientoConRelaciones[]
@@ -40,10 +36,6 @@ export function TransactionList({
   onLoadMore,
   hasMore,
 }: TransactionListProps) {
-  const [updatingMovements, setUpdatingMovements] = useState<Set<string>>(new Set())
-  const [editingConcept, setEditingConcept] = useState<string | null>(null)
-  const [conceptValue, setConceptValue] = useState("")
-
   const loadMoreRef = useRef<HTMLDivElement | null>(null)
 
   useEffect(() => {
@@ -67,50 +59,21 @@ export function TransactionList({
     }
   }, [onLoadMore, hasMore])
 
-  const handleCategoryChange = async (movementId: string, categoryId: string | null) => {
-    setUpdatingMovements((prev) => new Set(prev).add(movementId))
-    try {
-      await onMovementUpdate(movementId, { categoria_id: categoryId })
-    } catch (error) {
-      console.error("Error updating category:", error)
-    } finally {
-      setUpdatingMovements((prev) => {
-        const next = new Set(prev)
-        next.delete(movementId)
-        return next
-      })
+  const accountsById = useMemo(() => {
+    const map: Record<string, Cuenta> = {}
+    for (const acc of accounts) {
+      map[acc.id] = acc
     }
-  }
+    return map
+  }, [accounts])
 
-  const handleConceptClick = (movement: Movimiento, e: React.MouseEvent) => {
-    e.stopPropagation()
-    setEditingConcept(movement.id)
-    setConceptValue(movement.concepto)
-  }
-
-  const handleConceptSave = async (movementId: string) => {
-    if (conceptValue.trim() !== "") {
-      try {
-        await onMovementUpdate(movementId, { concepto: conceptValue.trim() })
-      } catch (error) {
-        console.error("Error updating concept:", error)
-      }
+  const categoriesById = useMemo(() => {
+    const map: Record<string, Categoria> = {}
+    for (const cat of categories) {
+      map[cat.id] = cat
     }
-    setEditingConcept(null)
-    setConceptValue("")
-  }
-
-  const handleConceptCancel = () => {
-    setEditingConcept(null)
-    setConceptValue("")
-  }
-
-  const handleTransactionClick = (movement: MovimientoConRelaciones, e: React.MouseEvent) => {
-    const target = e.target as HTMLElement
-    if (!target.closest("button") && !target.closest('[role="button"]') && !target.closest("input")) {
-      onMovementClick(movement)
-    }
-  }
+    return map
+  }, [categories])
 
   if (loading && movements.length === 0) {
     return (
@@ -146,107 +109,17 @@ export function TransactionList({
         <p className="text-sm text-muted-foreground font-medium">{total} transacciones encontradas</p>
       </div>
 
-      {movements.map((movement) => {
-        const account = accounts.find((acc) => acc.id === movement.cuenta_id)
-        const category = categories.find((cat) => cat.id === movement.categoria_id) as Categoria | undefined
-        const isUpdating = updatingMovements.has(movement.id)
-        const isEditingThisConcept = editingConcept === movement.id
-
-        return (
-          <div key={movement.id} className="relative" data-testid="transaction-row">
-            <div
-              className={cn(
-                "bg-card rounded-lg border border-border/50 p-3 hover:bg-muted/50 hover:border-border transition-all duration-200 cursor-pointer shadow-sm hover:shadow-md",
-                !category && "border-l-4 border-l-amber-400/60 bg-amber-50/30 dark:bg-amber-950/10"
-              )}
-              onClick={(e) => handleTransactionClick(movement, e)}
-              data-account-id={movement.cuenta_id}
-              data-delegation-id={account?.delegacion_id}
-            >
-              <div className="flex items-start gap-3">
-                <AccountTooltip account={account}>
-                  <div
-                    className="rounded-full p-0.5 cursor-pointer hover:scale-105 transition-transform flex-shrink-0 shadow-sm"
-                    style={{
-                      backgroundColor: account?.color || "#4ECDC4",
-                    }}
-                    data-testid="account-info"
-                    title={`Cuenta: ${account?.nombre || 'Sin nombre'} - Delegación ID: ${account?.delegacion_id || 'Sin delegación'}`}
-                  >
-                    <BankAvatar account={account} />
-                  </div>
-                </AccountTooltip>
-
-                {/* Content - Reorganized as requested */}
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="flex-1 min-w-0">
-                      {/* Title */}
-                      {isEditingThisConcept ? (
-                        <Input
-                          value={conceptValue}
-                          onChange={(e) => setConceptValue(e.target.value)}
-                          onBlur={() => handleConceptSave(movement.id)}
-                          onKeyDown={(e) => {
-                            if (e.key === "Enter") {
-                              handleConceptSave(movement.id)
-                            } else if (e.key === "Escape") {
-                              handleConceptCancel()
-                            }
-                          }}
-                          className="text-sm font-semibold h-6 px-2"
-                          autoFocus
-                        />
-                      ) : (
-                        <div className="flex items-center gap-2 mb-1">
-                          <h3
-                            className="font-semibold text-sm leading-tight cursor-pointer hover:text-primary line-clamp-1 transition-colors flex-1"
-                            onClick={(e) => handleConceptClick(movement, e)}
-                          >
-                            {movement.concepto}
-                          </h3>
-                          
-                          {/* Indicadores modernos */}
-                          <TransactionRowIndicators 
-                            description={movement.descripcion}
-                            fileCount={movement.archivos?.length || 0}
-                          />
-                        </div>
-                      )}
-                      
-                      {/* Category directly below title */}
-                      <div onClick={(e) => e.stopPropagation()}>
-                        {isUpdating ? (
-                          <div className="flex items-center gap-2">
-                            <LoadingSpinner size="sm" />
-                            <span className="text-xs text-muted-foreground hidden sm:inline">Actualizando...</span>
-                          </div>
-                        ) : (
-                          <CategoryChip
-                            category={category as unknown as Categoria}
-                            categories={categories as unknown as Categoria[]}
-                            onCategoryChange={(categoryId) => handleCategoryChange(movement.id, categoryId)}
-                          />
-                        )}
-                      </div>
-                    </div>
-
-                    {/* Right side: Amount and Date stacked */}
-                    <div className="flex-shrink-0 text-right min-w-0">
-                      <div className="mb-0.5">
-                        <AmountDisplay amount={movement.importe} size="sm" />
-                      </div>
-                      <div className="text-xs text-muted-foreground bg-muted/30 px-2 py-0.5 rounded-md whitespace-nowrap inline-block">
-                        {formatDate(movement.fecha)}
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        )
-      })}
+      {movements.map((movement) => (
+        <TransactionListRow
+          key={movement.id}
+          movement={movement}
+          account={accountsById[movement.cuenta_id]}
+          category={categoriesById[movement.categoria_id]}
+          categories={categories}
+          onMovementUpdate={onMovementUpdate}
+          onClick={onMovementClick}
+        />
+      ))}
       {hasMore && (
         <div ref={loadMoreRef} className="py-4 flex justify-center">
           <LoadingSpinner size="sm" />


### PR DESCRIPTION
## Summary
- extract file management into dedicated `TransactionFiles` component
- split transaction list rows into memoized `TransactionListRow`
- streamline `TransactionDetail` and `TransactionList` for faster rendering

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(failed: requires interactive ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68a66c2cb18883269e51b9d60b3faa35