### PR TITLE
feat: show recent transactions in dashboard

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import { useState } from "react"
 import { AppLayout } from "@/components/app-layout"
 import { FinancialSummary } from "@/components/dashboard/financial-summary"
 import { QuickActions } from "@/components/dashboard/quick-actions"
+import { RecentTransactions } from "@/components/dashboard/recent-transactions"
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs"
 import { TimeframeFilter, Timeframe, getTimeframeRange } from "@/components/dashboard/timeframe-filter"
 import { ActivityBalanceDashboard } from "@/components/dashboard/activity-balance"
@@ -36,6 +37,11 @@ export default function HomePage() {
           <div className="space-y-4">
             <h2 className="text-xl font-semibold">Acciones Rápidas</h2>
             <QuickActions />
+          </div>
+
+          <div className="space-y-4">
+            <h2 className="text-xl font-semibold">Últimas transacciones</h2>
+            <RecentTransactions />
           </div>
         </TabsContent>
 

--- a/components/dashboard/recent-transactions.tsx
+++ b/components/dashboard/recent-transactions.tsx
@@ -1,0 +1,54 @@
+"use client"
+
+import Link from "next/link"
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { useDelegationContext } from "@/contexts/delegation-context"
+import { useMovimientos } from "@/hooks/use-movimientos"
+import { format } from "date-fns"
+import { es } from "date-fns/locale"
+
+interface Props {
+  limit?: number
+}
+
+export function RecentTransactions({ limit = 5 }: Props) {
+  const { selectedDelegation } = useDelegationContext()
+  const { movimientos } = useMovimientos(selectedDelegation)
+
+  const latest = movimientos.slice(0, limit)
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <CardTitle className="text-sm font-medium">Últimas transacciones</CardTitle>
+        <Button variant="ghost" asChild size="sm" className="h-auto p-0">
+          <Link href="/transacciones">Ver todas</Link>
+        </Button>
+      </CardHeader>
+      <CardContent>
+        {latest.length === 0 ? (
+          <p className="text-sm text-muted-foreground">Sin movimientos recientes</p>
+        ) : (
+          <ul className="space-y-2">
+            {latest.map((mov) => (
+              <li key={mov.id} className="flex items-center justify-between text-sm">
+                <div className="flex flex-col">
+                  <span>{mov.concepto || "Sin concepto"}</span>
+                  <span className="text-muted-foreground">
+                    {format(new Date(mov.fecha), "d MMM", { locale: es })}
+                    {mov.categoria ? ` • ${mov.categoria.nombre}` : ""}
+                  </span>
+                </div>
+                <span className={mov.importe >= 0 ? "text-green-600" : "text-red-600"}>
+                  {mov.importe >= 0 ? "+" : "-"}€{Math.abs(mov.importe).toFixed(2)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add RecentTransactions component to display latest movements
- integrate widget into home dashboard page

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68bb67c0e2bc8326b9e4bb78bd7a02bd