### PR TITLE
feat: add category subcategories

### DIFF
--- a/components/categories/category-edit-form.tsx
+++ b/components/categories/category-edit-form.tsx
@@ -13,24 +13,18 @@ import type { Categoria } from "@/lib/types/database"
 
 interface CategoryEditFormProps {
   category: Categoria
+  parentCategory?: Categoria | null
   onSave: (patch: Partial<Categoria>) => Promise<void>
   onCancel: () => void
 }
 
-// Colores predefinidos para categorías
-const DEFAULT_COLORS = [
-  "#FF6B6B", "#4ECDC4", "#45B7D1", "#96CEB4", "#FFEAA7",
-  "#DDA0DD", "#98D8C8", "#F7DC6F", "#BB8FCE", "#85C1E9",
-  "#F8C471", "#82E0AA", "#F1948A", "#D7BDE2", "#FAD7A0",
-  "#A9DFBF", "#F9E79F", "#D5A6BD", "#A3E4D7", "#FFB6C1"
-]
-
-export function CategoryEditForm({ category, onSave, onCancel }: CategoryEditFormProps) {
+export function CategoryEditForm({ category, parentCategory, onSave, onCancel }: CategoryEditFormProps) {
+  const isSubcategory = !!parentCategory
   const [formData, setFormData] = useState({
     nombre: category.nombre,
     emoji: category.emoji || "📁",
     tipo: category.tipo,
-    color: category.color || "#4ECDC4",
+    color: category.color || parentCategory?.color || "#4ECDC4",
   })
   const [loading, setLoading] = useState(false)
 
@@ -62,10 +56,10 @@ export function CategoryEditForm({ category, onSave, onCancel }: CategoryEditFor
   return (
     <form onSubmit={handleSubmit} className="space-y-6 pt-6">
       {/* Category Icon and Color Preview */}
-      <div className="flex justify-center">
+      <div className="flex flex-col items-center gap-2">
         <Card className="relative">
           <CardContent className="p-6">
-            <div 
+            <div
               className="flex h-16 w-16 items-center justify-center rounded-lg text-2xl"
               style={{ backgroundColor: formData.color }}
             >
@@ -73,6 +67,11 @@ export function CategoryEditForm({ category, onSave, onCancel }: CategoryEditFor
             </div>
           </CardContent>
         </Card>
+        {isSubcategory && (
+          <p className="text-sm text-muted-foreground">
+            Subcategoría de {parentCategory?.nombre}
+          </p>
+        )}
       </div>
 
       {/* Emoji and Color Pickers */}
@@ -85,14 +84,19 @@ export function CategoryEditForm({ category, onSave, onCancel }: CategoryEditFor
             className="w-full justify-start"
           />
         </div>
-        
+
         <div className="space-y-2">
           <Label>Color</Label>
           <ColorPicker
             value={formData.color}
             onChange={(color) => setFormData({ ...formData, color })}
-            className="w-full"
+            className={`w-full ${isSubcategory ? "pointer-events-none opacity-50" : ""}`}
           />
+          {isSubcategory && (
+            <p className="text-xs text-muted-foreground">
+              Hereda el color de {parentCategory?.nombre}
+            </p>
+          )}
         </div>
       </div>
 

--- a/components/categories/category-list.tsx
+++ b/components/categories/category-list.tsx
@@ -19,19 +19,6 @@ import { AmountDisplay } from "@/components/amount-display"
 import { DeleteCategoryDialog } from "./delete-category-dialog"
 import type { Categoria } from "@/lib/types/database"
 
-const getCategoryTypeColor = (tipo: string) => {
-  switch (tipo) {
-    case "ingreso":
-      return "bg-green-100 text-green-800 hover:bg-green-200"
-    case "gasto":
-      return "bg-red-100 text-red-800 hover:bg-red-200"
-    case "mixto":
-      return "bg-blue-100 text-blue-800 hover:bg-blue-200"
-    default:
-      return "bg-gray-100 text-gray-800 hover:bg-gray-200"
-  }
-}
-
 interface CategoryCardProps {
   category: Categoria
   index: number
@@ -42,15 +29,20 @@ interface CategoryCardProps {
 }
 
 function CategoryCard({ category, index, balance, onEdit, onSearch, onDelete }: CategoryCardProps) {
+  const isSub = !!category.categoria_padre_id
   return (
     <Draggable draggableId={category.id} index={index}>
       {(provided, snapshot) => (
         <Card
           ref={provided.innerRef}
           {...provided.draggableProps}
-          className={cn("transition-shadow hover:shadow-md", snapshot.isDragging && "shadow-lg rotate-2")}
+          className={cn(
+            "transition-shadow hover:shadow-md",
+            snapshot.isDragging && "shadow-lg rotate-2",
+            isSub && "ml-6"
+          )}
         >
-          <CardContent className="p-3 sm:p-4 lg:p-6">
+          <CardContent className={cn("p-3 sm:p-4 lg:p-6", isSub && "py-2") }>
             <div className="flex items-center gap-3 sm:gap-4">
               {/* Drag Handle */}
               <div
@@ -62,7 +54,10 @@ function CategoryCard({ category, index, balance, onEdit, onSearch, onDelete }: 
 
               {/* Category Icon */}
               <div
-                className="flex h-12 w-12 sm:h-14 sm:w-14 lg:h-16 lg:w-16 items-center justify-center rounded-xl text-xl sm:text-2xl shadow-sm flex-shrink-0"
+                className={cn(
+                  "flex items-center justify-center rounded-xl text-xl sm:text-2xl shadow-sm flex-shrink-0",
+                  isSub ? "h-10 w-10" : "h-12 w-12 sm:h-14 sm:w-14 lg:h-16 lg:w-16"
+                )}
                 style={{ backgroundColor: category.color || "#e5e7eb" }}
               >
                 {category.emoji || "📁"}
@@ -72,18 +67,11 @@ function CategoryCard({ category, index, balance, onEdit, onSearch, onDelete }: 
               <div className="flex-1 min-w-0">
                 <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
                   <div className="min-w-0">
-                    <h3 className="font-semibold text-base sm:text-lg truncate">{category.nombre}</h3>
+                    <h3 className={cn("truncate", isSub ? "font-medium text-base" : "font-semibold text-base sm:text-lg")}>{category.nombre}</h3>
                     <div className="flex items-center gap-2 mt-1 sm:mt-0">
-                      
-                      
-                      
-                    <AmountDisplay amount={balance} size="sm" />
-
-
+                      <AmountDisplay amount={balance} size="sm" />
                     </div>
                   </div>
-                  
-             
                 </div>
               </div>
 
@@ -235,14 +223,33 @@ export function CategoryList() {
     const [reorderedItem] = items.splice(result.source.index, 1)
     items.splice(result.destination.index, 0, reorderedItem)
 
+    const findParent = () => {
+      for (let i = result.destination.index - 1; i >= 0; i--) {
+        if (items[i].categoria_padre_id === null) return items[i]
+      }
+      return null
+    }
+
+    const parent = findParent()
+    reorderedItem.categoria_padre_id = parent ? parent.id : null
+    reorderedItem.color = parent ? parent.color : reorderedItem.color
+
     try {
       const updates = items.map((item, index) => ({
         id: item.id,
         orden: index + 1,
       }))
 
+      await updateCategoria(reorderedItem.id, {
+        orden: result.destination.index + 1,
+        categoria_padre_id: reorderedItem.categoria_padre_id,
+        color: reorderedItem.color,
+      })
+
       for (const update of updates) {
-        await updateCategoria(update.id, { orden: update.orden })
+        if (update.id !== reorderedItem.id) {
+          await updateCategoria(update.id, { orden: update.orden })
+        }
       }
     } catch (error) {
       console.error("Error reordering categories:", error)
@@ -414,6 +421,7 @@ export function CategoryList() {
           {editingCategory && (
             <CategoryEditForm
               category={editingCategory}
+              parentCategory={categories.find((c) => c.id === editingCategory.categoria_padre_id) || null}
               onSave={handleSaveCategory}
               onCancel={() => setEditSheetOpen(false)}
             />

--- a/components/categories/category-search.tsx
+++ b/components/categories/category-search.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useMemo } from "react"
+import { cn } from "@/lib/utils"
 import { Check, ChevronsUpDown, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command"
@@ -26,13 +27,21 @@ export function CategorySearch({
   const [open, setOpen] = useState(false)
   const [searchValue, setSearchValue] = useState("")
 
+  const sortedCategories = useMemo(
+    () => [...categories].sort((a, b) => a.orden - b.orden),
+    [categories],
+  )
+
   const filteredCategories = useMemo(() => {
-    if (!searchValue) return categories
-    return categories.filter(category =>
-      category.nombre.toLowerCase().includes(searchValue.toLowerCase()) ||
-      (category.emoji && category.emoji.includes(searchValue))
-    )
-  }, [categories, searchValue])
+    const list = searchValue
+      ? sortedCategories.filter(
+          (category) =>
+            category.nombre.toLowerCase().includes(searchValue.toLowerCase()) ||
+            (category.emoji && category.emoji.includes(searchValue)),
+        )
+      : sortedCategories
+    return list
+  }, [sortedCategories, searchValue])
 
   const selectedCategoryObjects = useMemo(() => {
     return categories.filter(cat => selectedCategories.includes(cat.id))
@@ -94,6 +103,7 @@ export function CategorySearch({
                     key={category.id}
                     value={category.id}
                     onSelect={() => handleSelect(category.id)}
+                    className={cn(category.categoria_padre_id && "pl-6")}
                   >
                     <Check
                       className={`mr-2 h-4 w-4 ${

--- a/components/transactions/category-selector.tsx
+++ b/components/transactions/category-selector.tsx
@@ -3,6 +3,7 @@
 import type React from "react"
 
 import { useState, useMemo } from "react"
+import { cn } from "@/lib/utils"
 import { Check, ChevronsUpDown, X, Search, Plus } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -33,14 +34,21 @@ export function CategorySelector({
   const [open, setOpen] = useState(false)
   const [searchValue, setSearchValue] = useState("")
 
+  const sortedCategories = useMemo(
+    () => [...categories].sort((a, b) => a.orden - b.orden),
+    [categories],
+  )
+
   const filteredCategories = useMemo(() => {
-    if (!searchValue) return categories
-    return categories.filter(
+    const list = searchValue
+      ? sortedCategories.filter(
       (category) =>
         category.nombre.toLowerCase().includes(searchValue.toLowerCase()) ||
         (category.emoji && category.emoji.includes(searchValue)),
-    )
-  }, [categories, searchValue])
+      )
+      : sortedCategories
+    return list
+  }, [sortedCategories, searchValue])
 
   const selectedCategoryObjects = useMemo(() => {
     return categories.filter((cat) => selectedCategories.includes(cat.id))
@@ -130,7 +138,10 @@ export function CategorySelector({
                   {filteredCategories.map((category) => (
                     <div
                       key={category.id}
-                      className="flex items-center gap-2 p-2 hover:bg-muted/50 rounded cursor-pointer"
+                      className={cn(
+                        "flex items-center gap-2 p-2 hover:bg-muted/50 rounded cursor-pointer",
+                        category.categoria_padre_id && "pl-4",
+                      )}
                       onClick={() => handleSelect(category.id)}
                     >
                       <Badge


### PR DESCRIPTION
## Summary
- allow categories to have subcategories with inherited color
- show subcategories indented in selectors and lists
- lock color editing for subcategories and display parent info

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68b4412dc784832686bf4f29d29dab8c