### PR TITLE
feat: soporta subcategorías

### DIFF
--- a/components/categories/category-edit-form.tsx
+++ b/components/categories/category-edit-form.tsx
@@ -13,24 +13,18 @@ import type { Categoria } from "@/lib/types/database"
 
 interface CategoryEditFormProps {
   category: Categoria
+  parentCategory?: Categoria
   onSave: (patch: Partial<Categoria>) => Promise<void>
   onCancel: () => void
 }
 
-// Colores predefinidos para categorías
-const DEFAULT_COLORS = [
-  "#FF6B6B", "#4ECDC4", "#45B7D1", "#96CEB4", "#FFEAA7",
-  "#DDA0DD", "#98D8C8", "#F7DC6F", "#BB8FCE", "#85C1E9",
-  "#F8C471", "#82E0AA", "#F1948A", "#D7BDE2", "#FAD7A0",
-  "#A9DFBF", "#F9E79F", "#D5A6BD", "#A3E4D7", "#FFB6C1"
-]
 
-export function CategoryEditForm({ category, onSave, onCancel }: CategoryEditFormProps) {
+export function CategoryEditForm({ category, parentCategory, onSave, onCancel }: CategoryEditFormProps) {
   const [formData, setFormData] = useState({
     nombre: category.nombre,
     emoji: category.emoji || "📁",
     tipo: category.tipo,
-    color: category.color || "#4ECDC4",
+    color: parentCategory?.color || category.color || "#4ECDC4",
   })
   const [loading, setLoading] = useState(false)
 
@@ -49,7 +43,7 @@ export function CategoryEditForm({ category, onSave, onCancel }: CategoryEditFor
         nombre: formData.nombre.trim(),
         emoji: formData.emoji,
         tipo: formData.tipo,
-        color: formData.color,
+        ...(parentCategory ? {} : { color: formData.color }),
       })
     } catch (error) {
       console.error("Error saving category:", error)
@@ -85,16 +79,36 @@ export function CategoryEditForm({ category, onSave, onCancel }: CategoryEditFor
             className="w-full justify-start"
           />
         </div>
-        
+
+        {!parentCategory ? (
+          <div className="space-y-2">
+            <Label>Color</Label>
+            <ColorPicker
+              value={formData.color}
+              onChange={(color) => setFormData({ ...formData, color })}
+              className="w-full"
+            />
+          </div>
+        ) : (
+          <div className="space-y-2">
+            <Label>Color</Label>
+            <div
+              className="h-10 w-full rounded border"
+              style={{ backgroundColor: parentCategory.color }}
+            />
+          </div>
+        )}
+      </div>
+
+      {parentCategory && (
         <div className="space-y-2">
-          <Label>Color</Label>
-          <ColorPicker
-            value={formData.color}
-            onChange={(color) => setFormData({ ...formData, color })}
-            className="w-full"
+          <Label>Subcategoría de</Label>
+          <Input
+            value={`${parentCategory.emoji || ""} ${parentCategory.nombre}`}
+            disabled
           />
         </div>
-      </div>
+      )}
 
       {/* Category Name */}
       <div className="space-y-2">

--- a/components/categories/category-list.tsx
+++ b/components/categories/category-list.tsx
@@ -19,18 +19,6 @@ import { AmountDisplay } from "@/components/amount-display"
 import { DeleteCategoryDialog } from "./delete-category-dialog"
 import type { Categoria } from "@/lib/types/database"
 
-const getCategoryTypeColor = (tipo: string) => {
-  switch (tipo) {
-    case "ingreso":
-      return "bg-green-100 text-green-800 hover:bg-green-200"
-    case "gasto":
-      return "bg-red-100 text-red-800 hover:bg-red-200"
-    case "mixto":
-      return "bg-blue-100 text-blue-800 hover:bg-blue-200"
-    default:
-      return "bg-gray-100 text-gray-800 hover:bg-gray-200"
-  }
-}
 
 interface CategoryCardProps {
   category: Categoria
@@ -42,13 +30,18 @@ interface CategoryCardProps {
 }
 
 function CategoryCard({ category, index, balance, onEdit, onSearch, onDelete }: CategoryCardProps) {
+  const isSub = !!category.categoria_padre_id
   return (
     <Draggable draggableId={category.id} index={index}>
       {(provided, snapshot) => (
         <Card
           ref={provided.innerRef}
           {...provided.draggableProps}
-          className={cn("transition-shadow hover:shadow-md", snapshot.isDragging && "shadow-lg rotate-2")}
+          className={cn(
+            "transition-shadow hover:shadow-md",
+            snapshot.isDragging && "shadow-lg rotate-2",
+            isSub && "ml-6",
+          )}
         >
           <CardContent className="p-3 sm:p-4 lg:p-6">
             <div className="flex items-center gap-3 sm:gap-4">
@@ -62,7 +55,10 @@ function CategoryCard({ category, index, balance, onEdit, onSearch, onDelete }: 
 
               {/* Category Icon */}
               <div
-                className="flex h-12 w-12 sm:h-14 sm:w-14 lg:h-16 lg:w-16 items-center justify-center rounded-xl text-xl sm:text-2xl shadow-sm flex-shrink-0"
+                className={cn(
+                  "flex h-12 w-12 sm:h-14 sm:w-14 lg:h-16 lg:w-16 items-center justify-center rounded-xl text-xl sm:text-2xl shadow-sm flex-shrink-0",
+                  isSub && "h-10 w-10 sm:h-12 sm:w-12 lg:h-14 lg:w-14 text-lg sm:text-xl",
+                )}
                 style={{ backgroundColor: category.color || "#e5e7eb" }}
               >
                 {category.emoji || "📁"}
@@ -72,7 +68,7 @@ function CategoryCard({ category, index, balance, onEdit, onSearch, onDelete }: 
               <div className="flex-1 min-w-0">
                 <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
                   <div className="min-w-0">
-                    <h3 className="font-semibold text-base sm:text-lg truncate">{category.nombre}</h3>
+                    <h3 className={cn("font-semibold text-base sm:text-lg truncate", isSub && "font-medium")}>{category.nombre}</h3>
                     <div className="flex items-center gap-2 mt-1 sm:mt-0">
                       
                       
@@ -205,6 +201,12 @@ export function CategoryList() {
     try {
       if (editingCategory) {
         await updateCategoria(editingCategory.id, patch)
+        if (patch.color && editingCategory.categoria_padre_id === null) {
+          const children = categories.filter((c) => c.categoria_padre_id === editingCategory.id)
+          for (const child of children) {
+            await updateCategoria(child.id, { color: patch.color })
+          }
+        }
       } else if (organizacionId) {
         const maxOrder = Math.max(...categories.map((c) => c.orden), 0)
         await DatabaseService.createCategoria({
@@ -232,18 +234,24 @@ export function CategoryList() {
     if (!result.destination) return
 
     const items = Array.from(sortedCategories)
-    const [reorderedItem] = items.splice(result.source.index, 1)
-    items.splice(result.destination.index, 0, reorderedItem)
+    const [moved] = items.splice(result.source.index, 1)
+    items.splice(result.destination.index, 0, moved)
+
+    const prev = items[result.destination.index - 1]
+    const newParentId = prev ? (prev.categoria_padre_id ? prev.categoria_padre_id : prev.id) : null
+    const parentColor = newParentId ? items.find((c) => c.id === newParentId)?.color || moved.color : moved.color
 
     try {
-      const updates = items.map((item, index) => ({
-        id: item.id,
-        orden: index + 1,
-      }))
-
-      for (const update of updates) {
-        await updateCategoria(update.id, { orden: update.orden })
-      }
+      await Promise.all(
+        items.map((item, index) => {
+          const patch: Partial<Categoria> = { orden: index + 1 }
+          if (item.id === moved.id) {
+            patch.categoria_padre_id = newParentId
+            patch.color = parentColor
+          }
+          return updateCategoria(item.id, patch)
+        }),
+      )
     } catch (error) {
       console.error("Error reordering categories:", error)
     }
@@ -409,11 +417,14 @@ export function CategoryList() {
       <Sheet open={editSheetOpen} onOpenChange={setEditSheetOpen}>
         <SheetContent className="w-full sm:w-[400px] sm:max-w-[540px] overflow-y-auto">
           <SheetHeader>
-            <SheetTitle>Editar categoría</SheetTitle>
+            <SheetTitle>
+              {editingCategory?.categoria_padre_id ? "Editar subcategoría" : "Editar categoría"}
+            </SheetTitle>
           </SheetHeader>
           {editingCategory && (
             <CategoryEditForm
               category={editingCategory}
+              parentCategory={categories.find((c) => c.id === editingCategory.categoria_padre_id)}
               onSave={handleSaveCategory}
               onCancel={() => setEditSheetOpen(false)}
             />

--- a/components/categories/category-search.tsx
+++ b/components/categories/category-search.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useMemo } from "react"
+import { cn } from "@/lib/utils"
 import { Check, ChevronsUpDown, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command"
@@ -26,13 +27,38 @@ export function CategorySearch({
   const [open, setOpen] = useState(false)
   const [searchValue, setSearchValue] = useState("")
 
+  const orderedCategories = useMemo(() => {
+    return [...categories].sort((a, b) => a.orden - b.orden)
+  }, [categories])
+
+  const groupedCategories = useMemo(() => {
+    const top: (Categoria & { depth: number })[] = []
+    const children: Record<string, Categoria[]> = {}
+
+    for (const cat of orderedCategories) {
+      if (cat.categoria_padre_id) {
+        ;(children[cat.categoria_padre_id] ||= []).push(cat)
+      } else {
+        top.push({ ...cat, depth: 0 })
+      }
+    }
+
+    const result: (Categoria & { depth: number })[] = []
+    for (const cat of top) {
+      result.push(cat)
+      const subs = (children[cat.id] || []).sort((a, b) => a.orden - b.orden)
+      for (const sub of subs) result.push({ ...sub, depth: 1 })
+    }
+    return result
+  }, [orderedCategories])
+
   const filteredCategories = useMemo(() => {
-    if (!searchValue) return categories
-    return categories.filter(category =>
+    if (!searchValue) return groupedCategories
+    return groupedCategories.filter(category =>
       category.nombre.toLowerCase().includes(searchValue.toLowerCase()) ||
       (category.emoji && category.emoji.includes(searchValue))
     )
-  }, [categories, searchValue])
+  }, [groupedCategories, searchValue])
 
   const selectedCategoryObjects = useMemo(() => {
     return categories.filter(cat => selectedCategories.includes(cat.id))
@@ -94,6 +120,7 @@ export function CategorySearch({
                     key={category.id}
                     value={category.id}
                     onSelect={() => handleSelect(category.id)}
+                    className={cn(category.depth === 1 && "pl-6")}
                   >
                     <Check
                       className={`mr-2 h-4 w-4 ${


### PR DESCRIPTION
## Summary
- permitir crear y ordenar subcategorías arrastrando bajo una categoría
- edición de subcategorías con color bloqueado e indicador de categoría madre
- selector de categorías muestra subcategorías con sangría

## Testing
- `pnpm lint` *(falla: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68b4412dc784832686bf4f29d29dab8c