### PR TITLE
feat: support category sublevels

### DIFF
--- a/components/categories/category-edit-form.tsx
+++ b/components/categories/category-edit-form.tsx
@@ -15,22 +15,16 @@ interface CategoryEditFormProps {
   category: Categoria
   onSave: (patch: Partial<Categoria>) => Promise<void>
   onCancel: () => void
+  parentCategory?: Categoria | null
 }
 
-// Colores predefinidos para categorías
-const DEFAULT_COLORS = [
-  "#FF6B6B", "#4ECDC4", "#45B7D1", "#96CEB4", "#FFEAA7",
-  "#DDA0DD", "#98D8C8", "#F7DC6F", "#BB8FCE", "#85C1E9",
-  "#F8C471", "#82E0AA", "#F1948A", "#D7BDE2", "#FAD7A0",
-  "#A9DFBF", "#F9E79F", "#D5A6BD", "#A3E4D7", "#FFB6C1"
-]
-
-export function CategoryEditForm({ category, onSave, onCancel }: CategoryEditFormProps) {
+export function CategoryEditForm({ category, onSave, onCancel, parentCategory }: CategoryEditFormProps) {
+  const isSubcategory = !!category.categoria_padre_id
   const [formData, setFormData] = useState({
     nombre: category.nombre,
     emoji: category.emoji || "📁",
     tipo: category.tipo,
-    color: category.color || "#4ECDC4",
+    color: parentCategory?.color || category.color || "#4ECDC4",
   })
   const [loading, setLoading] = useState(false)
 
@@ -62,10 +56,15 @@ export function CategoryEditForm({ category, onSave, onCancel }: CategoryEditFor
   return (
     <form onSubmit={handleSubmit} className="space-y-6 pt-6">
       {/* Category Icon and Color Preview */}
-      <div className="flex justify-center">
+      <div className="flex flex-col items-center justify-center gap-2">
+        {isSubcategory && parentCategory && (
+          <p className="text-sm text-muted-foreground">
+            Subcategoría de <span className="font-semibold">{parentCategory.nombre}</span>
+          </p>
+        )}
         <Card className="relative">
           <CardContent className="p-6">
-            <div 
+            <div
               className="flex h-16 w-16 items-center justify-center rounded-lg text-2xl"
               style={{ backgroundColor: formData.color }}
             >
@@ -85,14 +84,18 @@ export function CategoryEditForm({ category, onSave, onCancel }: CategoryEditFor
             className="w-full justify-start"
           />
         </div>
-        
+
         <div className="space-y-2">
           <Label>Color</Label>
-          <ColorPicker
-            value={formData.color}
-            onChange={(color) => setFormData({ ...formData, color })}
-            className="w-full"
-          />
+          {isSubcategory ? (
+            <div className="flex h-10 w-full items-center rounded border px-3 opacity-60 cursor-not-allowed" style={{ backgroundColor: formData.color }} />
+          ) : (
+            <ColorPicker
+              value={formData.color}
+              onChange={(color) => setFormData({ ...formData, color })}
+              className="w-full"
+            />
+          )}
         </div>
       </div>
 

--- a/components/categories/category-list.tsx
+++ b/components/categories/category-list.tsx
@@ -42,15 +42,20 @@ interface CategoryCardProps {
 }
 
 function CategoryCard({ category, index, balance, onEdit, onSearch, onDelete }: CategoryCardProps) {
+  const isSub = !!category.categoria_padre_id
   return (
     <Draggable draggableId={category.id} index={index}>
       {(provided, snapshot) => (
         <Card
           ref={provided.innerRef}
           {...provided.draggableProps}
-          className={cn("transition-shadow hover:shadow-md", snapshot.isDragging && "shadow-lg rotate-2")}
+          className={cn(
+            "transition-shadow hover:shadow-md",
+            snapshot.isDragging && "shadow-lg rotate-2",
+            isSub && "ml-6"
+          )}
         >
-          <CardContent className="p-3 sm:p-4 lg:p-6">
+          <CardContent className={cn("p-3 sm:p-4 lg:p-6", isSub && "py-2")}> 
             <div className="flex items-center gap-3 sm:gap-4">
               {/* Drag Handle */}
               <div
@@ -62,7 +67,12 @@ function CategoryCard({ category, index, balance, onEdit, onSearch, onDelete }: 
 
               {/* Category Icon */}
               <div
-                className="flex h-12 w-12 sm:h-14 sm:w-14 lg:h-16 lg:w-16 items-center justify-center rounded-xl text-xl sm:text-2xl shadow-sm flex-shrink-0"
+                className={cn(
+                  "flex items-center justify-center rounded-xl shadow-sm flex-shrink-0",
+                  isSub
+                    ? "h-10 w-10 sm:h-12 sm:w-12 lg:h-14 lg:w-14 text-lg"
+                    : "h-12 w-12 sm:h-14 sm:w-14 lg:h-16 lg:w-16 text-xl sm:text-2xl"
+                )}
                 style={{ backgroundColor: category.color || "#e5e7eb" }}
               >
                 {category.emoji || "📁"}
@@ -72,18 +82,11 @@ function CategoryCard({ category, index, balance, onEdit, onSearch, onDelete }: 
               <div className="flex-1 min-w-0">
                 <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
                   <div className="min-w-0">
-                    <h3 className="font-semibold text-base sm:text-lg truncate">{category.nombre}</h3>
+                    <h3 className={cn("font-semibold truncate", isSub ? "text-sm" : "text-base sm:text-lg")}>{category.nombre}</h3>
                     <div className="flex items-center gap-2 mt-1 sm:mt-0">
-                      
-                      
-                      
-                    <AmountDisplay amount={balance} size="sm" />
-
-
+                      <AmountDisplay amount={balance} size="sm" />
                     </div>
                   </div>
-                  
-             
                 </div>
               </div>
 
@@ -205,6 +208,12 @@ export function CategoryList() {
     try {
       if (editingCategory) {
         await updateCategoria(editingCategory.id, patch)
+        if (!editingCategory.categoria_padre_id && patch.color) {
+          const children = categories.filter((c) => c.categoria_padre_id === editingCategory.id)
+          for (const child of children) {
+            await updateCategoria(child.id, { color: patch.color })
+          }
+        }
       } else if (organizacionId) {
         const maxOrder = Math.max(...categories.map((c) => c.orden), 0)
         await DatabaseService.createCategoria({
@@ -236,14 +245,28 @@ export function CategoryList() {
     items.splice(result.destination.index, 0, reorderedItem)
 
     try {
-      const updates = items.map((item, index) => ({
-        id: item.id,
-        orden: index + 1,
-      }))
+      const updates = items.map((item, index) => {
+        const prev = items[index - 1]
+        const newParentId = prev && !prev.categoria_padre_id ? prev.id : null
+        const parentColor = newParentId
+          ? items.find((c) => c.id === newParentId)?.color || item.color
+          : item.color
+        return {
+          id: item.id,
+          orden: index + 1,
+          categoria_padre_id: newParentId,
+          color: parentColor,
+        }
+      })
 
       for (const update of updates) {
-        await updateCategoria(update.id, { orden: update.orden })
+        await updateCategoria(update.id, {
+          orden: update.orden,
+          categoria_padre_id: update.categoria_padre_id,
+          color: update.color,
+        })
       }
+      await fetchCategorias()
     } catch (error) {
       console.error("Error reordering categories:", error)
     }
@@ -414,6 +437,7 @@ export function CategoryList() {
           {editingCategory && (
             <CategoryEditForm
               category={editingCategory}
+              parentCategory={categories.find((c) => c.id === editingCategory.categoria_padre_id) || null}
               onSave={handleSaveCategory}
               onCancel={() => setEditSheetOpen(false)}
             />

--- a/components/transactions/category-chip.tsx
+++ b/components/transactions/category-chip.tsx
@@ -17,17 +17,17 @@ export function CategoryChip({ category, categories, onCategoryChange }: Categor
   const [open, setOpen] = useState(false)
 
   const getCategoryColor = (category: Categoria) => {
-    if (category.color) {
-      return category.color
-    }
-    // Colores por defecto basados en el tipo
+    const color = category.categoria_padre_id
+      ? categories.find((c) => c.id === category.categoria_padre_id)?.color
+      : category.color
+    if (color) return color
     switch (category.tipo) {
       case "ingreso":
-        return "#10b981" // green-500
+        return "#10b981"
       case "gasto":
-        return "#ef4444" // red-500
+        return "#ef4444"
       default:
-        return "#6366f1" // indigo-500
+        return "#6366f1"
     }
   }
 

--- a/components/transactions/category-selector.tsx
+++ b/components/transactions/category-selector.tsx
@@ -10,6 +10,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { Badge } from "@/components/ui/badge"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import type { Categoria } from "@/lib/types/database"
+import { cn } from "@/lib/utils"
 
 interface CategorySelectorProps {
   categories: Categoria[]
@@ -42,6 +43,20 @@ export function CategorySelector({
     )
   }, [categories, searchValue])
 
+  const structuredCategories = useMemo(() => {
+    if (searchValue) return filteredCategories
+    const roots = categories.filter((c) => !c.categoria_padre_id).sort((a, b) => a.orden - b.orden)
+    const result: Categoria[] = []
+    roots.forEach((root) => {
+      result.push(root)
+      categories
+        .filter((c) => c.categoria_padre_id === root.id)
+        .sort((a, b) => a.orden - b.orden)
+        .forEach((sub) => result.push(sub))
+    })
+    return result
+  }, [categories, filteredCategories, searchValue])
+
   const selectedCategoryObjects = useMemo(() => {
     return categories.filter((cat) => selectedCategories.includes(cat.id))
   }, [categories, selectedCategories])
@@ -73,17 +88,17 @@ export function CategorySelector({
   }
 
   const getCategoryColor = (category: Categoria) => {
-    if (category.color) {
-      return category.color
-    }
-    // Colores por defecto basados en el tipo
+    const color = category.categoria_padre_id
+      ? categories.find((c) => c.id === category.categoria_padre_id)?.color
+      : category.color
+    if (color) return color
     switch (category.tipo) {
       case "ingreso":
-        return "#10b981" // green-500
+        return "#10b981"
       case "gasto":
-        return "#ef4444" // red-500
+        return "#ef4444"
       default:
-        return "#6366f1" // indigo-500
+        return "#6366f1"
     }
   }
 
@@ -121,16 +136,19 @@ export function CategorySelector({
           </div>
           <ScrollArea className="h-[280px]">
             <div className="p-2">
-              {filteredCategories.length === 0 ? (
+              {structuredCategories.length === 0 ? (
                 <div className="text-center py-6 text-muted-foreground">
                   <p className="text-sm">No se encontraron categorías</p>
                 </div>
               ) : (
                 <div className="space-y-1">
-                  {filteredCategories.map((category) => (
+                  {structuredCategories.map((category) => (
                     <div
                       key={category.id}
-                      className="flex items-center gap-2 p-2 hover:bg-muted/50 rounded cursor-pointer"
+                      className={cn(
+                        "flex items-center gap-2 p-2 hover:bg-muted/50 rounded cursor-pointer",
+                        category.categoria_padre_id && "pl-6"
+                      )}
                       onClick={() => handleSelect(category.id)}
                     >
                       <Badge


### PR DESCRIPTION
## Summary
- allow categories to have subcategorias with emoji, color inherited from parent
- show subcategories indented in lists and selectors
- keep subcategory color locked and mention parent in edit form

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68b4412dc784832686bf4f29d29dab8c