### PR TITLE
fix: stabilize transaction detail sheet

### DIFF
--- a/components/transactions/transaction-detail.tsx
+++ b/components/transactions/transaction-detail.tsx
@@ -21,6 +21,7 @@ import { TabWithCounter } from "./tab-with-counter"
 import { formatCurrency } from "@/lib/utils/format"
 import { TransactionFiles } from "./transaction-files"
 import type { Movimiento, Cuenta, Categoria } from "@/lib/types/database"
+import { LoadingSpinner } from "@/components/ui/loading-spinner"
 
 interface TransactionDetailProps {
   movement: Movimiento | null
@@ -76,12 +77,21 @@ export function TransactionDetail({
         categoria_id: movement.categoria_id,
         contraparte: movement.contraparte || "",
       })
+      setActiveTab("datos")
+      setFileCount(0)
+      setIsAmountEditing(false)
+      setShowAmountConfirm(false)
+      setPendingAmount("")
+      setIsSaving(false)
+      setLastSaved(null)
+      setShowSaved(false)
     }
   }, [movement])
 
   useEffect(() => {
     if (movement && hasChanges) {
       setIsSaving(true)
+      setShowSaved(false)
       const timeoutId = setTimeout(async () => {
         try {
           await onUpdate(movement.id, formData)
@@ -91,7 +101,7 @@ export function TransactionDetail({
         } finally {
           setIsSaving(false)
         }
-      }, 1000)
+      }, 2000)
 
       return () => clearTimeout(timeoutId)
     }
@@ -134,228 +144,237 @@ export function TransactionDetail({
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent className="w-full sm:w-[560px] sm:max-w-[640px] overflow-y-auto p-0 relative z-[60]">
-        <div className="p-4 sm:p-6">
-          <SheetHeader className="pb-4">
-            <div className="flex items-center gap-2">
-              {onBack && (
-                <Button variant="ghost" size="icon" className="-ml-2" onClick={onBack}>
-                  <ArrowLeft className="h-4 w-4" />
-                </Button>
-              )}
-              <SheetTitle className="text-xl font-semibold text-left">Transacción</SheetTitle>
-            </div>
-
-            <div className="bg-muted/30 rounded-lg p-3 sm:p-4 space-y-3 sm:space-y-4 mt-4">
-              {account && (
-                <div className="flex items-center gap-3">
-                  <div
-                    className="rounded-full p-0.5"
-                    style={{ backgroundColor: account.color || "#4ECDC4" }}
-                  >
-                    <BankAvatar account={account} size="sm" />
-                  </div>
-                  <div>
-                    <p className="font-medium text-sm">{account.nombre}</p>
-                    <p className="text-xs text-muted-foreground">{account.banco_nombre}</p>
-                  </div>
+      <SheetContent side="right" className="w-full sm:w-[560px] sm:max-w-[640px] overflow-y-auto p-0 z-[60]">
+        {!movement ? (
+          <div className="flex h-full min-h-[320px] flex-col items-center justify-center gap-3 p-6 text-sm text-muted-foreground">
+            <LoadingSpinner size="md" />
+            <span>Cargando transacción...</span>
+          </div>
+        ) : (
+          <>
+            <div className="p-4 sm:p-6">
+              <SheetHeader className="pb-4">
+                <div className="flex items-center gap-2">
+                  {onBack && (
+                    <Button variant="ghost" size="icon" className="-ml-2" onClick={onBack}>
+                      <ArrowLeft className="h-4 w-4" />
+                    </Button>
+                  )}
+                  <SheetTitle className="text-xl font-semibold text-left">Transacción</SheetTitle>
                 </div>
-              )}
 
-              <div className="text-center space-y-1">
-                {isAmountEditing ? (
-                  <Input
-                    type="number"
-                    step="0.01"
-                    value={pendingAmount}
-                    onChange={(e) => setPendingAmount(e.target.value)}
-                    onKeyDown={handleAmountChange}
-                    onBlur={cancelAmountChange}
-                    className="w-40 h-10 text-center font-bold text-xl mx-auto"
-                    autoFocus
-                  />
-                ) : (
-                  <button
-                    onClick={handleAmountClick}
-                    className={cn(
-                      "text-center font-bold text-xl sm:text-2xl hover:bg-muted/50 px-3 py-2 rounded transition-colors",
-                      (formData.importe || 0) >= 0 ? "text-green-600" : "text-red-600",
-                    )}
-                  >
-                    {formatCurrency(formData.importe || 0)}
-                  </button>
-                )}
-                <p className="text-sm text-muted-foreground">
-                  {formData.fecha ? format(new Date(formData.fecha), "dd/MM/yyyy") : "Sin fecha"}
-                </p>
-              </div>
-
-              {selectedCategory && (
-                <div className="flex justify-center">
-                  <div
-                    className="px-3 py-1 rounded-full text-sm font-medium flex items-center gap-2"
-                    style={{
-                      backgroundColor: selectedCategory.color + "20",
-                      color: selectedCategory.color,
-                      border: `1px solid ${selectedCategory.color}40`,
-                    }}
-                  >
-                    <span>{selectedCategory.emoji}</span>
-                    <span>{selectedCategory.nombre}</span>
-                  </div>
-                </div>
-              )}
-            </div>
-          </SheetHeader>
-
-          <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as "datos" | "archivos")} className="w-full">
-            <div className="flex w-full rounded-md bg-muted p-1">
-              <TabWithCounter
-                label="Datos"
-                isActive={activeTab === "datos"}
-                onClick={() => setActiveTab("datos")}
-                className="flex-1"
-              />
-              <TabWithCounter
-                label="Archivos"
-                count={fileCount}
-                isActive={activeTab === "archivos"}
-                onClick={() => setActiveTab("archivos")}
-                className="flex-1"
-              />
-            </div>
-
-            <TabsContent value="datos" className="space-y-4 mt-4">
-              {showAmountConfirm && (
-                <Alert className="border-amber-200 bg-amber-50">
-                  <AlertTriangle className="h-4 w-4 text-amber-600" />
-                  <AlertDescription className="flex items-center justify-between">
-                    <span className="text-amber-800">¿Seguro que quieres editar el importe?</span>
-                    <div className="flex gap-2">
-                      <Button size="sm" onClick={confirmAmountChange} className="h-7">
-                        Sí
-                      </Button>
-                      <Button size="sm" variant="outline" onClick={cancelAmountChange} className="h-7 bg-transparent">
-                        No
-                      </Button>
+                <div className="bg-muted/30 rounded-lg p-3 sm:p-4 space-y-3 sm:space-y-4 mt-4">
+                  {account && (
+                    <div className="flex items-center gap-3">
+                      <div
+                        className="rounded-full p-0.5"
+                        style={{ backgroundColor: account.color || "#4ECDC4" }}
+                      >
+                        <BankAvatar account={account} size="sm" />
+                      </div>
+                      <div>
+                        <p className="font-medium text-sm">{account.nombre}</p>
+                        <p className="text-xs text-muted-foreground">{account.banco_nombre}</p>
+                      </div>
                     </div>
-                  </AlertDescription>
-                </Alert>
-              )}
+                  )}
 
-              <div className="space-y-4">
-                <div className="space-y-2">
-                  <Label htmlFor="concepto" className="text-sm font-medium">
-                    Concepto
-                  </Label>
-                  <Input
-                    id="concepto"
-                    value={formData.concepto || ""}
-                    onChange={(e) => setFormData((prev) => ({ ...prev, concepto: e.target.value }))}
-                    placeholder="Concepto de la transacción"
-                  />
-                </div>
-
-                <div className="space-y-2">
-                  <Label htmlFor="fecha" className="text-sm font-medium">
-                    Fecha
-                  </Label>
-                  <Popover open={dateOpen} onOpenChange={setDateOpen}>
-                    <PopoverTrigger asChild>
-                      <Button
-                        variant="outline"
+                  <div className="text-center space-y-1">
+                    {isAmountEditing ? (
+                      <Input
+                        type="number"
+                        step="0.01"
+                        value={pendingAmount}
+                        onChange={(e) => setPendingAmount(e.target.value)}
+                        onKeyDown={handleAmountChange}
+                        onBlur={cancelAmountChange}
+                        className="w-40 h-10 text-center font-bold text-xl mx-auto"
+                        autoFocus
+                      />
+                    ) : (
+                      <button
+                        onClick={handleAmountClick}
                         className={cn(
-                          "w-full justify-start text-left font-normal h-9",
-                          !formData.fecha && "text-muted-foreground",
+                          "text-center font-bold text-xl sm:text-2xl hover:bg-muted/50 px-3 py-2 rounded transition-colors",
+                          (formData.importe || 0) >= 0 ? "text-green-600" : "text-red-600",
                         )}
                       >
-                        <CalendarIcon className="mr-2 h-4 w-4" />
-                        {formData.fecha ? format(new Date(formData.fecha), "dd/MM/yyyy") : "Fecha"}
-                      </Button>
-                    </PopoverTrigger>
-                    <PopoverContent className="w-auto p-0" align="start">
-                      <Calendar
-                        mode="single"
-                        selected={formData.fecha ? new Date(formData.fecha) : undefined}
-                        onSelect={(date) => {
-                          setFormData((prev) => ({ ...prev, fecha: date ? format(date, "yyyy-MM-dd") : undefined }))
-                          setDateOpen(false)
+                        {formatCurrency(formData.importe || 0)}
+                      </button>
+                    )}
+                    <p className="text-sm text-muted-foreground">
+                      {formData.fecha ? format(new Date(formData.fecha), "dd/MM/yyyy") : "Sin fecha"}
+                    </p>
+                  </div>
+
+                  {selectedCategory && (
+                    <div className="flex justify-center">
+                      <div
+                        className="px-3 py-1 rounded-full text-sm font-medium flex items-center gap-2"
+                        style={{
+                          backgroundColor: selectedCategory.color + "20",
+                          color: selectedCategory.color,
+                          border: `1px solid ${selectedCategory.color}40`,
                         }}
-                        initialFocus
+                      >
+                        <span>{selectedCategory.emoji}</span>
+                        <span>{selectedCategory.nombre}</span>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </SheetHeader>
+
+              <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as "datos" | "archivos")} className="w-full">
+                <div className="flex w-full rounded-md bg-muted p-1">
+                  <TabWithCounter
+                    label="Datos"
+                    isActive={activeTab === "datos"}
+                    onClick={() => setActiveTab("datos")}
+                    className="flex-1"
+                  />
+                  <TabWithCounter
+                    label="Archivos"
+                    count={fileCount}
+                    isActive={activeTab === "archivos"}
+                    onClick={() => setActiveTab("archivos")}
+                    className="flex-1"
+                  />
+                </div>
+
+                <TabsContent value="datos" className="space-y-4 mt-4">
+                  {showAmountConfirm && (
+                    <Alert className="border-amber-200 bg-amber-50">
+                      <AlertTriangle className="h-4 w-4 text-amber-600" />
+                      <AlertDescription className="flex items-center justify-between">
+                        <span className="text-amber-800">¿Seguro que quieres editar el importe?</span>
+                        <div className="flex gap-2">
+                          <Button size="sm" onClick={confirmAmountChange} className="h-7">
+                            Sí
+                          </Button>
+                          <Button size="sm" variant="outline" onClick={cancelAmountChange} className="h-7 bg-transparent">
+                            No
+                          </Button>
+                        </div>
+                      </AlertDescription>
+                    </Alert>
+                  )}
+
+                  <div className="space-y-4">
+                    <div className="space-y-2">
+                      <Label htmlFor="concepto" className="text-sm font-medium">
+                        Concepto
+                      </Label>
+                      <Input
+                        id="concepto"
+                        value={formData.concepto || ""}
+                        onChange={(e) => setFormData((prev) => ({ ...prev, concepto: e.target.value }))}
+                        placeholder="Concepto de la transacción"
                       />
-                    </PopoverContent>
-                  </Popover>
+                    </div>
+
+                    <div className="space-y-2">
+                      <Label htmlFor="fecha" className="text-sm font-medium">
+                        Fecha
+                      </Label>
+                      <Popover open={dateOpen} onOpenChange={setDateOpen}>
+                        <PopoverTrigger asChild>
+                          <Button
+                            variant="outline"
+                            className={cn(
+                              "w-full justify-start text-left font-normal h-9",
+                              !formData.fecha && "text-muted-foreground",
+                            )}
+                          >
+                            <CalendarIcon className="mr-2 h-4 w-4" />
+                            {formData.fecha ? format(new Date(formData.fecha), "dd/MM/yyyy") : "Fecha"}
+                          </Button>
+                        </PopoverTrigger>
+                        <PopoverContent className="w-auto p-0" align="start">
+                          <Calendar
+                            mode="single"
+                            selected={formData.fecha ? new Date(formData.fecha) : undefined}
+                            onSelect={(date) => {
+                              setFormData((prev) => ({ ...prev, fecha: date ? format(date, "yyyy-MM-dd") : undefined }))
+                              setDateOpen(false)
+                            }}
+                            initialFocus
+                          />
+                        </PopoverContent>
+                      </Popover>
+                    </div>
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="categoria" className="text-sm font-medium">
+                      Categoría
+                    </Label>
+                    <CategorySelector
+                      categories={categories}
+                      selectedCategories={formData.categoria_id ? [formData.categoria_id] : []}
+                      onSelectionChange={(categoryIds) =>
+                        setFormData((prev) => ({ ...prev, categoria_id: categoryIds.length > 0 ? categoryIds[0] : null }))
+                      }
+                      allowMultiple={false}
+                      placeholder="Sin categoría"
+                    />
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="contacto" className="text-sm font-medium">
+                      Contacto
+                    </Label>
+                    <Input
+                      id="contacto"
+                      value={formData.contraparte || ""}
+                      onChange={(e) => setFormData((prev) => ({ ...prev, contraparte: e.target.value }))}
+                      placeholder="Nombre del contacto"
+                      className="h-9"
+                    />
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="descripcion" className="text-sm font-medium">
+                      Descripción
+                    </Label>
+                    <Textarea
+                      id="descripcion"
+                      value={formData.descripcion || ""}
+                      onChange={(e) => setFormData((prev) => ({ ...prev, descripcion: e.target.value }))}
+                      placeholder="Descripción adicional (opcional)"
+                      rows={3}
+                      className="resize-none"
+                    />
+                  </div>
+                </TabsContent>
+
+                <TabsContent value="archivos" className="space-y-6 mt-6">
+                  <TransactionFiles
+                    movementId={movement?.id || null}
+                    delegacionId={account?.delegacion_id}
+                    onCountChange={setFileCount}
+                  />
+                </TabsContent>
+              </Tabs>
+            </div>
+            {(isSaving || showSaved) && (
+              <div className="absolute bottom-4 left-1/2 -translate-x-1/2">
+                <div className="flex items-center gap-2 px-3 py-2 bg-muted rounded-md shadow">
+                  {isSaving ? (
+                    <>
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                      <span className="text-sm">Guardando...</span>
+                    </>
+                  ) : (
+                    <>
+                      <Check className="h-4 w-4 text-green-600" />
+                      <span className="text-sm text-green-600">Guardado</span>
+                    </>
+                  )}
                 </div>
               </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="categoria" className="text-sm font-medium">
-                  Categoría
-                </Label>
-                <CategorySelector
-                  categories={categories}
-                  selectedCategories={formData.categoria_id ? [formData.categoria_id] : []}
-                  onSelectionChange={(categoryIds) =>
-                    setFormData((prev) => ({ ...prev, categoria_id: categoryIds.length > 0 ? categoryIds[0] : null }))
-                  }
-                  allowMultiple={false}
-                  placeholder="Sin categoría"
-                />
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="contacto" className="text-sm font-medium">
-                  Contacto
-                </Label>
-                <Input
-                  id="contacto"
-                  value={formData.contraparte || ""}
-                  onChange={(e) => setFormData((prev) => ({ ...prev, contraparte: e.target.value }))}
-                  placeholder="Nombre del contacto"
-                  className="h-9"
-                />
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="descripcion" className="text-sm font-medium">
-                  Descripción
-                </Label>
-                <Textarea
-                  id="descripcion"
-                  value={formData.descripcion || ""}
-                  onChange={(e) => setFormData((prev) => ({ ...prev, descripcion: e.target.value }))}
-                  placeholder="Descripción adicional (opcional)"
-                  rows={3}
-                  className="resize-none"
-                />
-              </div>
-            </TabsContent>
-
-            <TabsContent value="archivos" className="space-y-6 mt-6">
-              <TransactionFiles
-                movementId={movement?.id || null}
-                delegacionId={account?.delegacion_id}
-                onCountChange={setFileCount}
-              />
-            </TabsContent>
-          </Tabs>
-        </div>
-        {(isSaving || showSaved) && (
-          <div className="absolute bottom-4 left-1/2 -translate-x-1/2">
-            <div className="flex items-center gap-2 px-3 py-2 bg-muted rounded-md shadow">
-              {isSaving ? (
-                <>
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                  <span className="text-sm">Guardando...</span>
-                </>
-              ) : (
-                <>
-                  <Check className="h-4 w-4 text-green-600" />
-                  <span className="text-sm text-green-600">Guardado</span>
-                </>
-              )}
-            </div>
-          </div>
+            )}
+          </>
         )}
       </SheetContent>
     </Sheet>

--- a/components/transactions/transaction-list-row.tsx
+++ b/components/transactions/transaction-list-row.tsx
@@ -10,6 +10,8 @@ import { formatDate } from "@/lib/utils/format"
 import { Input } from "@/components/ui/input"
 import { LoadingSpinner } from "@/components/ui/loading-spinner"
 import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { Pencil } from "lucide-react"
 import type { Movimiento, MovimientoConRelaciones, Cuenta, Categoria } from "@/lib/types/database"
 
 interface TransactionListRowProps {
@@ -131,13 +133,27 @@ export const TransactionListRow = memo(function TransactionListRow({
                 </div>
               </div>
 
-              <div className="flex-shrink-0 text-right min-w-0">
-                <div className="mb-0.5">
-                  <AmountDisplay amount={movement.importe} size="sm" />
+              <div className="flex-shrink-0 flex items-start gap-2 min-w-0">
+                <div className="text-right">
+                  <div className="mb-0.5">
+                    <AmountDisplay amount={movement.importe} size="sm" />
+                  </div>
+                  <div className="text-xs text-muted-foreground bg-muted/30 px-2 py-0.5 rounded-md whitespace-nowrap inline-block">
+                    {formatDate(movement.fecha)}
+                  </div>
                 </div>
-                <div className="text-xs text-muted-foreground bg-muted/30 px-2 py-0.5 rounded-md whitespace-nowrap inline-block">
-                  {formatDate(movement.fecha)}
-                </div>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    onClick(movement, e)
+                  }}
+                  aria-label="Editar transacción"
+                >
+                  <Pencil className="h-4 w-4" />
+                </Button>
               </div>
             </div>
           </div>

--- a/components/transactions/transaction-manager.tsx
+++ b/components/transactions/transaction-manager.tsx
@@ -55,8 +55,9 @@ export function TransactionManager({ onTransactionCountChange }: TransactionMana
   } = useDelegationContext()
 
   const [filters, setFilters] = useState<TransactionFilters>({})
-  const [selectedMovement, setSelectedMovement] = useState<MovimientoConRelaciones | null>(null)
-  const [detailOpen, setDetailOpen] = useState(false)
+  const [selectedMovementId, setSelectedMovementId] = useState<string | null>(null)
+  const [selectedMovementSnapshot, setSelectedMovementSnapshot] =
+    useState<MovimientoConRelaciones | null>(null)
   const [filtersOpen, setFiltersOpen] = useState(false)
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
   const [createFormOpen, setCreateFormOpen] = useState(false)
@@ -111,8 +112,8 @@ export function TransactionManager({ onTransactionCountChange }: TransactionMana
   }
 
   const handleMovementClick = (movement: MovimientoConRelaciones) => {
-    setSelectedMovement(movement)
-    setDetailOpen(true)
+    setSelectedMovementId(movement.id)
+    setSelectedMovementSnapshot(movement)
   }
 
   const handleMovementUpdate = async (
@@ -120,17 +121,29 @@ export function TransactionManager({ onTransactionCountChange }: TransactionMana
     patch: Partial<MovimientoConRelaciones>,
   ) => {
     try {
-      if (patch.categoria_id !== undefined) {
-        await updateCategoria(movementId, patch.categoria_id)
-      }
-      const { categoria_id, ...rest } = patch
-      if (Object.keys(rest).length > 0) {
-        await updateMovimiento(movementId, rest)
+      const patchWithCategory = { ...patch }
+      const { categoria_id: categoriaIdForMovement, ...movementPatch } = patchWithCategory
+
+      if (categoriaIdForMovement !== undefined) {
+        await updateCategoria(movementId, categoriaIdForMovement)
       }
 
-      // Update selected movement if it's the one being edited
-      if (selectedMovement?.id === movementId) {
-        setSelectedMovement((prev) => (prev ? { ...prev, ...patch } : null))
+      if (Object.keys(movementPatch).length > 0) {
+        await updateMovimiento(movementId, movementPatch)
+      }
+
+      if (selectedMovementId === movementId) {
+        setSelectedMovementSnapshot((prev) =>
+          prev
+            ? {
+                ...prev,
+                ...movementPatch,
+                ...(categoriaIdForMovement !== undefined
+                  ? { categoria_id: categoriaIdForMovement }
+                  : {}),
+              }
+            : prev,
+        )
       }
     } catch (error) {
       console.error("Error updating movement:", error)
@@ -181,6 +194,23 @@ export function TransactionManager({ onTransactionCountChange }: TransactionMana
       onTransactionCountChange(movements.length)
     }
   }, [movements.length, onTransactionCountChange])
+
+  useEffect(() => {
+    if (!selectedMovementId) {
+      return
+    }
+
+    const updatedMovement = movements.find((movement) => movement.id === selectedMovementId) || null
+
+    if (updatedMovement) {
+      if (updatedMovement !== selectedMovementSnapshot) {
+        setSelectedMovementSnapshot(updatedMovement)
+      }
+    } else if (!loading) {
+      setSelectedMovementId(null)
+      setSelectedMovementSnapshot(null)
+    }
+  }, [selectedMovementId, movements, loading, selectedMovementSnapshot])
 
   useEffect(() => {
     const panel = searchParams.get("panel")
@@ -406,11 +436,16 @@ export function TransactionManager({ onTransactionCountChange }: TransactionMana
       </div>
 
       <TransactionDetail
-        movement={selectedMovement}
+        movement={selectedMovementSnapshot}
         accounts={accounts as unknown as Cuenta[]}
         categories={categories as unknown as Categoria[]}
-        open={detailOpen}
-        onOpenChange={setDetailOpen}
+        open={selectedMovementId !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setSelectedMovementId(null)
+            setSelectedMovementSnapshot(null)
+          }
+        }}
         onUpdate={async (movementId, patch) => {
           const fullPatch: Partial<MovimientoConRelaciones> = patch
           await handleMovementUpdate(movementId, fullPatch)


### PR DESCRIPTION
## Summary
- ensure transaction sidebar only opens with selected movement and stays synced after reloads
- add explicit edit button to transaction rows
- improve auto-save indicator and timing in transaction detail
- prevent blank editor states by syncing the selected movement and showing a loading fallback in the detail sheet

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68c6bbb0c470832691f0f024f0803094