### PR TITLE
feat: add admin configuration screen

### DIFF
--- a/app/api/admin/users/[id]/route.ts
+++ b/app/api/admin/users/[id]/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server"
+import { createAdminClient } from "@/lib/supabase/admin"
+
+export async function PUT(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const supabase = createAdminClient()
+  const { role, password, delegaciones } = await req.json()
+  if (password) {
+    await supabase.auth.admin.updateUserById(params.id, { password })
+  }
+  if (role) {
+    // Update role across memberships (simple approach: update all to same role)
+    await supabase
+      .from("membresia")
+      .update({ rol: role })
+      .eq("usuario_id", params.id)
+  }
+  if (Array.isArray(delegaciones)) {
+    // Replace delegations
+    await supabase.from("membresia").delete().eq("usuario_id", params.id)
+    const inserts = delegaciones.map((d: string) => ({
+      usuario_id: params.id,
+      delegacion_id: d,
+      rol: role || "usuario",
+    }))
+    if (inserts.length) {
+      await supabase.from("membresia").insert(inserts)
+    }
+  }
+  return NextResponse.json({ ok: true })
+}
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const supabase = createAdminClient()
+  await supabase.auth.admin.deleteUser(params.id)
+  await supabase.from("membresia").delete().eq("usuario_id", params.id)
+  await supabase.from("perfil").delete().eq("usuario_id", params.id)
+  return NextResponse.json({ ok: true })
+}

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server"
+import { createAdminClient } from "@/lib/supabase/admin"
+
+export async function GET() {
+  const supabase = createAdminClient()
+  const { data, error } = await supabase.auth.admin.listUsers()
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  const { data: memberships } = await supabase
+    .from("membresia")
+    .select("usuario_id, rol, delegacion:delegacion_id (id, nombre)")
+  const users = (data?.users || []).map((u) => ({
+    id: u.id,
+    email: u.email,
+    membresias: memberships?.filter((m) => m.usuario_id === u.id) || [],
+  }))
+  return NextResponse.json({ users })
+}

--- a/app/configuracion/page.tsx
+++ b/app/configuracion/page.tsx
@@ -1,0 +1,10 @@
+import { AppLayout } from "@/components/app-layout"
+import { ConfigPage } from "@/components/configuracion/config-page"
+
+export default function ConfiguracionPage() {
+  return (
+    <AppLayout>
+      <ConfigPage />
+    </AppLayout>
+  )
+}

