### PR TITLE
feat: enhance topbar with manual link and user controls

### DIFF
--- a/components/topbar.tsx
+++ b/components/topbar.tsx
@@ -1,6 +1,11 @@
 "use client"
+
+import { BookOpen, LogOut } from "lucide-react"
+
 import { DelegationSelector } from "./delegation-selector"
 import { Sidebar } from "./sidebar"
+import { Button } from "@/components/ui/button"
+import { useAuth } from "@/contexts/auth-context"
 
 interface TopbarProps {
   selectedDelegation?: string | null
@@ -8,6 +13,10 @@ interface TopbarProps {
 }
 
 export function Topbar({ selectedDelegation, onDelegationChange }: TopbarProps) {
+  const { user, signOut } = useAuth()
+  const manualUrl =
+    process.env.NEXT_PUBLIC_URL_MANUAL ?? process.env.URL_MANUAL ?? "#"
+
   return (
     <header className="sticky top-0 z-40 flex h-16 items-center gap-4 border-b bg-background px-4 lg:px-6">
       {/* Mobile menu button */}
@@ -21,7 +30,26 @@ export function Topbar({ selectedDelegation, onDelegationChange }: TopbarProps) 
       {/* Spacer */}
       <div className="flex-1" />
 
-      {/* Future: User menu, notifications, etc. */}
+      {/* Manual & User section */}
+      <div className="flex items-center gap-2">
+        <Button variant="ghost" size="icon" asChild>
+          <a href={manualUrl} target="_blank" rel="noopener noreferrer">
+            <BookOpen className="h-5 w-5" />
+            <span className="sr-only">Manual</span>
+          </a>
+        </Button>
+        {user && (
+          <>
+            <span className="hidden text-sm text-muted-foreground sm:block">
+              {user.email}
+            </span>
+            <Button variant="ghost" size="icon" onClick={signOut}>
+              <LogOut className="h-5 w-5" />
+              <span className="sr-only">Cerrar sesión</span>
+            </Button>
+          </>
+        )}
+      </div>
     </header>
   )
 }


### PR DESCRIPTION
## Summary
- add manual button linking to app manual via env `URL_MANUAL`
- show logged-in email and provide logout control in topbar

## Testing
- `pnpm lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68bde59cd4308326b9a72ded3461b2b0