### PR TITLE
feat: show related movements in sidebar

### DIFF
--- a/components/categories/category-list.tsx
+++ b/components/categories/category-list.tsx
@@ -17,6 +17,7 @@ import { DatabaseService } from "@/lib/services/database"
 import { GripVertical, Search, Edit, Trash2, Plus, Building2, Wallet, X } from "lucide-react"
 import { AmountDisplay } from "@/components/amount-display"
 import { DeleteCategoryDialog } from "./delete-category-dialog"
+import { RelatedMovementsSheet } from "@/components/transactions/related-movements-sheet"
 import type { Categoria } from "@/lib/types/database"
 
 
@@ -129,6 +130,7 @@ export function CategoryList() {
   const [deletingCategory, setDeletingCategory] = useState<Categoria | null>(null)
   const [editSheetOpen, setEditSheetOpen] = useState(false)
   const [createSheetOpen, setCreateSheetOpen] = useState(false)
+  const [viewingCategory, setViewingCategory] = useState<Categoria | null>(null)
   const [dateFrom, setDateFrom] = useState<string | undefined>()
   const [dateTo, setDateTo] = useState<string | undefined>()
 
@@ -176,7 +178,7 @@ export function CategoryList() {
   }
 
   const handleSearch = (category: Categoria) => {
-    window.location.href = `/transacciones?categoria=${category.id}`
+    setViewingCategory(category)
   }
 
   const handleDeleteRequest = (category: Categoria) => {
@@ -468,6 +470,14 @@ export function CategoryList() {
           />
         </SheetContent>
       </Sheet>
+
+      <RelatedMovementsSheet
+        category={viewingCategory}
+        open={!!viewingCategory}
+        onOpenChange={(open) => {
+          if (!open) setViewingCategory(null)
+        }}
+      />
     </div>
   )
 }

--- a/components/cuentas/cuentas-manager.tsx
+++ b/components/cuentas/cuentas-manager.tsx
@@ -10,6 +10,7 @@ import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sh
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { CuentaEditForm } from "./cuenta-edit-form"
 import { DeleteAccountDialog } from "./delete-account-dialog"
+import { RelatedMovementsSheet } from "@/components/transactions/related-movements-sheet"
 import type { Cuenta } from "@/lib/types/database"
 import { useCuentas } from "@/hooks/use-cuentas"
 import { useDelegationContext } from "@/contexts/delegation-context"
@@ -40,6 +41,7 @@ export function CuentasManager() {
   const [copiedIban, setCopiedIban] = useState<string | null>(null)
   const [balances, setBalances] = useState<Record<string, number>>({})
   const [operationStates, setOperationStates] = useState<Record<string, 'creating' | 'updating' | 'deleting'>>({})
+  const [viewingAccount, setViewingAccount] = useState<Cuenta | null>(null)
 
   // Función para actualizar el estado de una operación
   const setOperationState = useCallback((cuentaId: string, state: 'creating' | 'updating' | 'deleting' | null) => {
@@ -612,6 +614,16 @@ export function CuentasManager() {
                             <Button
                               variant="outline"
                               size="sm"
+                              onClick={() => setViewingAccount(cuenta)}
+                              disabled={isCreating || isUpdating || isDeleting}
+                              className="h-8 w-8 sm:h-9 sm:w-9 p-0 text-blue-600 hover:text-blue-700 hover:bg-blue-50 hover:border-blue-200 dark:hover:bg-blue-950 disabled:opacity-50 disabled:cursor-not-allowed"
+                              title="Ver movimientos"
+                            >
+                              <Search className="h-3 w-3 sm:h-4 sm:w-4" />
+                            </Button>
+                            <Button
+                              variant="outline"
+                              size="sm"
                               onClick={() => setEditingCuenta(cuenta)}
                               disabled={isCreating || isUpdating || isDeleting}
                               className="h-8 w-8 sm:h-9 sm:w-9 p-0 hover:bg-blue-50 hover:border-blue-200 dark:hover:bg-blue-950 disabled:opacity-50 disabled:cursor-not-allowed"
@@ -690,6 +702,14 @@ export function CuentasManager() {
           onCancel={() => setDeletingCuenta(null)}
         />
       )}
+
+      <RelatedMovementsSheet
+        account={viewingAccount}
+        open={!!viewingAccount}
+        onOpenChange={(open) => {
+          if (!open) setViewingAccount(null)
+        }}
+      />
     </div>
   )
 }

--- a/components/transactions/related-movements-sheet.tsx
+++ b/components/transactions/related-movements-sheet.tsx
@@ -1,0 +1,138 @@
+"use client"
+
+import { useState, useEffect, useRef } from "react"
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet"
+import { LoadingSpinner } from "@/components/ui/loading-spinner"
+import { ErrorMessage } from "@/components/ui/error-message"
+import { AmountDisplay } from "@/components/ui/amount-display"
+import { BankAvatar } from "./bank-avatar"
+import { useDelegationContext } from "@/contexts/delegation-context"
+import { useMovimientos } from "@/hooks/use-movimientos"
+import { useCategorias } from "@/hooks/use-categorias"
+import { useCuentas } from "@/hooks/use-cuentas"
+import { formatDate } from "@/lib/utils/format"
+import { TransactionDetail } from "./transaction-detail"
+import type { Cuenta, Categoria, MovimientoConRelaciones, Movimiento } from "@/lib/types/database"
+
+interface RelatedMovementsSheetProps {
+  account?: Cuenta | null
+  category?: Categoria | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function RelatedMovementsSheet({ account, category, open, onOpenChange }: RelatedMovementsSheetProps) {
+  const { selectedDelegation, getCurrentDelegation } = useDelegationContext()
+  const { categorias: categories } = useCategorias(getCurrentDelegation()?.organizacion_id)
+  const { cuentas: accounts } = useCuentas(selectedDelegation)
+
+  const { movimientos, loading, error, loadMore, hasMore, updateMovimiento } = useMovimientos(
+    selectedDelegation,
+    {
+      cuentaId: account?.id,
+      categoriaIds: category ? [category.id] : undefined,
+    },
+    { pageSize: 50 },
+  )
+
+  const [selectedMovement, setSelectedMovement] = useState<MovimientoConRelaciones | null>(null)
+  const [detailOpen, setDetailOpen] = useState(false)
+  const loadMoreRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    if (!hasMore) return
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting) {
+        loadMore()
+      }
+    })
+    const current = loadMoreRef.current
+    if (current) observer.observe(current)
+    return () => {
+      if (current) observer.unobserve(current)
+    }
+  }, [loadMore, hasMore])
+
+  const title = account ? `Movimientos de ${account.nombre}` : category ? `Movimientos de ${category.nombre}` : "Movimientos"
+
+  return (
+    <>
+      <Sheet open={open} onOpenChange={onOpenChange}>
+        <SheetContent side="right" className="w-full sm:w-[540px] overflow-y-auto">
+          <SheetHeader>
+            <SheetTitle>{title}</SheetTitle>
+          </SheetHeader>
+          <div className="py-6">
+            {loading && movimientos.length === 0 ? (
+              <div className="flex justify-center py-10">
+                <LoadingSpinner size="lg" />
+              </div>
+            ) : error ? (
+              <ErrorMessage message={error} />
+            ) : movimientos.length === 0 ? (
+              <p className="text-sm text-center text-muted-foreground">No hay movimientos</p>
+            ) : (
+              <div className="divide-y">
+                {movimientos.map((mov) => (
+                  <button
+                    key={mov.id}
+                    onClick={() => {
+                      setSelectedMovement(mov)
+                      setDetailOpen(true)
+                    }}
+                    className="w-full text-left p-4 hover:bg-muted flex items-center justify-between gap-4"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <p className="font-medium truncate">{mov.concepto}</p>
+                      <div className="flex items-center gap-2 text-xs text-muted-foreground mt-1">
+                        <span>{formatDate(mov.fecha)}</span>
+                        {account ? (
+                          mov.categoria ? (
+                            <span className="flex items-center gap-1">
+                              {mov.categoria.emoji && <span>{mov.categoria.emoji}</span>}
+                              <span className="truncate">{mov.categoria.nombre}</span>
+                            </span>
+                          ) : (
+                            <span>Sin categoría</span>
+                          )
+                        ) : category ? (
+                          <span className="flex items-center gap-1">
+                            <BankAvatar account={mov.cuenta} size="sm" />
+                            <span className="truncate">{mov.cuenta.nombre}</span>
+                          </span>
+                        ) : null}
+                      </div>
+                    </div>
+                    <AmountDisplay amount={mov.importe} size="sm" />
+                  </button>
+                ))}
+                {hasMore && (
+                  <div ref={loadMoreRef} className="py-4 flex justify-center">
+                    <LoadingSpinner size="sm" />
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        </SheetContent>
+      </Sheet>
+      <TransactionDetail
+        movement={selectedMovement as unknown as Movimiento}
+        accounts={accounts as unknown as Cuenta[]}
+        categories={categories as unknown as Categoria[]}
+        open={detailOpen}
+        onOpenChange={(open) => {
+          setDetailOpen(open)
+          if (!open) setSelectedMovement(null)
+        }}
+        onUpdate={async (id, patch) => {
+          await updateMovimiento(id, patch)
+        }}
+        onBack={() => {
+          setDetailOpen(false)
+          setSelectedMovement(null)
+        }}
+      />
+    </>
+  )
+}

--- a/components/transactions/transaction-detail.tsx
+++ b/components/transactions/transaction-detail.tsx
@@ -4,7 +4,7 @@ import type React from "react"
 
 import { useState, useEffect } from "react"
 import { format } from "date-fns"
-import { CalendarIcon, AlertTriangle, Check, Loader2 } from "lucide-react"
+import { CalendarIcon, AlertTriangle, Check, Loader2, ArrowLeft } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -29,6 +29,7 @@ interface TransactionDetailProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   onUpdate: (movementId: string, patch: Partial<Movimiento>) => Promise<void>
+  onBack?: () => void
 }
 
 export function TransactionDetail({
@@ -38,6 +39,7 @@ export function TransactionDetail({
   open,
   onOpenChange,
   onUpdate,
+  onBack,
 }: TransactionDetailProps) {
   const [formData, setFormData] = useState<Partial<Movimiento>>({})
   const [dateOpen, setDateOpen] = useState(false)
@@ -135,7 +137,14 @@ export function TransactionDetail({
       <SheetContent className="w-full sm:w-[400px] sm:max-w-[540px] overflow-y-auto p-0 relative">
         <div className="p-4 sm:p-6">
           <SheetHeader className="pb-4">
-            <SheetTitle className="text-xl font-semibold text-left">Transacción</SheetTitle>
+            <div className="flex items-center gap-2">
+              {onBack && (
+                <Button variant="ghost" size="icon" className="-ml-2" onClick={onBack}>
+                  <ArrowLeft className="h-4 w-4" />
+                </Button>
+              )}
+              <SheetTitle className="text-xl font-semibold text-left">Transacción</SheetTitle>
+            </div>
 
             <div className="bg-muted/30 rounded-lg p-3 sm:p-4 space-y-3 sm:space-y-4 mt-4">
               {account && (

--- a/hooks/use-movimientos.ts
+++ b/hooks/use-movimientos.ts
@@ -17,13 +17,13 @@ interface MovimientosFilters {
   uncategorized?: boolean
 }
 
-const PAGE_SIZE = 100
+const DEFAULT_PAGE_SIZE = 100
 
 export function useMovimientos(
   delegacionId: string | null,
   filters?: MovimientosFilters,
-  options: { timeoutMs?: number } = {}
-) {
+    options: { timeoutMs?: number; pageSize?: number } = {}
+  ) {
   const [movimientos, setMovimientos] = useState<MovimientoConRelaciones[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -34,6 +34,7 @@ export function useMovimientos(
   const abortRef = useRef<AbortController | null>(null)
   const timeoutRef = useRef<NodeJS.Timeout | null>(null)
   const timeoutMs = options.timeoutMs ?? 15000
+  const pageSize = options.pageSize ?? DEFAULT_PAGE_SIZE
 
   const fetchMovimientos = useCallback(
     async (pageToLoad = 0, append = false) => {
@@ -56,8 +57,8 @@ export function useMovimientos(
         setLoading(true)
         setError(null)
 
-        const from = pageToLoad * PAGE_SIZE
-        const to = from + PAGE_SIZE - 1
+        const from = pageToLoad * pageSize
+        const to = from + pageSize - 1
 
         const build = async (signal: AbortSignal) => {
           let query = supabase
@@ -114,7 +115,7 @@ export function useMovimientos(
         if (error) throw error
 
         setMovimientos(prev => (append ? [...prev, ...(data || [])] : (data || [])))
-        if ((data || []).length < PAGE_SIZE) {
+        if ((data || []).length < pageSize) {
           setHasMore(false)
         }
       } catch (err) {
@@ -131,7 +132,7 @@ export function useMovimientos(
         }
       }
     },
-    [delegacionId, filters?.fechaDesde, filters?.fechaHasta, (filters?.categoriaIds || []).join(","), filters?.cuentaId, filters?.busqueda, filters?.amountFrom, filters?.amountTo, filters?.uncategorized, timeoutMs]
+      [delegacionId, filters?.fechaDesde, filters?.fechaHasta, (filters?.categoriaIds || []).join(","), filters?.cuentaId, filters?.busqueda, filters?.amountFrom, filters?.amountTo, filters?.uncategorized, timeoutMs, pageSize]
   )
 
   useEffect(() => {
@@ -146,7 +147,7 @@ export function useMovimientos(
       if (abortRef.current) abortRef.current.abort()
       if (timeoutRef.current) clearTimeout(timeoutRef.current)
     }
-  }, [delegacionId, filters?.fechaDesde, filters?.fechaHasta, (filters?.categoriaIds || []).join(","), filters?.cuentaId, filters?.busqueda, filters?.amountFrom, filters?.amountTo, filters?.uncategorized, fetchMovimientos])
+    }, [delegacionId, filters?.fechaDesde, filters?.fechaHasta, (filters?.categoriaIds || []).join(","), filters?.cuentaId, filters?.busqueda, filters?.amountFrom, filters?.amountTo, filters?.uncategorized, fetchMovimientos, pageSize])
 
   useRevalidateOnFocusJitter(() => fetchMovimientos(0, false), { minMs: 90, maxMs: 220 })
 


### PR DESCRIPTION
## Summary
- add reusable sidebar to list movements filtered by account or category
- allow editing a movement with a back arrow to return to the list
- support custom page size for movement queries

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68baf4cf2b508326b7a3660d08a278d1