### PR TITLE
feat: add toggleable debug mode and cleanup stale timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,7 @@ Continue building your app on:
 2. Deploy your chats from the v0 interface
 3. Changes are automatically pushed to this repository
 4. Vercel deploys the latest version from this repository
+
+## Debug mode
+
+Set the environment variable `NEXT_PUBLIC_DEBUG=true` to enable verbose console logs. By default these debug logs are silenced in production.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next"
 import { Geist, Geist_Mono } from "next/font/google"
 import { Analytics } from "@vercel/analytics/next"
 import { AppProviders } from "@/contexts/app-providers"
+import "@/lib/debug"
 import "./globals.css"
 
 const geist = Geist({

--- a/contexts/app-providers.tsx
+++ b/contexts/app-providers.tsx
@@ -5,6 +5,7 @@ import { AuthProvider } from "./auth-context"
 import { DelegationProvider } from "./delegation-context"
 import { ConnectionMonitor } from "@/components/connection-monitor"
 import { Toaster } from "sonner"
+import "@/lib/debug"
 
 interface AppProvidersProps {
   children: React.ReactNode

--- a/hooks/use-categorias.ts
+++ b/hooks/use-categorias.ts
@@ -11,12 +11,10 @@ export function useCategorias(organizacionId?: string) {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const abortRef = useRef<AbortController | null>(null)
-  const timeoutRef = useRef<NodeJS.Timeout | null>(null)
   const TIMEOUT_MS = 12000
 
   const fetchCategorias = useCallback(async () => {
     if (abortRef.current) abortRef.current.abort()
-    if (timeoutRef.current) clearTimeout(timeoutRef.current)
 
     const ac = new AbortController()
     abortRef.current = ac
@@ -50,10 +48,7 @@ export function useCategorias(organizacionId?: string) {
       }
     } finally {
       setLoading(false)
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current)
-        timeoutRef.current = null
-      }
+      // runQuery handles timeout internally
     }
   }, [organizacionId])
 
@@ -61,7 +56,6 @@ export function useCategorias(organizacionId?: string) {
     fetchCategorias()
     return () => {
       if (abortRef.current) abortRef.current.abort()
-      if (timeoutRef.current) clearTimeout(timeoutRef.current)
     }
   }, [fetchCategorias])
 

--- a/hooks/use-cuentas.ts
+++ b/hooks/use-cuentas.ts
@@ -21,7 +21,6 @@ export function useCuentas(
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const abortControllerRef = useRef<AbortController | null>(null)
-  const timeoutRef = useRef<NodeJS.Timeout | null>(null)
   const forceRefreshRef = useRef<number>(0) // Para forzar refrescos
   
   // DEBUG: Track excessive calls  
@@ -53,10 +52,6 @@ export function useCuentas(
     // Cancel previous request if still pending
     if (abortControllerRef.current) {
       abortControllerRef.current.abort()
-    }
-    
-    if (timeoutRef.current) {
-      clearTimeout(timeoutRef.current)
     }
 
     // Create new abort controller for this request
@@ -99,11 +94,7 @@ export function useCuentas(
             .abortSignal(signal)
       })
 
-      // Clear timeout if query completed successfully
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current)
-        timeoutRef.current = null
-      }
+      // runQuery handles timeout internally
 
       if (abortController.signal.aborted) {
         return // Request was cancelled
@@ -133,11 +124,6 @@ export function useCuentas(
     } finally {
       // Always clear loading to avoid spinner lock; next fetch will set true
       setLoading(false)
-      // Cleanup
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current)
-        timeoutRef.current = null
-      }
     }
   }, [memoizedDelegacionId, timeout, cuentas.length])
 
@@ -157,9 +143,6 @@ export function useCuentas(
     return () => {
       if (abortControllerRef.current) {
         abortControllerRef.current.abort()
-      }
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current)
       }
     }
   }, [memoizedDelegacionId, fetchCuentas, cuentas.length])

--- a/hooks/use-delegations.ts
+++ b/hooks/use-delegations.ts
@@ -15,7 +15,6 @@ export function useDelegations({ timeout = 10000 }: { timeout?: number } = {}) {
   const { user } = useAuth()
 
   const abortControllerRef = useRef<AbortController | null>(null)
-  const timeoutRef = useRef<NodeJS.Timeout | null>(null)
 
   const fetchDelegations = useCallback(async () => {
     if (!user) {
@@ -26,7 +25,6 @@ export function useDelegations({ timeout = 10000 }: { timeout?: number } = {}) {
 
     // Cancel previous pending request (if any)
     if (abortControllerRef.current) abortControllerRef.current.abort()
-    if (timeoutRef.current) clearTimeout(timeoutRef.current)
 
     const abortController = new AbortController()
     abortControllerRef.current = abortController
@@ -80,10 +78,7 @@ export function useDelegations({ timeout = 10000 }: { timeout?: number } = {}) {
     } finally {
       // Always clear loading state; a new fetch will set it to true again
       setLoading(false)
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current)
-        timeoutRef.current = null
-      }
+      // runQuery handles its own timeout
     }
   }, [user, timeout])
 
@@ -91,7 +86,6 @@ export function useDelegations({ timeout = 10000 }: { timeout?: number } = {}) {
     fetchDelegations()
     return () => {
       if (abortControllerRef.current) abortControllerRef.current.abort()
-      if (timeoutRef.current) clearTimeout(timeoutRef.current)
     }
   }, [fetchDelegations])
 

--- a/lib/debug.ts
+++ b/lib/debug.ts
@@ -1,0 +1,13 @@
+const debugEnabled = process.env.NEXT_PUBLIC_DEBUG === 'true'
+
+if (!debugEnabled) {
+  console.log = () => {}
+  console.debug = () => {}
+}
+
+export { debugEnabled }
+export function debugLog(...args: unknown[]) {
+  if (debugEnabled) {
+    console.log(...args)
+  }
+}


### PR DESCRIPTION
## Summary
- silence console logs unless `NEXT_PUBLIC_DEBUG=true`
- remove unused timeout cleanup in delegations, cuentas, and categorias hooks
- document new debug mode env var

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm build` *(fails: Creating an optimized production build ...)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6b9789c88326b8b3e21415008c86