### PR TITLE
feat: categorías globales y delegacionales

### DIFF
--- a/components/categories/category-edit-form.tsx
+++ b/components/categories/category-edit-form.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import type React from "react"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -16,23 +16,43 @@ interface CategoryEditFormProps {
   parentCategory?: Categoria
   onSave: (patch: Partial<Categoria>) => Promise<void>
   onCancel: () => void
+  canEditGlobal: boolean
 }
 
 
-export function CategoryEditForm({ category, parentCategory, onSave, onCancel }: CategoryEditFormProps) {
+export function CategoryEditForm({ category, parentCategory, onSave, onCancel, canEditGlobal }: CategoryEditFormProps) {
   const [formData, setFormData] = useState({
     nombre: category.nombre,
     emoji: category.emoji || "📁",
     tipo: category.tipo,
     color: parentCategory?.color || category.color || "#4ECDC4",
+    es_global: parentCategory && !parentCategory.es_global ? false : category.es_global || false,
   })
   const [loading, setLoading] = useState(false)
+
+  const canToggleGlobal = canEditGlobal && (!parentCategory || parentCategory.es_global)
+
+  // Reset form when editing a different category
+  useEffect(() => {
+    setFormData({
+      nombre: category.nombre,
+      emoji: category.emoji || "📁",
+      tipo: category.tipo,
+      color: parentCategory?.color || category.color || "#4ECDC4",
+      es_global: parentCategory && !parentCategory.es_global ? false : category.es_global || false,
+    })
+  }, [category, parentCategory])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
 
     if (!formData.nombre.trim()) {
       alert("El nombre de la categoría es obligatorio")
+      return
+    }
+
+    if (formData.es_global && parentCategory && !parentCategory.es_global) {
+      alert("Solo puedes marcar como global una subcategoría si su categoría padre también es global")
       return
     }
 
@@ -43,6 +63,7 @@ export function CategoryEditForm({ category, parentCategory, onSave, onCancel }:
         nombre: formData.nombre.trim(),
         emoji: formData.emoji,
         tipo: formData.tipo,
+        es_global: formData.es_global,
         ...(parentCategory ? {} : { color: formData.color }),
       })
     } catch (error) {
@@ -99,6 +120,39 @@ export function CategoryEditForm({ category, parentCategory, onSave, onCancel }:
           </div>
         )}
       </div>