--- a/components/configuracion/config-page.tsx
+++ b/components/configuracion/config-page.tsx
@@ -1,0 +1,289 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useDelegationContext } from "@/contexts/delegation-context"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet"
+import { supabase } from "@/lib/supabase/client"
+import type { Delegacion } from "@/lib/types/database"
+import { useIsAdmin } from "@/hooks/use-is-admin"
+
+interface DelegacionWithCount extends Delegacion {
+  movimientos?: number
+}
+
+interface UserMembresia {
+  usuario_id: string
+  rol: string
+  delegacion: { id: string; nombre: string } | null
+}
+
+interface UserData {
+  id: string
+  email: string | undefined
+  membresias: UserMembresia[]
+}
+
+export function ConfigPage() {
+  const { setSelectedDelegation } = useDelegationContext()
+  const isAdmin = useIsAdmin()
+  const [delegaciones, setDelegaciones] = useState<DelegacionWithCount[]>([])
+  const [users, setUsers] = useState<UserData[]>([])
+  const [editingDelegacion, setEditingDelegacion] = useState<DelegacionWithCount | null>(null)
+  const [editingUser, setEditingUser] = useState<UserData | null>(null)
+  const [userForm, setUserForm] = useState({ role: "", password: "", delegaciones: [] as string[] })
+
+  useEffect(() => {
+    setSelectedDelegation(null)
+  }, [setSelectedDelegation])
+
+  useEffect(() => {
+    const fetchDelegaciones = async () => {
+      const { data } = await supabase.from("delegacion").select("id,codigo,nombre")
+      const withCounts: DelegacionWithCount[] = await Promise.all(
+        (data || []).map(async (d) => {
+          const { count } = await supabase
+            .from("movimiento")
+            .select("id", { count: "exact", head: true })
+            .eq("delegacion_id", d.id)
+          return { ...d, movimientos: count || 0 }
+        })
+      )
+      setDelegaciones(withCounts)
+    }
+    const fetchUsers = async () => {
+      const res = await fetch("/api/admin/users")
+      const json = await res.json()
+      setUsers(json.users || [])
+    }
+    if (isAdmin) {
+      fetchDelegaciones()
+      fetchUsers()
+    }
+  }, [isAdmin])
+
+  if (!isAdmin) {
+    return <p className="text-center text-muted-foreground">Acceso restringido</p>
+  }
+
+  return (
+    <div className="space-y-10">
+      {/* Delegaciones Section */}
+      <section>
+        <h2 className="text-xl font-semibold mb-4">Delegaciones</h2>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Nombre</TableHead>
+              <TableHead>Código</TableHead>
+              <TableHead>UUID</TableHead>
+              <TableHead>Movimientos</TableHead>
+              <TableHead className="text-right">Acciones</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {delegaciones.map((d) => (
+              <TableRow key={d.id}>
+                <TableCell>{d.nombre}</TableCell>
+                <TableCell>{d.codigo || "-"}</TableCell>
+                <TableCell className="font-mono text-xs">{d.id}</TableCell>
+                <TableCell>{d.movimientos || 0}</TableCell>
+                <TableCell className="text-right">
+                  <Button size="sm" variant="outline" onClick={() => setEditingDelegacion(d)}>
+                    Editar
+                  </Button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </section>
+
+      {/* Usuarios Section */}
+      <section>
+        <h2 className="text-xl font-semibold mb-4">Usuarios</h2>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Email</TableHead>
+              <TableHead>Rol</TableHead>
+              <TableHead>Delegaciones</TableHead>
+              <TableHead className="text-right">Acciones</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {users.map((u) => {
+              const role = u.membresias[0]?.rol || "-"
+              const delegs = u.membresias.map((m) => m.delegacion?.nombre).filter(Boolean).join(", ")
+              return (
+                <TableRow key={u.id}>
+                  <TableCell>{u.email}</TableCell>
+                  <TableCell>{role}</TableCell>
+                  <TableCell>{delegs}</TableCell>
+                  <TableCell className="text-right space-x-2">
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => {
+                        setEditingUser(u)
+                        setUserForm({
+                          role: role,
+                          password: "",
+                          delegaciones: u.membresias.map((m) => m.delegacion?.id || ""),
+                        })
+                      }}
+                    >
+                      Editar
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="destructive"
+                      onClick={async () => {
+                        await fetch(`/api/admin/users/${u.id}`, { method: "DELETE" })
+                        setUsers((prev) => prev.filter((x) => x.id !== u.id))
+                      }}
+                    >
+                      Eliminar
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              )
+            })}
+          </TableBody>
+        </Table>
+      </section>
+
+      {/* Delegacion Edit Sheet */}
+      <Sheet open={!!editingDelegacion} onOpenChange={() => setEditingDelegacion(null)}>
+        <SheetContent className="w-full sm:w-[400px] sm:max-w-[540px] overflow-y-auto">
+          <SheetHeader>
+            <SheetTitle>Editar delegación</SheetTitle>
+          </SheetHeader>
+          {editingDelegacion && (
+            <form
+              className="space-y-4 py-4"
+              onSubmit={async (e) => {
+                e.preventDefault()
+                const formData = new FormData(e.currentTarget)
+                const nombre = formData.get("nombre") as string
+                const codigo = formData.get("codigo") as string
+                await supabase
+                  .from("delegacion")
+                  .update({ nombre, codigo })
+                  .eq("id", editingDelegacion.id)
+                setDelegaciones((prev) =>
+                  prev.map((d) =>
+                    d.id === editingDelegacion.id ? { ...d, nombre, codigo } : d
+                  )
+                )
+                setEditingDelegacion(null)
+              }}
+            >
+              <div className="space-y-2">
+                <label className="text-sm font-medium">UUID</label>
+                <Input value={editingDelegacion.id} disabled className="font-mono text-xs" />
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Nombre</label>
+                <Input name="nombre" defaultValue={editingDelegacion.nombre} required />
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Código</label>
+                <Input name="codigo" defaultValue={editingDelegacion.codigo || ""} />
+              </div>
+              <div className="pt-4 flex justify-end">
+                <Button type="submit">Guardar</Button>
+              </div>
+            </form>
+          )}
+        </SheetContent>
+      </Sheet>
+
+      {/* User Edit Sheet */}
+      <Sheet open={!!editingUser} onOpenChange={() => setEditingUser(null)}>
+        <SheetContent className="w-full sm:w-[400px] sm:max-w-[540px] overflow-y-auto">
+          <SheetHeader>
+            <SheetTitle>Editar usuario</SheetTitle>
+          </SheetHeader>
+          {editingUser && (
+            <form
+              className="space-y-4 py-4"
+              onSubmit={async (e) => {
+                e.preventDefault()
+                await fetch(`/api/admin/users/${editingUser.id}`, {
+                  method: "PUT",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify(userForm),
+                })
+                setUsers((prev) =>
+                  prev.map((u) =>
+                    u.id === editingUser.id
+                      ? {
+                          ...u,
+                          membresias: userForm.delegaciones.map((d) => ({
+                            usuario_id: editingUser.id,
+                            rol: userForm.role,
+                            delegacion: delegaciones.find((del) => del.id === d) || null,
+                          })),
+                        }
+                      : u
+                  )
+                )
+                setEditingUser(null)
+              }}
+            >
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Email</label>
+                <Input value={editingUser.email} disabled />
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Rol</label>
+                <Input
+                  value={userForm.role}
+                  onChange={(e) => setUserForm((f) => ({ ...f, role: e.target.value }))}
+                  placeholder="admin | usuario"
+                  required
+                />
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Contraseña (opcional)</label>
+                <Input
+                  type="password"
+                  value={userForm.password}
+                  onChange={(e) => setUserForm((f) => ({ ...f, password: e.target.value }))}
+                />
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Delegaciones</label>
+                <div className="max-h-40 overflow-y-auto space-y-1 p-2 border rounded-md">
+                  {delegaciones.map((d) => (
+                    <label key={d.id} className="flex items-center space-x-2 text-sm">
+                      <input
+                        type="checkbox"
+                        checked={userForm.delegaciones.includes(d.id)}
+                        onChange={(e) => {
+                          setUserForm((f) => {
+                            const set = new Set(f.delegaciones)
+                            if (e.target.checked) set.add(d.id)
+                            else set.delete(d.id)
+                            return { ...f, delegaciones: Array.from(set) }
+                          })
+                        }}
+                      />
+                      <span>{d.nombre}</span>
+                    </label>
+                  ))}
+                </div>
+              </div>
+              <div className="pt-4 flex justify-end">
+                <Button type="submit">Guardar</Button>
+              </div>
+            </form>
+          )}
+        </SheetContent>
+      </Sheet>
+    </div>
+  )
+}

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -21,6 +21,7 @@ import {
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
+import useIsAdmin from "@/hooks/use-is-admin"
 
 interface SidebarContentProps {
   className?: string
@@ -30,6 +31,7 @@ interface SidebarContentProps {
 
 function SidebarContent({ className, collapsed = false, transactionCount }: SidebarContentProps) {
   const pathname = usePathname()
+  const isAdmin = useIsAdmin()
 
   const navigation = [
     {
@@ -81,13 +83,17 @@ function SidebarContent({ className, collapsed = false, transactionCount }: Side
       count: 14,
       enabled: false,
     },
-    {
-      name: "Configuración",
-      href: "/configuracion",
-      icon: Settings,
-      count: null,
-      enabled: false,
-    },
+    ...(isAdmin
+      ? [
+          {
+            name: "Configuración",
+            href: "/configuracion",
+            icon: Settings,
+            count: null,
+            enabled: true,
+          },
+        ]
+      : []),
     {
       name: "Diagnóstico",
       href: "/diagnostico",

--- a/hooks/use-is-admin.ts
+++ b/hooks/use-is-admin.ts
@@ -1,0 +1,45 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { supabase } from "@/lib/supabase/client"
+import { useAuth } from "@/contexts/auth-context"
+
+export function useIsAdmin() {
+  const { user } = useAuth()
+  const [isAdmin, setIsAdmin] = useState(false)
+
+  useEffect(() => {
+    let mounted = true
+    const checkRole = async () => {
+      if (!user) {
+        setIsAdmin(false)
+        return
+      }
+      try {
+        const { data, error } = await supabase
+          .from("membresia")
+          .select("rol")
+          .eq("usuario_id", user.id)
+          .eq("rol", "admin")
+          .limit(1)
+        if (!mounted) return
+        if (error) {
+          console.error("Error checking admin role", error)
+          setIsAdmin(false)
+        } else {
+          setIsAdmin(data?.length > 0)
+        }
+      } catch (err) {
+        if (mounted) setIsAdmin(false)
+      }
+    }
+    checkRole()
+    return () => {
+      mounted = false
+    }
+  }, [user])
+
+  return isAdmin
+}
+
+export default useIsAdmin

--- a/lib/supabase/admin.ts
+++ b/lib/supabase/admin.ts
@@ -1,0 +1,11 @@
+import { createClient } from "@supabase/supabase-js"
+import type { Database } from "@/lib/types/database"
+
+export function createAdminClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error("Missing Supabase admin environment variables")
+  }
+  return createClient<Database>(supabaseUrl, serviceRoleKey)
+}


### PR DESCRIPTION
## Summary
- add useIsAdmin hook and restrict Configuración entry to admins
- implement admin configuration page with delegations and user management
- provide Supabase admin API routes for user listing and updates

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68bb677ce6bc8326bd379034c2428a03