### PR TITLE
feat: add admin configuration panel

### DIFF
--- a/app/api/admin/users/[id]/route.ts
+++ b/app/api/admin/users/[id]/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server"
+import { createClient } from "@supabase/supabase-js"
+
+function createAdminClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!supabaseUrl || !serviceKey) {
+    throw new Error("Missing Supabase keys")
+  }
+  return createClient(supabaseUrl, serviceKey)
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: { id: string } },
+) {
+  const supabase = createAdminClient()
+  const body = await request.json()
+  if (body.password) {
+    const { error } = await supabase.auth.admin.updateUserById(params.id, {
+      password: body.password,
+    })
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 })
+    }
+  }
+  return NextResponse.json({ success: true })
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: { id: string } },
+) {
+  const supabase = createAdminClient()
+  const { error } = await supabase.auth.admin.deleteUser(params.id)
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  return NextResponse.json({ success: true })
+}
+

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server"
+import { createClient } from "@supabase/supabase-js"
+
+export async function GET() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!supabaseUrl || !serviceKey) {
+    return NextResponse.json({ error: "Missing Supabase keys" }, { status: 500 })
+  }
+  const supabase = createClient(supabaseUrl, serviceKey)
+  const { data, error } = await supabase.auth.admin.listUsers()
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  return NextResponse.json({ users: data.users })
+}
+

--- a/app/configuracion/page.tsx
+++ b/app/configuracion/page.tsx
@@ -1,0 +1,34 @@
+import { AppLayout } from "@/components/app-layout"
+import { ConfigurationManager } from "@/components/configuration/configuration-manager"
+import { createClient } from "@/lib/supabase/server"
+import { redirect } from "next/navigation"
+
+export default async function ConfiguracionPage() {
+  const supabase = createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    redirect("/auth/login")
+  }
+  const { data, error } = await supabase
+    .from("membresia")
+    .select("rol")
+    .eq("usuario_id", user.id)
+  const isAdmin = !error && (data || []).some((m) => m.rol === "admin")
+  if (!isAdmin) {
+    redirect("/")
+  }
+  return (
+    <AppLayout showDelegationSelector={false}>
+      <div className="space-y-4 sm:space-y-6">
+        <div className="px-1">
+          <h1 className="text-2xl sm:text-3xl font-bold tracking-tight">Configuración</h1>
+          <p className="text-muted-foreground text-sm sm:text-base">Administración del sistema</p>
+        </div>
+        <ConfigurationManager />
+      </div>
+    </AppLayout>
+  )
+}
+

--- a/components/app-layout.tsx
+++ b/components/app-layout.tsx
@@ -12,9 +12,10 @@ import { cn } from "@/lib/utils"
 interface AppLayoutProps {
   children: React.ReactNode
   transactionCount?: number // Added prop for transaction count
+  showDelegationSelector?: boolean
 }
 
