### PR TITLE
fix: improve transaction editing

### DIFF
--- a/components/transactions/transaction-detail.tsx
+++ b/components/transactions/transaction-detail.tsx
@@ -76,12 +76,15 @@ export function TransactionDetail({
         categoria_id: movement.categoria_id,
         contraparte: movement.contraparte || "",
       })
+      setLastSaved(null)
+      setShowSaved(false)
     }
   }, [movement])
 
   useEffect(() => {
     if (movement && hasChanges) {
       setIsSaving(true)
+      setShowSaved(false)
       const timeoutId = setTimeout(async () => {
         try {
           await onUpdate(movement.id, formData)
@@ -91,7 +94,7 @@ export function TransactionDetail({
         } finally {
           setIsSaving(false)
         }
-      }, 1000)
+      }, 2000)
 
       return () => clearTimeout(timeoutId)
     }
@@ -134,7 +137,7 @@ export function TransactionDetail({
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent className="w-full sm:w-[560px] sm:max-w-[640px] overflow-y-auto p-0 relative z-[60]">
+      <SheetContent side="right" className="w-full sm:w-[560px] sm:max-w-[640px] overflow-y-auto p-0 relative z-[60]">
         <div className="p-4 sm:p-6">
           <SheetHeader className="pb-4">
             <div className="flex items-center gap-2">

--- a/components/transactions/transaction-list-row.tsx
+++ b/components/transactions/transaction-list-row.tsx
@@ -10,6 +10,8 @@ import { formatDate } from "@/lib/utils/format"
 import { Input } from "@/components/ui/input"
 import { LoadingSpinner } from "@/components/ui/loading-spinner"
 import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { Pencil } from "lucide-react"
 import type { Movimiento, MovimientoConRelaciones, Cuenta, Categoria } from "@/lib/types/database"
 
 interface TransactionListRowProps {
@@ -131,13 +133,27 @@ export const TransactionListRow = memo(function TransactionListRow({
                 </div>
               </div>
 
-              <div className="flex-shrink-0 text-right min-w-0">
-                <div className="mb-0.5">
-                  <AmountDisplay amount={movement.importe} size="sm" />
+              <div className="flex-shrink-0 flex items-start gap-2 min-w-0">
+                <div className="text-right">
+                  <div className="mb-0.5">
+                    <AmountDisplay amount={movement.importe} size="sm" />
+                  </div>
+                  <div className="text-xs text-muted-foreground bg-muted/30 px-2 py-0.5 rounded-md whitespace-nowrap inline-block">
+                    {formatDate(movement.fecha)}
+                  </div>
                 </div>
-                <div className="text-xs text-muted-foreground bg-muted/30 px-2 py-0.5 rounded-md whitespace-nowrap inline-block">
-                  {formatDate(movement.fecha)}
-                </div>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    onClick(movement, e)
+                  }}
+                  aria-label="Editar transacción"
+                >
+                  <Pencil className="h-4 w-4" />
+                </Button>
               </div>
             </div>
           </div>

--- a/components/transactions/transaction-manager.tsx
+++ b/components/transactions/transaction-manager.tsx
@@ -409,8 +409,11 @@ export function TransactionManager({ onTransactionCountChange }: TransactionMana
         movement={selectedMovement}
         accounts={accounts as unknown as Cuenta[]}
         categories={categories as unknown as Categoria[]}
-        open={detailOpen}
-        onOpenChange={setDetailOpen}
+        open={detailOpen && !!selectedMovement}
+        onOpenChange={(open) => {
+          setDetailOpen(open)
+          if (!open) setSelectedMovement(null)
+        }}
         onUpdate={async (movementId, patch) => {
           const fullPatch: Partial<MovimientoConRelaciones> = patch
           await handleMovementUpdate(movementId, fullPatch)


### PR DESCRIPTION
## Summary
- ensure transaction sidebar only opens with selected movement
- add explicit edit button to transaction rows
- improve auto-save indicator and timing in transaction detail

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68c6bbb0c470832691f0f024f0803094