### PR TITLE
feat: improve dashboard with cash flow trend

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,7 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs"
 import { TimeframeFilter, Timeframe, getTimeframeRange } from "@/components/dashboard/timeframe-filter"
 import { ActivityBalanceDashboard } from "@/components/dashboard/activity-balance"
 import { CategoryAnalysisDashboard } from "@/components/dashboard/category-analysis"
+import { CashFlowTrend } from "@/components/dashboard/cash-flow-trend"
 
 export default function HomePage() {
   const [timeframe, setTimeframe] = useState<Timeframe>("school-year")
@@ -32,6 +33,8 @@ export default function HomePage() {
           </div>
 
           <FinancialSummary from={from} to={to} />
+
+          <CashFlowTrend from={from} to={to} />
 
           <div className="space-y-4">
             <h2 className="text-xl font-semibold">Acciones Rápidas</h2>

--- a/components/dashboard/cash-flow-trend.tsx
+++ b/components/dashboard/cash-flow-trend.tsx
@@ -1,0 +1,68 @@
+"use client"
+
+import { useMemo } from "react"
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
+import { useDelegationContext } from "@/contexts/delegation-context"
+import { useMovimientos } from "@/hooks/use-movimientos"
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart"
+import { LineChart, Line, XAxis, YAxis, CartesianGrid } from "recharts"
+import { format } from "date-fns"
+import { es } from "date-fns/locale"
+
+interface Props {
+  from: string
+  to: string
+}
+
+export function CashFlowTrend({ from, to }: Props) {
+  const { selectedDelegation } = useDelegationContext()
+  const { movimientos } = useMovimientos(selectedDelegation, {
+    fechaDesde: from,
+    fechaHasta: to,
+  })
+
+  const data = useMemo(() => {
+    const sorted = [...movimientos].sort((a, b) => a.fecha.localeCompare(b.fecha))
+    let balance = 0
+    return sorted.map((m) => {
+      balance += m.importe
+      return { date: m.fecha, balance }
+    })
+  }, [movimientos])
+
+  const chartConfig = {
+    balance: { label: "Saldo acumulado", color: "hsl(var(--chart-3))" },
+  } satisfies ChartConfig
+
+  if (!data.length) return null
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Evolución de saldo</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ChartContainer config={chartConfig} className="h-[300px]">
+          <LineChart data={data}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis
+              dataKey="date"
+              tickFormatter={(value) =>
+                format(new Date(value), "d MMM", { locale: es })
+              }
+            />
+            <YAxis />
+            <ChartTooltip content={<ChartTooltipContent />} />
+            <Line type="monotone" dataKey="balance" stroke="var(--color-balance)" />
+          </LineChart>
+        </ChartContainer>
+      </CardContent>
+    </Card>
+  )
+}
+

--- a/components/dashboard/financial-summary.tsx
+++ b/components/dashboard/financial-summary.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { TrendingUp, TrendingDown, Wallet, Target, Tag } from "lucide-react"
+import { TrendingUp, TrendingDown, Wallet, Target, Tag, Calculator } from "lucide-react"
 import { useDelegationContext } from "@/contexts/delegation-context"
 import { useMovimientos } from "@/hooks/use-movimientos"
 import { useMemo } from "react"
@@ -23,7 +23,7 @@ export function FinancialSummary({ from, to }: Props) {
 
   const summary = useMemo(() => {
     if (!movimientos.length)
-      return { ingresos: 0, gastos: 0, balance: 0, count: 0, uncategorized: 0 }
+      return { ingresos: 0, gastos: 0, balance: 0, count: 0, uncategorized: 0, average: 0 }
 
     const ingresos = movimientos
       .filter((m) => m.importe > 0)
@@ -36,6 +36,8 @@ export function FinancialSummary({ from, to }: Props) {
     const uncategorized = movimientos.filter((m) => !m.categoria_id).length
 
     const balance = ingresos - gastos
+    const totalAbs = ingresos + gastos
+    const average = movimientos.length ? totalAbs / movimientos.length : 0
 
     return {
       ingresos,
@@ -43,6 +45,7 @@ export function FinancialSummary({ from, to }: Props) {
       balance,
       count: movimientos.length,
       uncategorized,
+      average,
     }
   }, [movimientos])
 
@@ -89,10 +92,18 @@ export function FinancialSummary({ from, to }: Props) {
       bgColor: "bg-orange-50",
       action: () => router.push("/transacciones?uncategorized=1"),
     },
+    {
+      title: "Ticket medio",
+      value: `€${summary.average.toFixed(2)}`,
+      description: "Importe medio",
+      icon: Calculator,
+      color: "text-purple-600",
+      bgColor: "bg-purple-50",
+    },
   ]
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-6 gap-4">
       {metrics.map((metric) => (
         <Card
           key={metric.title}


### PR DESCRIPTION
## Summary
- add cash flow trend chart to dashboard
- compute average transaction value metric
- expose cash flow and metric in home dashboard

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68bb67c0e2bc8326b9e4bb78bd7a02bd