### PR TITLE
fix: ensure google oauth uses site url fallback

### DIFF
--- a/components/auth/login-form.tsx
+++ b/components/auth/login-form.tsx
@@ -45,7 +45,7 @@ export default function LoginForm() {
     console.log("OAuth start", { provider: "google" })
     const redirectTo =
       process.env.NEXT_PUBLIC_DEV_SUPABASE_REDIRECT_URL ||
-      `${process.env.NEXT_PUBLIC_SITE_URL}/auth/callback`
+      `${process.env.NEXT_PUBLIC_SITE_URL ?? window.location.origin}/auth/callback`
     const { error } = await supabase.auth.signInWithOAuth({
       provider: "google",
       options: { redirectTo },


### PR DESCRIPTION
## Summary
- fallback to window.origin when building Google OAuth redirect URL

## Testing
- `pnpm lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6569d5c88326a11d17d9f04ad286