### PR TITLE
feat: add manual link and session info to topbar

### DIFF
--- a/components/topbar.tsx
+++ b/components/topbar.tsx
@@ -1,6 +1,10 @@
 "use client"
 import { DelegationSelector } from "./delegation-selector"
 import { Sidebar } from "./sidebar"
+import { Button } from "@/components/ui/button"
+import { Avatar, AvatarFallback } from "@/components/ui/avatar"
+import { useAuth } from "@/contexts/auth-context"
+import { BookOpen, LogOut } from "lucide-react"
 
 interface TopbarProps {
   selectedDelegation?: string | null
@@ -8,6 +12,9 @@ interface TopbarProps {
 }
 
 export function Topbar({ selectedDelegation, onDelegationChange }: TopbarProps) {
+  const { user, signOut } = useAuth()
+  const manualUrl = process.env.NEXT_PUBLIC_URL_MANUAL || process.env.URL_MANUAL
+
   return (
     <header className="sticky top-0 z-40 flex h-16 items-center gap-4 border-b bg-background px-4 lg:px-6">
       {/* Mobile menu button */}
@@ -21,7 +28,36 @@ export function Topbar({ selectedDelegation, onDelegationChange }: TopbarProps) 
       {/* Spacer */}
       <div className="flex-1" />
 
-      {/* Future: User menu, notifications, etc. */}
+      {/* Manual button */}
+      {manualUrl && (
+        <Button variant="ghost" size="sm" asChild>
+          <a
+            href={manualUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-2"
+          >
+            <BookOpen className="h-4 w-4" />
+            <span>Manual</span>
+          </a>
+        </Button>
+      )}
+
+      {/* User info */}
+      {user && (
+        <div className="flex items-center gap-2">
+          <Avatar className="h-8 w-8">
+            <AvatarFallback>
+              {user.email?.[0]?.toUpperCase()}
+            </AvatarFallback>
+          </Avatar>
+          <span className="text-sm font-medium">{user.email}</span>
+          <Button variant="ghost" size="icon" onClick={signOut}>
+            <LogOut className="h-4 w-4" />
+            <span className="sr-only">Cerrar sesión</span>
+          </Button>
+        </div>
+      )}
     </header>
   )
 }


### PR DESCRIPTION
## Summary
- show manual link using URL_MANUAL env
- display logged in email and sign out button in topbar

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68bde59cd4308326b9a72ded3461b2b0