### PR TITLE
feat(auth): add Google login

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -11,11 +11,23 @@ export async function GET(request: Request) {
     const supabase = createClient()
     const { error } = await supabase.auth.exchangeCodeForSession(code)
     if (!error) {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser()
+      console.log("OAuth con Google exitoso para usuario", user?.id)
       const redirectUrl = process.env.NEXT_PUBLIC_SITE_URL || origin
       return NextResponse.redirect(`${redirectUrl}${next}`)
     }
+    console.warn("OAuth con Google no autorizado", error.message)
+    const redirectUrl = process.env.NEXT_PUBLIC_SITE_URL || origin
+    const loginUrl = new URL("/auth/login", redirectUrl)
+    loginUrl.searchParams.set(
+      "error",
+      "Tu correo no está autorizado. Contacta con un administrador.",
+    )
+    return NextResponse.redirect(loginUrl.toString())
   }
 
-  // return the user to an error page with instructions
+  console.error("OAuth callback sin código")
   return NextResponse.redirect(`${origin}/auth/auth-code-error`)
 }

--- a/components/auth/login-form.tsx
+++ b/components/auth/login-form.tsx
@@ -1,15 +1,15 @@
 "use client"
 
 import { useFormStatus } from "react-dom"
-import { useActionState } from "react"
+import { useActionState, useEffect, type SVGProps } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Loader2, Building2, TrendingUp, Cpu } from "lucide-react"
 import Link from "next/link"
-import { useRouter } from "next/navigation"
-import { useEffect } from "react"
+import { useRouter, useSearchParams } from "next/navigation"
 import { signIn } from "@/lib/actions/auth"
+import { createClient } from "@/lib/supabase/client"
 
 function SubmitButton() {
   const { pending } = useFormStatus()
@@ -33,8 +33,33 @@ function SubmitButton() {
   )
 }
 
+function GoogleIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="-0.5 0 48 48" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path
+        fill="#FBBC05"
+        d="M9.827 24c0-1.524.253-2.985.705-4.356L2.623 13.604C1.082 16.734.214 20.26.214 24c0 3.737.867 7.261 2.406 10.388l7.904-6.05A14.17 14.17 0 0 1 9.827 24"
+      />
+      <path
+        fill="#EB4335"
+        d="M23.714 10.133c3.311 0 6.302 1.173 8.652 3.093L39.202 6.4C35.036 2.773 29.695.533 23.714.533 14.427.533 6.445 5.844 2.623 13.604l7.909 6.04c1.822-5.532 7.017-9.51 13.182-9.51"
+      />
+      <path
+        fill="#34A853"
+        d="M23.714 37.867c-6.165 0-11.36-3.978-13.182-9.51l-7.909 6.091C6.445 42.156 14.427 47.467 23.714 47.467c5.732 0 11.205-2.035 15.312-5.849l-7.507-5.804c-2.118 1.334-4.785 2.052-7.805 2.052"
+      />
+      <path
+        fill="#4285F4"
+        d="M46.145 24c0-1.387-.213-2.88-.534-4.267H23.714V28.8h12.605a11.89 11.89 0 0 1-4.8 7.014l7.507 5.804C43.339 37.614 46.145 31.649 46.145 24"
+      />
+    </svg>
+  )
+}
+
 export default function LoginForm() {
   const router = useRouter()
+  const searchParams = useSearchParams()
+  const oauthError = searchParams.get("error")
   const [state, formAction] = useActionState(signIn, null)
 
   // Handle successful login by redirecting
@@ -43,6 +68,23 @@ export default function LoginForm() {
       router.push("/")
     }
   }, [state, router])
+
+  async function handleGoogleSignIn() {
+    console.log("Iniciando OAuth con Google")
+    const supabase = createClient()
+    const redirectTo =
+      process.env.NEXT_PUBLIC_DEV_SUPABASE_REDIRECT_URL ||
+      `${window.location.origin}/auth/callback`
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider: "google",
+      options: {
+        redirectTo,
+      },
+    })
+    if (error) {
+      console.error("Error iniciando OAuth", error)
+    }
+  }
 
   return (
     <div className="relative z-10 w-full max-w-md">
@@ -71,9 +113,9 @@ export default function LoginForm() {
         </CardHeader>
         <CardContent className="space-y-6">
           <form action={formAction} className="space-y-4">
-            {state?.error && (
+            {(state?.error || oauthError) && (
               <div className="bg-destructive/10 border border-destructive/50 text-destructive px-4 py-3 rounded-lg animate-in slide-in-from-top-2 duration-300">
-                {state.error}
+                {state?.error ?? oauthError}
               </div>
             )}
 
@@ -105,6 +147,26 @@ export default function LoginForm() {
             </div>
 
             <SubmitButton />
+
+            <div className="relative py-2">
+              <div className="absolute inset-0 flex items-center">
+                <span className="w-full border-t border-border/30"></span>
+              </div>
+              <div className="relative flex justify-center text-xs uppercase">
+                <span className="bg-card/95 px-2 text-muted-foreground">o</span>
+              </div>
+            </div>
+
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleGoogleSignIn}
+              className="w-full group relative overflow-hidden transition-all duration-300 hover:scale-[1.02] bg-background"
+            >
+              <div className="absolute inset-0 bg-gradient-to-r from-transparent via-muted/20 to-transparent -translate-x-full group-hover:translate-x-full transition-transform duration-700"></div>
+              <GoogleIcon className="mr-2 h-4 w-4" />
+              Entrar con Google
+            </Button>
 
             <div className="text-center text-sm text-muted-foreground">
               ¿No tienes cuenta? Solicítala a tu responsable{" "}


### PR DESCRIPTION
## Summary
- add Google OAuth login button and flow
- show unauthorized message when email is not allowed
- log OAuth start, success, and unauthorized attempts

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68b45fda4c688326928c3131ce0a2f87