+
+      {canEditGlobal ? (
+        <div className="space-y-2">
+          <Label>Ámbito</Label>
+          <Select
+            value={formData.es_global ? "global" : "local"}
+            onValueChange={(value) =>
+              setFormData({ ...formData, es_global: value === "global" })
+            }
+            disabled={!canToggleGlobal}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="local">Categoría de delegación</SelectItem>
+              <SelectItem value="global">Categoría global</SelectItem>
+            </SelectContent>
+          </Select>
+          {!canToggleGlobal && parentCategory && !parentCategory.es_global && (
+            <p className="text-xs text-muted-foreground">
+              Marca primero la categoría padre como global para poder globalizar esta subcategoría.
+            </p>
+          )}
+        </div>
+      ) : (
+        formData.es_global && (
+          <div className="space-y-2">
+            <Label>Ámbito</Label>
+            <Input value="Categoría global" disabled readOnly />
+          </div>
+        )
+      )}
 
       {parentCategory && (
         <div className="space-y-2">

--- a/components/categories/category-list.tsx
+++ b/components/categories/category-list.tsx
@@ -3,18 +3,20 @@
 import { cn } from "@/lib/utils"
 import { useState, useEffect } from "react"
 import { useSearchParams } from "next/navigation"
-import { DragDropContext, Droppable, Draggable } from "@hello-pangea/dnd"
+import { DragDropContext, Droppable, Draggable, type DropResult } from "@hello-pangea/dnd"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Card, CardContent } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet"
 import { CategoryEditForm } from "./category-edit-form"
 import { DateRangeFilter } from "@/components/transactions/date-range-filter"
 import { useCategorias } from "@/hooks/use-categorias"
 import { useMovimientos } from "@/hooks/use-movimientos"
 import { useDelegationContext } from "@/contexts/delegation-context"
+import useIsAdmin from "@/hooks/use-is-admin"
 import { DatabaseService } from "@/lib/services/database"
-import { GripVertical, Search, Edit, Trash2, Plus, Building2, Wallet, X } from "lucide-react"
+import { GripVertical, Search, Edit, Trash2, Plus, X } from "lucide-react"
 import { AmountDisplay } from "@/components/amount-display"
 import { DeleteCategoryDialog } from "./delete-category-dialog"
 import { RelatedMovementsSheet } from "@/components/transactions/related-movements-sheet"
@@ -28,12 +30,15 @@ interface CategoryCardProps {
   onEdit: (category: Categoria) => void
   onSearch: (category: Categoria) => void
   onDelete: (category: Categoria) => void
+  canManageGlobal: boolean
 }
 
-function CategoryCard({ category, index, balance, onEdit, onSearch, onDelete }: CategoryCardProps) {
+function CategoryCard({ category, index, balance, onEdit, onSearch, onDelete, canManageGlobal }: CategoryCardProps) {
   const isSub = !!category.categoria_padre_id
+  const isGlobal = category.es_global
+  const dragDisabled = isGlobal && !canManageGlobal
   return (
-    <Draggable draggableId={category.id} index={index}>
+    <Draggable draggableId={category.id} index={index} isDragDisabled={dragDisabled}>
       {(provided, snapshot) => (
         <Card
           ref={provided.innerRef}
@@ -49,7 +54,12 @@ function CategoryCard({ category, index, balance, onEdit, onSearch, onDelete }: 
               {/* Drag Handle */}
               <div
                 {...provided.dragHandleProps}
-                className="flex h-8 w-8 items-center justify-center rounded text-muted-foreground hover:bg-muted cursor-grab active:cursor-grabbing flex-shrink-0"
+                className={cn(
+                  "flex h-8 w-8 items-center justify-center rounded text-muted-foreground flex-shrink-0",
+                  dragDisabled
+                    ? "cursor-not-allowed bg-muted"
+                    : "hover:bg-muted cursor-grab active:cursor-grabbing",
+                )}
               >
                 <GripVertical className="h-4 w-4" />
               </div>
@@ -70,17 +80,13 @@ function CategoryCard({ category, index, balance, onEdit, onSearch, onDelete }: 
                 <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
                   <div className="min-w-0">
                     <h3 className={cn("font-semibold text-base sm:text-lg truncate", isSub && "font-medium")}>{category.nombre}</h3>
-                    <div className="flex items-center gap-2 mt-1 sm:mt-0">
-                      
-                      
-                      
-                    <AmountDisplay amount={balance} size="sm" />
-
-
+                    <div className="flex flex-wrap items-center gap-2 mt-1 sm:mt-0 text-sm text-muted-foreground">
+                      <AmountDisplay amount={balance} size="sm" />
+                      {isGlobal && <Badge variant="outline">Global</Badge>}
                     </div>
                   </div>
-                  
-             
+
+
                 </div>
               </div>
 
@@ -100,6 +106,7 @@ function CategoryCard({ category, index, balance, onEdit, onSearch, onDelete }: 
                   size="icon"
                   className="h-8 w-8 sm:h-9 sm:w-9 text-gray-600 hover:bg-gray-50"
                   onClick={() => onEdit(category)}
+                  disabled={isGlobal && !canManageGlobal}
                   title="Editar categoría"
                 >
                   <Edit className="h-3 w-3 sm:h-4 sm:w-4" />
@@ -109,6 +116,7 @@ function CategoryCard({ category, index, balance, onEdit, onSearch, onDelete }: 
                   size="icon"
                   className="h-8 w-8 sm:h-9 sm:w-9 text-red-600 hover:bg-red-50"
                   onClick={() => onDelete(category)}
+                  disabled={isGlobal && !canManageGlobal}
                   title="Eliminar categoría"
                 >
                   <Trash2 className="h-3 w-3 sm:h-4 sm:w-4" />
@@ -134,11 +142,13 @@ export function CategoryList() {
   const [dateFrom, setDateFrom] = useState<string | undefined>()
   const [dateTo, setDateTo] = useState<string | undefined>()
 
+  const isGestorCentral = useIsAdmin()
   const currentDelegation = getCurrentDelegation()
   const organizacionId = currentDelegation?.organizacion_id
+  const delegacionId = selectedDelegation || null
 
-  const { categorias: categories, loading, error, updateCategoria, fetchCategorias } = useCategorias(organizacionId)
-  const { movimientos } = useMovimientos(selectedDelegation || null)
+  const { categorias: categories, loading, error, updateCategoria, fetchCategorias } = useCategorias(delegacionId || undefined)
+  const { movimientos } = useMovimientos(delegacionId)
   const searchParams = useSearchParams()
 
   // Todos los useEffect y useCallback van aquí
@@ -168,6 +178,10 @@ export function CategoryList() {
   }
 
   const handleEdit = (category: Categoria) => {
+    if (category.es_global && !isGestorCentral) {
+      alert("Solo un gestor central puede editar las categorías globales")
+      return
+    }
     setEditingCategory(category)
     setEditSheetOpen(true)
   }
@@ -182,6 +196,10 @@ export function CategoryList() {
   }
 
   const handleDeleteRequest = (category: Categoria) => {
+    if (category.es_global && !isGestorCentral) {
+      alert("Solo un gestor central puede eliminar categorías globales")
+      return
+    }
     setDeletingCategory(category)
   }
 
@@ -202,7 +220,23 @@ export function CategoryList() {
   const handleSaveCategory = async (patch: Partial<Categoria>) => {
     try {
       if (editingCategory) {
-        await updateCategoria(editingCategory.id, patch)
+        if (editingCategory.es_global && !isGestorCentral) {
+          alert("No tienes permisos para editar una categoría global")
+          return
+        }
+
+        if (patch.es_global === false && !delegacionId) {
+          alert("Selecciona una delegación para convertir la categoría en local")
+          return
+        }
+
+        const updates: Partial<Categoria> = { ...patch }
+        if (patch.es_global !== undefined) {
+          updates.es_global = patch.es_global
+          updates.delegacion_id = patch.es_global ? null : delegacionId
+        }
+
+        await updateCategoria(editingCategory.id, updates)
         if (patch.color && editingCategory.categoria_padre_id === null) {
           const children = categories.filter((c) => c.categoria_padre_id === editingCategory.id)
           for (const child of children) {
@@ -210,15 +244,23 @@ export function CategoryList() {
           }
         }
       } else if (organizacionId) {
+        const esGlobal = !!patch.es_global
+        if (!esGlobal && !delegacionId) {
+          alert("Selecciona una delegación antes de crear una categoría local")
+          return
+        }
+
         const maxOrder = Math.max(...categories.map((c) => c.orden), 0)
         await DatabaseService.createCategoria({
           organizacion_id: organizacionId,
+          delegacion_id: esGlobal ? null : delegacionId!,
           nombre: patch.nombre!,
           tipo: patch.tipo!,
           emoji: patch.emoji || "📁",
           color: patch.color || "#4ECDC4",
           orden: maxOrder + 1,
-          categoria_padre_id: null,
+          categoria_padre_id: patch.categoria_padre_id ?? null,
+          es_global: esGlobal,
         })
         await fetchCategorias()
       }
@@ -232,12 +274,29 @@ export function CategoryList() {
     }
   }
 
-  const handleDragEnd = async (result: any) => {
+  const handleDragEnd = async (result: DropResult) => {
     if (!result.destination) return
 
     const items = Array.from(sortedCategories)
     const [moved] = items.splice(result.source.index, 1)
     items.splice(result.destination.index, 0, moved)
+
+    if (!isGestorCentral && moved.es_global) {
+      return
+    }
+
+    if (!isGestorCentral) {
+      const globalMoved = items.some((item, index) => {
+        if (!item.es_global) return false
+        const originalIndex = sortedCategories.findIndex((c) => c.id === item.id)
+        return originalIndex !== index
+      })
+      if (globalMoved) {
+        return
+      }
+    }
+
+    const prev = items[result.destination.index - 1] || null
 
     const newParentId = prev
       ? (prev.categoria_padre_id === null
@@ -412,6 +471,7 @@ export function CategoryList() {
                     onEdit={handleEdit}
                     onSearch={handleSearch}
                     onDelete={handleDeleteRequest}
+                    canManageGlobal={isGestorCentral}
                   />
                 ))}
                 {provided.placeholder}
@@ -443,6 +503,7 @@ export function CategoryList() {
               parentCategory={categories.find((c) => c.id === editingCategory.categoria_padre_id)}
               onSave={handleSaveCategory}
               onCancel={() => setEditSheetOpen(false)}
+              canEditGlobal={isGestorCentral}
             />
           )}
         </SheetContent>
@@ -457,16 +518,19 @@ export function CategoryList() {
             category={{
               id: "",
               organizacion_id: organizacionId || "",
+              delegacion_id: delegacionId,
               nombre: "",
               tipo: "gasto",
               emoji: "📁",
               color: "#4ECDC4",
               orden: 0,
               categoria_padre_id: null,
+              es_global: false,
               creado_en: "",
             }}
             onSave={handleSaveCategory}
             onCancel={() => setCreateSheetOpen(false)}
+            canEditGlobal={isGestorCentral}
           />
         </SheetContent>
       </Sheet>

--- a/components/dashboard/activity-balance.tsx
+++ b/components/dashboard/activity-balance.tsx
@@ -22,11 +22,11 @@ import { format } from "date-fns"
 import { es } from "date-fns/locale"
 
 export function ActivityBalanceDashboard() {
-  const { selectedDelegation, getCurrentDelegation } = useDelegationContext()
+  const { selectedDelegation } = useDelegationContext()
   const [timeframe, setTimeframe] = useState<Timeframe>("month")
   const [categoryIds, setCategoryIds] = useState<string[]>([])
 
-  const { categorias } = useCategorias(getCurrentDelegation()?.organizacion_id)
+  const { categorias } = useCategorias(selectedDelegation || undefined)
   const { from, to } = getTimeframeRange(timeframe)
   const { movimientos } = useMovimientos(selectedDelegation, {
     fechaDesde: from,

--- a/components/dashboard/category-analysis.tsx
+++ b/components/dashboard/category-analysis.tsx
@@ -27,11 +27,11 @@ import {
 } from "@/components/ui/table"
 
 export function CategoryAnalysisDashboard() {
-  const { selectedDelegation, getCurrentDelegation } = useDelegationContext()
+  const { selectedDelegation } = useDelegationContext()
   const [timeframe, setTimeframe] = useState<Timeframe>("month")
   const [categoryIds, setCategoryIds] = useState<string[]>([])
 
-  const { categorias } = useCategorias(getCurrentDelegation()?.organizacion_id)
+  const { categorias } = useCategorias(selectedDelegation || undefined)
   const { from, to } = getTimeframeRange(timeframe)
   const { movimientos } = useMovimientos(selectedDelegation, {
     fechaDesde: from,

--- a/components/transactions/related-movements-sheet.tsx
+++ b/components/transactions/related-movements-sheet.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect, useRef } from "react"
+import { useEffect, useRef } from "react"
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet"
 import { LoadingSpinner } from "@/components/ui/loading-spinner"
 import { ErrorMessage } from "@/components/ui/error-message"
@@ -8,10 +8,8 @@ import { AmountDisplay } from "@/components/ui/amount-display"
 import { BankAvatar } from "./bank-avatar"
 import { useDelegationContext } from "@/contexts/delegation-context"
 import { useMovimientos } from "@/hooks/use-movimientos"
-import { useCategorias } from "@/hooks/use-categorias"
-import { useCuentas } from "@/hooks/use-cuentas"
 import { formatDate } from "@/lib/utils/format"
-import type { Cuenta, Categoria, MovimientoConRelaciones } from "@/lib/types/database"
+import type { Cuenta, Categoria } from "@/lib/types/database"
 
 interface RelatedMovementsSheetProps {
   account?: Cuenta | null
@@ -21,10 +19,7 @@ interface RelatedMovementsSheetProps {
 }
 
 export function RelatedMovementsSheet({ account, category, open, onOpenChange }: RelatedMovementsSheetProps) {
-  const { selectedDelegation, getCurrentDelegation } = useDelegationContext()
-  const { categorias: categories } = useCategorias(getCurrentDelegation()?.organizacion_id)
-  const { cuentas: accounts } = useCuentas(selectedDelegation)
-
+  const { selectedDelegation } = useDelegationContext()
   const { movimientos, loading, error, loadMore, hasMore } = useMovimientos(
     selectedDelegation,
     {

--- a/components/transactions/transaction-manager.tsx
+++ b/components/transactions/transaction-manager.tsx
@@ -67,7 +67,6 @@ export function TransactionManager({ onTransactionCountChange }: TransactionMana
   const searchParams = useSearchParams()
 
   const currentDelegation = getCurrentDelegation()
-  const organizacionId = currentDelegation?.organizacion_id
 
   console.log(`🏢 TransactionManager: selectedDelegation = ${selectedDelegation}, currentDelegation = ${currentDelegation?.nombre}`)
 
@@ -92,7 +91,7 @@ export function TransactionManager({ onTransactionCountChange }: TransactionMana
     uncategorized: filters.uncategorized,
   })
 
-  const { categorias: categories } = useCategorias(organizacionId)
+  const { categorias: categories } = useCategorias(selectedDelegation || undefined)
   const { cuentas: accounts } = useCuentas(selectedDelegation)
 
   const handleDownload = async () => {

--- a/hooks/use-categorias.ts
+++ b/hooks/use-categorias.ts
@@ -6,7 +6,7 @@ import type { Categoria } from "@/lib/types/database"
 import { useRevalidateOnFocusJitter } from "./use-app-status"
 import { runQuery } from "@/lib/db/query"
 
-export function useCategorias(organizacionId?: string) {
+export function useCategorias(delegacionId?: string) {
   const [categorias, setCategorias] = useState<Categoria[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -18,23 +18,30 @@ export function useCategorias(organizacionId?: string) {
     if (abortRef.current) abortRef.current.abort()
     if (timeoutRef.current) clearTimeout(timeoutRef.current)
 
+    if (!delegacionId) {
+      setCategorias([])
+      setLoading(false)
+      setError(null)
+      return
+    }
+
     const ac = new AbortController()
     abortRef.current = ac
     try {
       setLoading(true)
 
-      const { data, error } = await runQuery<any[]>({
+      const { data, error } = await runQuery<Categoria[]>({
         label: 'fetch-categorias',
         table: 'categoria',
         timeoutMs: TIMEOUT_MS,
         build: async (signal) => {
-          let query = supabase
+          return await supabase
             .from("categoria")
             .select("*")
+            .in("delegacion_id", [delegacionId, null])
             .order("orden", { ascending: true })
             .order("nombre", { ascending: true })
-          if (organizacionId) query = query.eq("organizacion_id", organizacionId)
-          return await query.abortSignal(signal)
+            .abortSignal(signal)
         }
       })
 
@@ -43,7 +50,11 @@ export function useCategorias(organizacionId?: string) {
         return
       }
 
-      setCategorias(data || [])
+      const filtered = (data || []).filter(
+        (cat) => cat.es_global || cat.delegacion_id === delegacionId,
+      )
+
+      setCategorias(filtered)
     } catch (err) {
       if (!ac.signal.aborted) {
         setError(err instanceof Error ? err.message : "Error desconocido")
@@ -55,7 +66,7 @@ export function useCategorias(organizacionId?: string) {
         timeoutRef.current = null
       }
     }
-  }, [organizacionId])
+  }, [delegacionId])
 
   useEffect(() => {
     fetchCategorias()
@@ -74,7 +85,11 @@ export function useCategorias(organizacionId?: string) {
 
       if (error) throw error
 
-      setCategorias((prev) => prev.map((cat) => (cat.id === id ? { ...cat, ...updates } : cat)))
+      setCategorias((prev) =>
+        prev
+          .map((cat) => (cat.id === id ? { ...cat, ...updates } : cat))
+          .filter((cat) => cat.es_global || cat.delegacion_id === delegacionId),
+      )
     } catch (err) {
       setError(err instanceof Error ? err.message : "Error al actualizar categoría")
     }

--- a/lib/services/database.ts
+++ b/lib/services/database.ts
@@ -15,16 +15,18 @@ export class DatabaseService {
   }
 
   // Categoria operations (client-side only)
-  static async getCategoriasByOrganizacion(organizacionId: string): Promise<Categoria[]> {
+  static async getCategoriasByDelegacion(delegacionId: string): Promise<Categoria[]> {
     const supabase = this.getClient()
     const { data, error } = await supabase
       .from("categoria")
       .select("*")
-      .eq("organizacion_id", organizacionId)
+      .in("delegacion_id", [delegacionId, null])
       .order("orden", { ascending: true })
 
     if (error) throw error
-    return data || []
+    return (data || []).filter(
+      (categoria) => categoria.es_global || categoria.delegacion_id === delegacionId,
+    )
   }
 
   static async createCategoria(categoria: Omit<Categoria, "id" | "creado_en">): Promise<Categoria> {

--- a/lib/services/server-database.ts
+++ b/lib/services/server-database.ts
@@ -135,15 +135,17 @@ export class ServerDatabaseService {
   }
 
   // Categoria operations (server-side)
-  static async getCategoriasByOrganizacion(organizacionId: string): Promise<Categoria[]> {
+  static async getCategoriasByDelegacion(delegacionId: string): Promise<Categoria[]> {
     const supabase = this.getServerClient()
     const { data, error } = await supabase
       .from("categoria")
       .select("*")
-      .eq("organizacion_id", organizacionId)
+      .in("delegacion_id", [delegacionId, null])
       .order("orden", { ascending: true })
 
     if (error) throw error
-    return data || []
+    return (data || []).filter(
+      (categoria) => categoria.es_global || categoria.delegacion_id === delegacionId,
+    )
   }
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -37,12 +37,14 @@ export interface Cuenta {
 export interface Categoria {
   id: UUID
   organizacion_id: UUID
+  delegacion_id: UUID | null
   nombre: string
   tipo: TipoCategoria
   emoji: string | null
   color: string | null
   orden: number
   categoria_padre_id: UUID | null
+  es_global: boolean
   creado_en: string
 }
 

--- a/lib/types/database.ts
+++ b/lib/types/database.ts
@@ -152,31 +152,37 @@ export type Database = {
           color: string
           id: string
           organizacion_id: string
+          delegacion_id: string | null
           nombre: string
           tipo: string
           emoji: string | null
           orden: number
           categoria_padre_id: string | null
+          es_global: boolean
           creado_en: string
         }
         Insert: {
           id?: string
           organizacion_id: string
+          delegacion_id?: string | null
           nombre: string
           tipo: string
           emoji?: string | null
           orden?: number
           categoria_padre_id?: string | null
+          es_global?: boolean
           creado_en?: string
         }
         Update: {
           id?: string
           organizacion_id?: string
+          delegacion_id?: string | null
           nombre?: string
           tipo?: string
           emoji?: string | null
           orden?: number
           categoria_padre_id?: string | null
+          es_global?: boolean
           creado_en?: string
         }
       }


### PR DESCRIPTION
## Summary
- add delegation-aware fields to categories and update the fetching services/hooks
- enhance the category editor/list UI to mark globals, restrict editing and show badges
- update dashboards and transaction flows to consume the delegation scoped categories

## Testing
- pnpm lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c9ac9df5a0832691924b80ebf2d4f8