### PR TITLE
fix: stabilize transaction detail sheet

### DIFF
--- a/components/transactions/transaction-detail.tsx
+++ b/components/transactions/transaction-detail.tsx
@@ -2,7 +2,7 @@
 
 import type React from "react"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useRef } from "react"
 import { format } from "date-fns"
 import { CalendarIcon, AlertTriangle, Check, Loader2, ArrowLeft } from "lucide-react"
 import { cn } from "@/lib/utils"
@@ -21,6 +21,7 @@ import { TabWithCounter } from "./tab-with-counter"
 import { formatCurrency } from "@/lib/utils/format"
 import { TransactionFiles } from "./transaction-files"
 import type { Movimiento, Cuenta, Categoria } from "@/lib/types/database"
+import { LoadingSpinner } from "@/components/ui/loading-spinner"
 
 interface TransactionDetailProps {
   movement: Movimiento | null
@@ -46,11 +47,25 @@ export function TransactionDetail({
   const [showAmountConfirm, setShowAmountConfirm] = useState(false)
   const [pendingAmount, setPendingAmount] = useState<string>("")
   const [isAmountEditing, setIsAmountEditing] = useState(false)
-  const [isSaving, setIsSaving] = useState(false)
-  const [lastSaved, setLastSaved] = useState<Date | null>(null)
+  const [saveStatus, setSaveStatus] = useState<"idle" | "saving" | "saved">("idle")
   const [activeTab, setActiveTab] = useState<"datos" | "archivos">("datos")
   const [fileCount, setFileCount] = useState(0)
-  const [showSaved, setShowSaved] = useState(false)
+  const autoSaveTimerRef = useRef<NodeJS.Timeout | null>(null)
+  const savedResetTimerRef = useRef<NodeJS.Timeout | null>(null)
+
+  const clearAutoSaveTimer = () => {
+    if (autoSaveTimerRef.current) {
+      clearTimeout(autoSaveTimerRef.current)
+      autoSaveTimerRef.current = null
+    }
+  }
+
+  const clearSavedResetTimer = () => {
+    if (savedResetTimerRef.current) {
+      clearTimeout(savedResetTimerRef.current)
+      savedResetTimerRef.current = null
+    }
+  }
 
   const account = accounts.find((acc) => acc.id === movement?.cuenta_id)
   const selectedCategory = categories.find((cat) => cat.id === formData.categoria_id)
@@ -76,34 +91,62 @@ export function TransactionDetail({
         categoria_id: movement.categoria_id,
         contraparte: movement.contraparte || "",
       })
+      setActiveTab("datos")
+      setFileCount(0)
+      setIsAmountEditing(false)
+      setShowAmountConfirm(false)
+      setPendingAmount("")
+      clearAutoSaveTimer()
+      clearSavedResetTimer()
+      setSaveStatus("idle")
+    } else {
+      setFormData({})
+      clearAutoSaveTimer()
+      clearSavedResetTimer()
+      setSaveStatus("idle")
     }
   }, [movement])
 
   useEffect(() => {
-    if (movement && hasChanges) {
-      setIsSaving(true)
-      const timeoutId = setTimeout(async () => {
-        try {
-          await onUpdate(movement.id, formData)
-          setLastSaved(new Date())
-        } catch (error) {
-          console.error("Error auto-saving:", error)
-        } finally {
-          setIsSaving(false)
-        }
-      }, 1000)
+    if (!movement) {
+      return
+    }
 
-      return () => clearTimeout(timeoutId)
+    if (!hasChanges) {
+      clearAutoSaveTimer()
+      setSaveStatus((status) => (status === "saving" ? "idle" : status))
+      return
+    }
+
+    clearAutoSaveTimer()
+    clearSavedResetTimer()
+    setSaveStatus("saving")
+
+    autoSaveTimerRef.current = setTimeout(async () => {
+      try {
+        await onUpdate(movement.id, formData)
+        setSaveStatus("saved")
+        clearSavedResetTimer()
+        savedResetTimerRef.current = setTimeout(() => {
+          setSaveStatus("idle")
+        }, 2000)
+      } catch (error) {
+        console.error("Error auto-saving:", error)
+        setSaveStatus("idle")
+      }
+    }, 2000)
+
+    return () => {
+      clearAutoSaveTimer()
     }
   }, [formData, movement, hasChanges, onUpdate])
 
   useEffect(() => {
-    if (!isSaving && lastSaved) {
-      setShowSaved(true)
-      const timer = setTimeout(() => setShowSaved(false), 2000)
-      return () => clearTimeout(timer)
+    return () => {
+      clearAutoSaveTimer()
+      clearSavedResetTimer()
     }
-  }, [isSaving, lastSaved])
+  }, [])
 
   const handleAmountClick = () => {
     setIsAmountEditing(true)
@@ -119,8 +162,73 @@ export function TransactionDetail({
     }
   }
 
+  const parseAmountInput = (value: string) => {
+    const trimmed = value.replace(/\s/g, "")
+
+    if (!trimmed) {
+      return null
+    }
+
+    const usesCommaAsDecimal =
+      trimmed.includes(",") && (!trimmed.includes(".") || trimmed.lastIndexOf(",") > trimmed.lastIndexOf("."))
+
+    const normalized = usesCommaAsDecimal
+      ? trimmed.replace(/\./g, "").replace(/,/g, ".")
+      : trimmed.replace(/,/g, "")
+
+    const parsed = Number.parseFloat(normalized)
+    return Number.isNaN(parsed) ? null : parsed
+  }
+
+  const formatPreviousDate = (dateValue?: string | null) => {
+    if (!dateValue) {
+      return "Sin fecha registrada"
+    }
+
+    try {
+      return format(new Date(dateValue), "dd/MM/yyyy")
+    } catch (error) {
+      console.error("Error formatting previous date:", error)
+      return dateValue
+    }
+  }
+
+  const formatPreviousAmount = (amountValue?: number | null) => {
+    if (typeof amountValue !== "number") {
+      return "Sin cantidad registrada"
+    }
+
+    return formatCurrency(amountValue)
+  }
+
+  const appendChangeDetails = (prev: Partial<Movimiento>) => {
+    const descriptionSource = prev.descripcion ?? ""
+    const previousDateLabel = formatPreviousDate(prev.fecha)
+    const previousAmountLabel = formatPreviousAmount(prev.importe)
+    const details = `Fecha anterior a la modificación: ${previousDateLabel}\nCantidad anterior a la modificación: ${previousAmountLabel}`
+    const trimmedDescription = descriptionSource.trimEnd()
+    return trimmedDescription ? `${trimmedDescription}\n${details}` : details
+  }
+
   const confirmAmountChange = () => {
-    setFormData((prev) => ({ ...prev, importe: Number.parseFloat(pendingAmount) || 0 }))
+    const parsedAmount = parseAmountInput(pendingAmount)
+
+    if (parsedAmount === null) {
+      return
+    }
+
+    setFormData((prev) => {
+      if (parsedAmount === prev.importe) {
+        return prev
+      }
+
+      return {
+        ...prev,
+        importe: parsedAmount,
+        descripcion: appendChangeDetails(prev),
+      }
+    })
+
     setShowAmountConfirm(false)
     setPendingAmount("")
     setIsAmountEditing(false)
@@ -132,230 +240,274 @@ export function TransactionDetail({
     setIsAmountEditing(false)
   }
 
+  const statusLabel =
+    saveStatus === "saving" ? "Guardando..." : saveStatus === "saved" ? "Guardado" : "Sin cambios"
+
+  const statusIcon =
+    saveStatus === "saving" ? (
+      <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+    ) : (
+      <Check
+        className={cn(
+          "h-4 w-4",
+          saveStatus === "saved" ? "text-emerald-600 dark:text-emerald-300" : "text-muted-foreground",
+        )}
+      />
+    )
+
+  const statusContainerClass = cn(
+    "flex items-center gap-2 px-3 py-2 rounded-md border shadow-sm",
+    saveStatus === "saved"
+      ? "bg-emerald-100 dark:bg-emerald-950/40 border-emerald-200 dark:border-emerald-700"
+      : "bg-muted dark:bg-muted border-border dark:border-border",
+  )
+
+  const statusTextClass = cn(
+    "text-sm",
+    saveStatus === "saved" ? "text-emerald-700 dark:text-emerald-200" : "text-muted-foreground",
+  )
+
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent className="w-full sm:w-[560px] sm:max-w-[640px] overflow-y-auto p-0 relative z-[60]">
-        <div className="p-4 sm:p-6">
-          <SheetHeader className="pb-4">
-            <div className="flex items-center gap-2">
-              {onBack && (
-                <Button variant="ghost" size="icon" className="-ml-2" onClick={onBack}>
-                  <ArrowLeft className="h-4 w-4" />
-                </Button>
-              )}
-              <SheetTitle className="text-xl font-semibold text-left">Transacción</SheetTitle>
-            </div>
-
-            <div className="bg-muted/30 rounded-lg p-3 sm:p-4 space-y-3 sm:space-y-4 mt-4">
-              {account && (
-                <div className="flex items-center gap-3">
-                  <div
-                    className="rounded-full p-0.5"
-                    style={{ backgroundColor: account.color || "#4ECDC4" }}
-                  >
-                    <BankAvatar account={account} size="sm" />
-                  </div>
-                  <div>
-                    <p className="font-medium text-sm">{account.nombre}</p>
-                    <p className="text-xs text-muted-foreground">{account.banco_nombre}</p>
-                  </div>
+      <SheetContent side="right" className="w-full sm:w-[560px] sm:max-w-[640px] overflow-y-auto p-0 z-[60]">
+        {!movement ? (
+          <div className="flex h-full min-h-[320px] flex-col items-center justify-center gap-3 p-6 text-sm text-muted-foreground">
+            <LoadingSpinner size="md" />
+            <span>Cargando transacción...</span>
+          </div>
+        ) : (
+          <>
+            <div className="p-4 sm:p-6">
+              <SheetHeader className="pb-4">
+                <div className="flex items-center gap-2">
+                  {onBack && (
+                    <Button variant="ghost" size="icon" className="-ml-2" onClick={onBack}>
+                      <ArrowLeft className="h-4 w-4" />
+                    </Button>
+                  )}
+                  <SheetTitle className="text-xl font-semibold text-left">Transacción</SheetTitle>
                 </div>
-              )}
 
-              <div className="text-center space-y-1">
-                {isAmountEditing ? (
-                  <Input
-                    type="number"
-                    step="0.01"
-                    value={pendingAmount}
-                    onChange={(e) => setPendingAmount(e.target.value)}
-                    onKeyDown={handleAmountChange}
-                    onBlur={cancelAmountChange}
-                    className="w-40 h-10 text-center font-bold text-xl mx-auto"
-                    autoFocus
-                  />
-                ) : (
-                  <button
-                    onClick={handleAmountClick}
-                    className={cn(
-                      "text-center font-bold text-xl sm:text-2xl hover:bg-muted/50 px-3 py-2 rounded transition-colors",
-                      (formData.importe || 0) >= 0 ? "text-green-600" : "text-red-600",
-                    )}
-                  >
-                    {formatCurrency(formData.importe || 0)}
-                  </button>
-                )}
-                <p className="text-sm text-muted-foreground">
-                  {formData.fecha ? format(new Date(formData.fecha), "dd/MM/yyyy") : "Sin fecha"}
-                </p>
-              </div>
-
-              {selectedCategory && (
-                <div className="flex justify-center">
-                  <div
-                    className="px-3 py-1 rounded-full text-sm font-medium flex items-center gap-2"
-                    style={{
-                      backgroundColor: selectedCategory.color + "20",
-                      color: selectedCategory.color,
-                      border: `1px solid ${selectedCategory.color}40`,
-                    }}
-                  >
-                    <span>{selectedCategory.emoji}</span>
-                    <span>{selectedCategory.nombre}</span>
-                  </div>
-                </div>
-              )}
-            </div>
-          </SheetHeader>
-
-          <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as "datos" | "archivos")} className="w-full">
-            <div className="flex w-full rounded-md bg-muted p-1">
-              <TabWithCounter
-                label="Datos"
-                isActive={activeTab === "datos"}
-                onClick={() => setActiveTab("datos")}
-                className="flex-1"
-              />
-              <TabWithCounter
-                label="Archivos"
-                count={fileCount}
-                isActive={activeTab === "archivos"}
-                onClick={() => setActiveTab("archivos")}
-                className="flex-1"
-              />
-            </div>
-
-            <TabsContent value="datos" className="space-y-4 mt-4">
-              {showAmountConfirm && (
-                <Alert className="border-amber-200 bg-amber-50">
-                  <AlertTriangle className="h-4 w-4 text-amber-600" />
-                  <AlertDescription className="flex items-center justify-between">
-                    <span className="text-amber-800">¿Seguro que quieres editar el importe?</span>
-                    <div className="flex gap-2">
-                      <Button size="sm" onClick={confirmAmountChange} className="h-7">
-                        Sí
-                      </Button>
-                      <Button size="sm" variant="outline" onClick={cancelAmountChange} className="h-7 bg-transparent">
-                        No
-                      </Button>
+                <div className="bg-muted/30 rounded-lg p-3 sm:p-4 space-y-3 sm:space-y-4 mt-4">
+                  {account && (
+                    <div className="flex items-center gap-3">
+                      <div
+                        className="rounded-full p-0.5"
+                        style={{ backgroundColor: account.color || "#4ECDC4" }}
+                      >
+                        <BankAvatar account={account} size="sm" />
+                      </div>
+                      <div>
+                        <p className="font-medium text-sm">{account.nombre}</p>
+                        <p className="text-xs text-muted-foreground">{account.banco_nombre}</p>
+                      </div>
                     </div>
-                  </AlertDescription>
-                </Alert>
-              )}
+                  )}
 
-              <div className="space-y-4">
-                <div className="space-y-2">
-                  <Label htmlFor="concepto" className="text-sm font-medium">
-                    Concepto
-                  </Label>
-                  <Input
-                    id="concepto"
-                    value={formData.concepto || ""}
-                    onChange={(e) => setFormData((prev) => ({ ...prev, concepto: e.target.value }))}
-                    placeholder="Concepto de la transacción"
-                  />
-                </div>
-
-                <div className="space-y-2">
-                  <Label htmlFor="fecha" className="text-sm font-medium">
-                    Fecha
-                  </Label>
-                  <Popover open={dateOpen} onOpenChange={setDateOpen}>
-                    <PopoverTrigger asChild>
-                      <Button
-                        variant="outline"
+                  <div className="text-center space-y-1">
+                    {isAmountEditing ? (
+                      <Input
+                        type="number"
+                        step="0.01"
+                        value={pendingAmount}
+                        onChange={(e) => setPendingAmount(e.target.value)}
+                        onKeyDown={handleAmountChange}
+                        onBlur={cancelAmountChange}
+                        className="w-40 h-10 text-center font-bold text-xl mx-auto"
+                        autoFocus
+                      />
+                    ) : (
+                      <button
+                        onClick={handleAmountClick}
                         className={cn(
-                          "w-full justify-start text-left font-normal h-9",
-                          !formData.fecha && "text-muted-foreground",
+                          "text-center font-bold text-xl sm:text-2xl hover:bg-muted/50 px-3 py-2 rounded transition-colors",
+                          (formData.importe || 0) >= 0 ? "text-green-600" : "text-red-600",
                         )}
                       >
-                        <CalendarIcon className="mr-2 h-4 w-4" />
-                        {formData.fecha ? format(new Date(formData.fecha), "dd/MM/yyyy") : "Fecha"}
-                      </Button>
-                    </PopoverTrigger>
-                    <PopoverContent className="w-auto p-0" align="start">
-                      <Calendar
-                        mode="single"
-                        selected={formData.fecha ? new Date(formData.fecha) : undefined}
-                        onSelect={(date) => {
-                          setFormData((prev) => ({ ...prev, fecha: date ? format(date, "yyyy-MM-dd") : undefined }))
-                          setDateOpen(false)
+                        {formatCurrency(formData.importe || 0)}
+                      </button>
+                    )}
+                    <p className="text-sm text-muted-foreground">
+                      {formData.fecha ? format(new Date(formData.fecha), "dd/MM/yyyy") : "Sin fecha"}
+                    </p>
+                  </div>
+
+                  {selectedCategory && (
+                    <div className="flex justify-center">
+                      <div
+                        className="px-3 py-1 rounded-full text-sm font-medium flex items-center gap-2"
+                        style={{
+                          backgroundColor: selectedCategory.color + "20",
+                          color: selectedCategory.color,
+                          border: `1px solid ${selectedCategory.color}40`,
                         }}
-                        initialFocus
+                      >
+                        <span>{selectedCategory.emoji}</span>
+                        <span>{selectedCategory.nombre}</span>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </SheetHeader>
+
+              <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as "datos" | "archivos")} className="w-full">
+                <div className="flex w-full rounded-md bg-muted p-1">
+                  <TabWithCounter
+                    label="Datos"
+                    isActive={activeTab === "datos"}
+                    onClick={() => setActiveTab("datos")}
+                    className="flex-1"
+                  />
+                  <TabWithCounter
+                    label="Archivos"
+                    count={fileCount}
+                    isActive={activeTab === "archivos"}
+                    onClick={() => setActiveTab("archivos")}
+                    className="flex-1"
+                  />
+                </div>
+
+                <TabsContent value="datos" className="space-y-4 mt-4">
+                  {showAmountConfirm && (
+                    <Alert className="border-amber-200 bg-amber-50 dark:border-amber-700 dark:bg-amber-950/40">
+                      <AlertTriangle className="h-4 w-4 text-amber-600 dark:text-amber-400" />
+                      <AlertDescription className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between text-amber-800 dark:text-amber-100">
+                        <span>¿Seguro que quieres editar el importe?</span>
+                        <div className="flex gap-2">
+                          <Button size="sm" variant="outline" onClick={cancelAmountChange} className="h-7 bg-transparent dark:text-amber-100 dark:hover:bg-amber-900/60">
+                            No
+                          </Button>
+                          <Button size="sm" onClick={confirmAmountChange} autoFocus className="h-7">
+                            Sí
+                          </Button>
+                        </div>
+                      </AlertDescription>
+                    </Alert>
+                  )}
+
+                  <div className="space-y-4">
+                    <div className="space-y-2">
+                      <Label htmlFor="concepto" className="text-sm font-medium">
+                        Concepto
+                      </Label>
+                      <Input
+                        id="concepto"
+                        value={formData.concepto || ""}
+                        onChange={(e) => setFormData((prev) => ({ ...prev, concepto: e.target.value }))}
+                        placeholder="Concepto de la transacción"
                       />
-                    </PopoverContent>
-                  </Popover>
+                    </div>
+
+                    <div className="space-y-2">
+                      <Label htmlFor="fecha" className="text-sm font-medium">
+                        Fecha
+                      </Label>
+                      <Popover open={dateOpen} onOpenChange={setDateOpen}>
+                        <PopoverTrigger asChild>
+                          <Button
+                            variant="outline"
+                            className={cn(
+                              "w-full justify-start text-left font-normal h-9",
+                              !formData.fecha && "text-muted-foreground",
+                            )}
+                          >
+                            <CalendarIcon className="mr-2 h-4 w-4" />
+                            {formData.fecha ? format(new Date(formData.fecha), "dd/MM/yyyy") : "Fecha"}
+                          </Button>
+                        </PopoverTrigger>
+                        <PopoverContent className="w-auto p-0" align="start">
+                          <Calendar
+                            mode="single"
+                            selected={formData.fecha ? new Date(formData.fecha) : undefined}
+                            onSelect={(date) => {
+                              if (!date) {
+                                return
+                              }
+
+                              const nextDate = format(date, "yyyy-MM-dd")
+
+                              setFormData((prev) => {
+                                if (prev.fecha === nextDate) {
+                                  return prev
+                                }
+
+                                return {
+                                  ...prev,
+                                  fecha: nextDate,
+                                  descripcion: appendChangeDetails(prev),
+                                }
+                              })
+
+                              setDateOpen(false)
+                            }}
+                            initialFocus
+                          />
+                        </PopoverContent>
+                      </Popover>
+                    </div>
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="categoria" className="text-sm font-medium">
+                      Categoría
+                    </Label>
+                    <CategorySelector
+                      categories={categories}
+                      selectedCategories={formData.categoria_id ? [formData.categoria_id] : []}
+                      onSelectionChange={(categoryIds) =>
+                        setFormData((prev) => ({ ...prev, categoria_id: categoryIds.length > 0 ? categoryIds[0] : null }))
+                      }
+                      allowMultiple={false}
+                      placeholder="Sin categoría"
+                    />
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="contacto" className="text-sm font-medium">
+                      Contacto
+                    </Label>
+                    <Input
+                      id="contacto"
+                      value={formData.contraparte || ""}
+                      onChange={(e) => setFormData((prev) => ({ ...prev, contraparte: e.target.value }))}
+                      placeholder="Nombre del contacto"
+                      className="h-9"
+                    />
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="descripcion" className="text-sm font-medium">
+                      Descripción
+                    </Label>
+                    <Textarea
+                      id="descripcion"
+                      value={formData.descripcion || ""}
+                      onChange={(e) => setFormData((prev) => ({ ...prev, descripcion: e.target.value }))}
+                      placeholder="Descripción adicional (opcional)"
+                      rows={3}
+                      className="resize-none"
+                    />
+                  </div>
+                </TabsContent>
+
+                <TabsContent value="archivos" className="space-y-6 mt-6">
+                  <TransactionFiles
+                    movementId={movement?.id || null}
+                    delegacionId={account?.delegacion_id}
+                    onCountChange={setFileCount}
+                  />
+                </TabsContent>
+              </Tabs>
+            </div>
+            {movement && (
+              <div className="absolute bottom-4 left-1/2 -translate-x-1/2">
+                <div className={statusContainerClass}>
+                  {statusIcon}
+                  <span className={statusTextClass}>{statusLabel}</span>
                 </div>
               </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="categoria" className="text-sm font-medium">
-                  Categoría
-                </Label>
-                <CategorySelector
-                  categories={categories}
-                  selectedCategories={formData.categoria_id ? [formData.categoria_id] : []}
-                  onSelectionChange={(categoryIds) =>
-                    setFormData((prev) => ({ ...prev, categoria_id: categoryIds.length > 0 ? categoryIds[0] : null }))
-                  }
-                  allowMultiple={false}
-                  placeholder="Sin categoría"
-                />
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="contacto" className="text-sm font-medium">
-                  Contacto
-                </Label>
-                <Input
-                  id="contacto"
-                  value={formData.contraparte || ""}
-                  onChange={(e) => setFormData((prev) => ({ ...prev, contraparte: e.target.value }))}
-                  placeholder="Nombre del contacto"
-                  className="h-9"
-                />
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="descripcion" className="text-sm font-medium">
-                  Descripción
-                </Label>
-                <Textarea
-                  id="descripcion"
-                  value={formData.descripcion || ""}
-                  onChange={(e) => setFormData((prev) => ({ ...prev, descripcion: e.target.value }))}
-                  placeholder="Descripción adicional (opcional)"
-                  rows={3}
-                  className="resize-none"
-                />
-              </div>
-            </TabsContent>
-
-            <TabsContent value="archivos" className="space-y-6 mt-6">
-              <TransactionFiles
-                movementId={movement?.id || null}
-                delegacionId={account?.delegacion_id}
-                onCountChange={setFileCount}
-              />
-            </TabsContent>
-          </Tabs>
-        </div>
-        {(isSaving || showSaved) && (
-          <div className="absolute bottom-4 left-1/2 -translate-x-1/2">
-            <div className="flex items-center gap-2 px-3 py-2 bg-muted rounded-md shadow">
-              {isSaving ? (
-                <>
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                  <span className="text-sm">Guardando...</span>
-                </>
-              ) : (
-                <>
-                  <Check className="h-4 w-4 text-green-600" />
-                  <span className="text-sm text-green-600">Guardado</span>
-                </>
-              )}
-            </div>
-          </div>
+            )}
+          </>
         )}
       </SheetContent>
     </Sheet>

--- a/components/transactions/transaction-list-row.tsx
+++ b/components/transactions/transaction-list-row.tsx
@@ -10,6 +10,8 @@ import { formatDate } from "@/lib/utils/format"
 import { Input } from "@/components/ui/input"
 import { LoadingSpinner } from "@/components/ui/loading-spinner"
 import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { Pencil } from "lucide-react"
 import type { Movimiento, MovimientoConRelaciones, Cuenta, Categoria } from "@/lib/types/database"
 
 interface TransactionListRowProps {
@@ -131,13 +133,27 @@ export const TransactionListRow = memo(function TransactionListRow({
                 </div>
               </div>
 
-              <div className="flex-shrink-0 text-right min-w-0">
-                <div className="mb-0.5">
-                  <AmountDisplay amount={movement.importe} size="sm" />
+              <div className="flex-shrink-0 flex items-start gap-2 min-w-0">
+                <div className="text-right">
+                  <div className="mb-0.5">
+                    <AmountDisplay amount={movement.importe} size="sm" />
+                  </div>
+                  <div className="text-xs text-muted-foreground bg-muted/30 px-2 py-0.5 rounded-md whitespace-nowrap inline-block">
+                    {formatDate(movement.fecha)}
+                  </div>
                 </div>
-                <div className="text-xs text-muted-foreground bg-muted/30 px-2 py-0.5 rounded-md whitespace-nowrap inline-block">
-                  {formatDate(movement.fecha)}
-                </div>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    onClick(movement, e)
+                  }}
+                  aria-label="Editar transacción"
+                >
+                  <Pencil className="h-4 w-4" />
+                </Button>
               </div>
             </div>
           </div>

--- a/components/transactions/transaction-manager.tsx
+++ b/components/transactions/transaction-manager.tsx
@@ -55,8 +55,9 @@ export function TransactionManager({ onTransactionCountChange }: TransactionMana
   } = useDelegationContext()
 
   const [filters, setFilters] = useState<TransactionFilters>({})
-  const [selectedMovement, setSelectedMovement] = useState<MovimientoConRelaciones | null>(null)
-  const [detailOpen, setDetailOpen] = useState(false)
+  const [selectedMovementId, setSelectedMovementId] = useState<string | null>(null)
+  const [selectedMovementSnapshot, setSelectedMovementSnapshot] =
+    useState<MovimientoConRelaciones | null>(null)
   const [filtersOpen, setFiltersOpen] = useState(false)
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
   const [createFormOpen, setCreateFormOpen] = useState(false)
@@ -111,8 +112,8 @@ export function TransactionManager({ onTransactionCountChange }: TransactionMana
   }
 
   const handleMovementClick = (movement: MovimientoConRelaciones) => {
-    setSelectedMovement(movement)
-    setDetailOpen(true)
+    setSelectedMovementId(movement.id)
+    setSelectedMovementSnapshot(movement)
   }
 
   const handleMovementUpdate = async (
@@ -120,17 +121,29 @@ export function TransactionManager({ onTransactionCountChange }: TransactionMana
     patch: Partial<MovimientoConRelaciones>,
   ) => {
     try {
-      if (patch.categoria_id !== undefined) {
-        await updateCategoria(movementId, patch.categoria_id)
-      }
-      const { categoria_id, ...rest } = patch
-      if (Object.keys(rest).length > 0) {
-        await updateMovimiento(movementId, rest)
+      const patchWithCategory = { ...patch }
+      const { categoria_id: categoriaIdForMovement, ...movementPatch } = patchWithCategory
+
+      if (categoriaIdForMovement !== undefined) {
+        await updateCategoria(movementId, categoriaIdForMovement)
       }
 
-      // Update selected movement if it's the one being edited
-      if (selectedMovement?.id === movementId) {
-        setSelectedMovement((prev) => (prev ? { ...prev, ...patch } : null))
+      if (Object.keys(movementPatch).length > 0) {
+        await updateMovimiento(movementId, movementPatch)
+      }
+
+      if (selectedMovementId === movementId) {
+        setSelectedMovementSnapshot((prev) =>
+          prev
+            ? {
+                ...prev,
+                ...movementPatch,
+                ...(categoriaIdForMovement !== undefined
+                  ? { categoria_id: categoriaIdForMovement }
+                  : {}),
+              }
+            : prev,
+        )
       }
     } catch (error) {
       console.error("Error updating movement:", error)
@@ -181,6 +194,23 @@ export function TransactionManager({ onTransactionCountChange }: TransactionMana
       onTransactionCountChange(movements.length)
     }
   }, [movements.length, onTransactionCountChange])
+
+  useEffect(() => {
+    if (!selectedMovementId) {
+      return
+    }
+
+    const updatedMovement = movements.find((movement) => movement.id === selectedMovementId) || null
+
+    if (updatedMovement) {
+      if (updatedMovement !== selectedMovementSnapshot) {
+        setSelectedMovementSnapshot(updatedMovement)
+      }
+    } else if (!loading) {
+      setSelectedMovementId(null)
+      setSelectedMovementSnapshot(null)
+    }
+  }, [selectedMovementId, movements, loading, selectedMovementSnapshot])
 
   useEffect(() => {
     const panel = searchParams.get("panel")
@@ -406,11 +436,16 @@ export function TransactionManager({ onTransactionCountChange }: TransactionMana
       </div>
 
       <TransactionDetail
-        movement={selectedMovement}
+        movement={selectedMovementSnapshot}
         accounts={accounts as unknown as Cuenta[]}
         categories={categories as unknown as Categoria[]}
-        open={detailOpen}
-        onOpenChange={setDetailOpen}
+        open={selectedMovementId !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setSelectedMovementId(null)
+            setSelectedMovementSnapshot(null)
+          }
+        }}
         onUpdate={async (movementId, patch) => {
           const fullPatch: Partial<MovimientoConRelaciones> = patch
           await handleMovementUpdate(movementId, fullPatch)


### PR DESCRIPTION
## Summary
- ensure transaction sidebar only opens with selected movement and stays synced after reloads
- add explicit edit button to transaction rows
- refine auto-save status messaging and amount editing confirmations so users see “Sin cambios”, “Guardando…”, or “Guardado” even in dark mode
- append previous date and amount details to the description whenever either field is edited while keeping the calendar-based date selector

## Testing
- `pnpm lint` *(fails: prompts for “How would you like to configure ESLint?”)*

------
https://chatgpt.com/codex/tasks/task_e_68c6bbb0c470832691f0f024f0803094