-export function AppLayout({ children, transactionCount }: AppLayoutProps) {
+export function AppLayout({ children, transactionCount, showDelegationSelector = true }: AppLayoutProps) {
   const { selectedDelegation, setSelectedDelegation } = useDelegationContext()
   const { user, loading } = useAuth()
   const router = useRouter()
@@ -79,7 +80,11 @@ export function AppLayout({ children, transactionCount }: AppLayoutProps) {
       {/* Main Content */}
       <div className={cn("transition-all duration-300", sidebarCollapsed ? "lg:pl-16" : "lg:pl-72")}>
         {/* Topbar */}
-        <Topbar selectedDelegation={selectedDelegation} onDelegationChange={setSelectedDelegation} />
+        <Topbar
+          selectedDelegation={selectedDelegation}
+          onDelegationChange={setSelectedDelegation}
+          showDelegationSelector={showDelegationSelector}
+        />
 
         {/* Page Content */}
         <main className="flex-1 p-4 lg:p-6">{children}</main>

--- a/components/configuration/configuration-manager.tsx
+++ b/components/configuration/configuration-manager.tsx
@@ -1,0 +1,276 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { supabase } from "@/lib/supabase/client"
+import { Button } from "@/components/ui/button"
+import {
+  Table,
+  TableHeader,
+  TableRow,
+  TableHead,
+  TableBody,
+  TableCell,
+} from "@/components/ui/table"
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select"
+import type { Delegacion } from "@/lib/types/database"
+
+interface DelegacionWithCount extends Delegacion {
+  movimientos: number
+}
+
+interface UserInfo {
+  id: string
+  email: string
+  delegaciones: { id: string; nombre: string }[]
+  rol: string | null
+}
+
+export function ConfigurationManager() {
+  const [delegaciones, setDelegaciones] = useState<DelegacionWithCount[]>([])
+  const [users, setUsers] = useState<UserInfo[]>([])
+  const [editingDelegacion, setEditingDelegacion] = useState<DelegacionWithCount | null>(null)
+  const [editingUser, setEditingUser] = useState<UserInfo | null>(null)
+
+  useEffect(() => {
+    fetchDelegaciones()
+    fetchUsers()
+  }, [])
+
+  async function fetchDelegaciones() {
+    const { data } = await supabase.from("delegacion").select("id, codigo, nombre")
+    const results: DelegacionWithCount[] = []
+    if (data) {
+      for (const d of data) {
+        const { count } = await supabase
+          .from("movimiento")
+          .select("*", { count: "exact", head: true })
+          .eq("delegacion_id", d.id)
+        results.push({ ...d, movimientos: count ?? 0 })
+      }
+    }
+    setDelegaciones(results)
+  }
+
+  async function fetchUsers() {
+    const res = await fetch("/api/admin/users")
+    if (!res.ok) return
+    const json = await res.json()
+    const baseUsers: UserInfo[] = json.users.map((u: any) => ({
+      id: u.id,
+      email: u.email,
+      delegaciones: [],
+      rol: null,
+    }))
+    const { data } = await supabase
+      .from("membresia")
+      .select("usuario_id, rol, delegacion:delegacion_id (id, nombre)")
+    baseUsers.forEach((u) => {
+      const memberships = (data || []).filter((m: any) => m.usuario_id === u.id)
+      u.delegaciones = memberships.map((m: any) => m.delegacion).filter(Boolean)
+      u.rol = memberships[0]?.rol || null
+    })
+    setUsers(baseUsers)
+  }
+
+  async function saveDelegacion(patch: { nombre: string; codigo: string | null }) {
+    if (!editingDelegacion) return
+    await supabase.from("delegacion").update(patch).eq("id", editingDelegacion.id)
+    await fetchDelegaciones()
+    setEditingDelegacion(null)
+  }
+
+  async function saveUser(updated: UserInfo & { password?: string }) {
+    if (updated.password) {
+      await fetch(`/api/admin/users/${updated.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ password: updated.password }),
+      })
+    }
+    const { data: current } = await supabase
+      .from("membresia")
+      .select("delegacion_id")
+      .eq("usuario_id", updated.id)
+    const currentIds = (current || []).map((m) => m.delegacion_id)
+    const selectedIds = updated.delegaciones.map((d) => d.id)
+    const toRemove = currentIds.filter((id) => !selectedIds.includes(id))
+    const toAdd = selectedIds.filter((id) => !currentIds.includes(id))
+    if (toRemove.length) {
+      await supabase.from("membresia").delete().in("delegacion_id", toRemove).eq("usuario_id", updated.id)
+    }
+    for (const id of toAdd) {
+      await supabase
+        .from("membresia")
+        .insert({ usuario_id: updated.id, delegacion_id: id, rol: updated.rol || "user" })
+    }
+    await supabase
+      .from("membresia")
+      .update({ rol: updated.rol || "user" })
+      .in("delegacion_id", selectedIds)
+      .eq("usuario_id", updated.id)
+    await fetchUsers()
+    setEditingUser(null)
+  }
+
+  async function deleteUser(user: UserInfo) {
+    await fetch(`/api/admin/users/${user.id}`, { method: "DELETE" })
+    await supabase.from("membresia").delete().eq("usuario_id", user.id)
+    await fetchUsers()
+  }
+
+  return (
+    <div className="space-y-10">
+      <section>
+        <h2 className="text-xl font-semibold mb-2">Delegaciones</h2>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Nombre</TableHead>
+              <TableHead>Código</TableHead>
+              <TableHead>Movimientos</TableHead>
+              <TableHead className="w-20"></TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {delegaciones.map((d) => (
+              <TableRow key={d.id}>
+                <TableCell>{d.nombre}</TableCell>
+                <TableCell>{d.codigo}</TableCell>
+                <TableCell>{d.movimientos}</TableCell>
+                <TableCell className="text-right">
+                  <Button size="sm" variant="outline" onClick={() => setEditingDelegacion(d)}>
+                    Editar
+                  </Button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </section>
+
+      <section>
+        <h2 className="text-xl font-semibold mb-2">Usuarios</h2>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Email</TableHead>
+              <TableHead>Rol</TableHead>
+              <TableHead>Delegaciones</TableHead>
+              <TableHead className="w-24"></TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {users.map((u) => (
+              <TableRow key={u.id}>
+                <TableCell>{u.email}</TableCell>
+                <TableCell>{u.rol}</TableCell>
+                <TableCell>{u.delegaciones.map((d) => d.nombre).join(", ") || "-"}</TableCell>
+                <TableCell className="flex gap-2 justify-end">
+                  <Button size="sm" variant="outline" onClick={() => setEditingUser(u)}>
+                    Editar
+                  </Button>
+                  <Button size="sm" variant="destructive" onClick={() => deleteUser(u)}>
+                    Eliminar
+                  </Button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </section>
+
+      <Sheet open={!!editingDelegacion} onOpenChange={(o) => !o && setEditingDelegacion(null)}>
+        <SheetContent side="right" className="w-full sm:w-[400px]">
+          <SheetHeader>
+            <SheetTitle>Editar delegación</SheetTitle>
+          </SheetHeader>
+          {editingDelegacion && (
+            <form
+              className="mt-4 space-y-4"
+              onSubmit={(e) => {
+                e.preventDefault()
+                const formData = new FormData(e.currentTarget as HTMLFormElement)
+                saveDelegacion({
+                  nombre: formData.get("nombre") as string,
+                  codigo: (formData.get("codigo") as string) || null,
+                })
+              }}
+            >
+              <Input name="nombre" defaultValue={editingDelegacion.nombre} placeholder="Nombre" />
+              <Input name="codigo" defaultValue={editingDelegacion.codigo || ""} placeholder="Código" />
+              <p className="text-xs text-muted-foreground">UUID: {editingDelegacion.id}</p>
+              <Button type="submit">Guardar</Button>
+            </form>
+          )}
+        </SheetContent>
+      </Sheet>
+
+      <Sheet open={!!editingUser} onOpenChange={(o) => !o && setEditingUser(null)}>
+        <SheetContent side="right" className="w-full sm:w-[400px]">
+          <SheetHeader>
+            <SheetTitle>Editar usuario</SheetTitle>
+          </SheetHeader>
+          {editingUser && (
+            <form
+              className="mt-4 space-y-4"
+              onSubmit={(e) => {
+                e.preventDefault()
+                const formData = new FormData(e.currentTarget as HTMLFormElement)
+                const password = (formData.get("password") as string) || undefined
+                const role = formData.get("rol") as string
+                const delegacionIds = formData.getAll("delegaciones") as string[]
+                const delegacionesSeleccionadas = delegaciones.filter((d) =>
+                  delegacionIds.includes(d.id),
+                )
+                saveUser({ ...editingUser, rol: role, delegaciones: delegacionesSeleccionadas, password })
+              }}
+            >
+              <p className="text-sm">{editingUser.email}</p>
+              <Select name="rol" defaultValue={editingUser.rol || "user"}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Rol" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="admin">Administrador</SelectItem>
+                  <SelectItem value="editor">Editor</SelectItem>
+                  <SelectItem value="user">Usuario</SelectItem>
+                </SelectContent>
+              </Select>
+              <Input type="password" name="password" placeholder="Nueva contraseña" />
+              <div className="space-y-2">
+                <p className="text-sm font-medium">Delegaciones</p>
+                {delegaciones.map((d) => (
+                  <label key={d.id} className="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      name="delegaciones"
+                      value={d.id}
+                      defaultChecked={editingUser.delegaciones.some((dd) => dd.id === d.id)}
+                      className="h-4 w-4"
+                    />
+                    <span className="text-sm">{d.nombre}</span>
+                  </label>
+                ))}
+              </div>
+              <div className="flex justify-end gap-2">
+                <Button type="button" variant="outline" onClick={() => setEditingUser(null)}>
+                  Cancelar
+                </Button>
+                <Button type="submit">Guardar</Button>
+              </div>
+            </form>
+          )}
+        </SheetContent>
+      </Sheet>
+    </div>
+  )
+}
+

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -21,6 +21,7 @@ import {
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
+import { useIsAdmin } from "@/hooks/use-is-admin"
 
 interface SidebarContentProps {
   className?: string
@@ -30,6 +31,7 @@ interface SidebarContentProps {
 
 function SidebarContent({ className, collapsed = false, transactionCount }: SidebarContentProps) {
   const pathname = usePathname()
+  const isAdmin = useIsAdmin()
 
   const navigation = [
     {
@@ -86,7 +88,7 @@ function SidebarContent({ className, collapsed = false, transactionCount }: Side
       href: "/configuracion",
       icon: Settings,
       count: null,
-      enabled: false,
+      enabled: isAdmin,
     },
     {
       name: "Diagnóstico",

--- a/components/topbar.tsx
+++ b/components/topbar.tsx
@@ -5,18 +5,21 @@ import { Sidebar } from "./sidebar"
 interface TopbarProps {
   selectedDelegation?: string | null
   onDelegationChange?: (delegationId: string) => void
+  showDelegationSelector?: boolean
 }
 
-export function Topbar({ selectedDelegation, onDelegationChange }: TopbarProps) {
+export function Topbar({ selectedDelegation, onDelegationChange, showDelegationSelector = true }: TopbarProps) {
   return (
     <header className="sticky top-0 z-40 flex h-16 items-center gap-4 border-b bg-background px-4 lg:px-6">
       {/* Mobile menu button */}
       <Sidebar showDesktop={false} />
 
       {/* Delegation selector */}
-      <div className="flex items-center gap-4">
-        <DelegationSelector value={selectedDelegation} onValueChange={onDelegationChange} />
-      </div>
+      {showDelegationSelector && (
+        <div className="flex items-center gap-4">
+          <DelegationSelector value={selectedDelegation} onValueChange={onDelegationChange} />
+        </div>
+      )}
 
       {/* Spacer */}
       <div className="flex-1" />

--- a/hooks/use-is-admin.ts
+++ b/hooks/use-is-admin.ts
@@ -1,0 +1,34 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { supabase } from "@/lib/supabase/client"
+import { useAuth } from "@/contexts/auth-context"
+
+export function useIsAdmin() {
+  const { user } = useAuth()
+  const [isAdmin, setIsAdmin] = useState(false)
+
+  useEffect(() => {
+    if (!user) {
+      setIsAdmin(false)
+      return
+    }
+    let isMounted = true
+    const check = async () => {
+      const { data, error } = await supabase
+        .from("membresia")
+        .select("rol")
+        .eq("usuario_id", user.id)
+      if (!error && isMounted) {
+        setIsAdmin((data ?? []).some((m) => m.rol === "admin"))
+      }
+    }
+    check()
+    return () => {
+      isMounted = false
+    }
+  }, [user])
+
+  return isAdmin
+}
+


### PR DESCRIPTION
## Summary
- add admin-only configuration page to manage delegaciones and usuarios
- support editing delegations, user roles, assignments and passwords
- hide delegation selector in configuration and expose admin-only sidebar entry

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68bb677ce6bc8326bd379034c2428a03