### PR TITLE
feat: soportar categorías globales y locales por delegación

### DIFF
--- a/components/categories/category-edit-form.tsx
+++ b/components/categories/category-edit-form.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import type React from "react"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -16,17 +16,28 @@ interface CategoryEditFormProps {
   parentCategory?: Categoria
   onSave: (patch: Partial<Categoria>) => Promise<void>
   onCancel: () => void
+  canManageGlobal: boolean
 }
 
+type ScopeOption = "delegacion" | "global"
 
-export function CategoryEditForm({ category, parentCategory, onSave, onCancel }: CategoryEditFormProps) {
+export function CategoryEditForm({ category, parentCategory, onSave, onCancel, canManageGlobal }: CategoryEditFormProps) {
   const [formData, setFormData] = useState({
     nombre: category.nombre,
     emoji: category.emoji || "📁",
     tipo: category.tipo,
     color: parentCategory?.color || category.color || "#4ECDC4",
+    scope: (category.es_global ? "global" : "delegacion") as ScopeOption,
   })
   const [loading, setLoading] = useState(false)
+
+  const canToggleGlobal = canManageGlobal && (!parentCategory || parentCategory.es_global)
+
+  useEffect(() => {
+    if (!canToggleGlobal) {
+      setFormData((prev) => (prev.scope === "global" ? { ...prev, scope: "delegacion" } : prev))
+    }
+  }, [canToggleGlobal])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -44,6 +55,7 @@ export function CategoryEditForm({ category, parentCategory, onSave, onCancel }:
         emoji: formData.emoji,
         tipo: formData.tipo,
         ...(parentCategory ? {} : { color: formData.color }),
+        es_global: formData.scope === "global",
       })
     } catch (error) {
       console.error("Error saving category:", error)
@@ -107,6 +119,32 @@ export function CategoryEditForm({ category, parentCategory, onSave, onCancel }:
             value={`${parentCategory.emoji || ""} ${parentCategory.nombre}`}
             disabled
           />
+        </div>
+      )}
+
+      {canManageGlobal && (
+        <div className="space-y-2">
+          <Label>Ámbito *</Label>
+          <Select
+            value={formData.scope}
+            onValueChange={(value) =>
+              setFormData((prev) => ({ ...prev, scope: value as ScopeOption }))
+            }
+            disabled={!canToggleGlobal}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="delegacion">Delegación actual</SelectItem>
+              <SelectItem value="global">Global (todas las delegaciones)</SelectItem>
+            </SelectContent>
+          </Select>
+          {!canToggleGlobal && (
+            <p className="text-xs text-muted-foreground">
+              Solo puedes marcar una subcategoría como global si su categoría superior también es global.
+            </p>
+          )}
         </div>
       )}
 

--- a/components/categories/category-list.tsx
+++ b/components/categories/category-list.tsx
@@ -8,13 +8,15 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Card, CardContent } from "@/components/ui/card"
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet"
+import { Badge } from "@/components/ui/badge"
 import { CategoryEditForm } from "./category-edit-form"
 import { DateRangeFilter } from "@/components/transactions/date-range-filter"
 import { useCategorias } from "@/hooks/use-categorias"
 import { useMovimientos } from "@/hooks/use-movimientos"
 import { useDelegationContext } from "@/contexts/delegation-context"
+import useIsAdmin from "@/hooks/use-is-admin"
 import { DatabaseService } from "@/lib/services/database"
-import { GripVertical, Search, Edit, Trash2, Plus, Building2, Wallet, X } from "lucide-react"
+import { GripVertical, Search, Edit, Trash2, Plus, X, Globe2 } from "lucide-react"
 import { AmountDisplay } from "@/components/amount-display"
 import { DeleteCategoryDialog } from "./delete-category-dialog"
 import { RelatedMovementsSheet } from "@/components/transactions/related-movements-sheet"
@@ -28,12 +30,27 @@ interface CategoryCardProps {
   onEdit: (category: Categoria) => void
   onSearch: (category: Categoria) => void
   onDelete: (category: Categoria) => void
+  canEdit: boolean
+  canDelete: boolean
+  isDragDisabled: boolean
+  isGlobal: boolean
 }
 
-function CategoryCard({ category, index, balance, onEdit, onSearch, onDelete }: CategoryCardProps) {
+function CategoryCard({
+  category,
+  index,
+  balance,
+  onEdit,
+  onSearch,
+  onDelete,
+  canEdit,
+  canDelete,
+  isDragDisabled,
+  isGlobal,
+}: CategoryCardProps) {
   const isSub = !!category.categoria_padre_id
   return (
-    <Draggable draggableId={category.id} index={index}>
+    <Draggable draggableId={category.id} index={index} isDragDisabled={isDragDisabled}>
       {(provided, snapshot) => (
         <Card
           ref={provided.innerRef}
@@ -42,14 +59,23 @@ function CategoryCard({ category, index, balance, onEdit, onSearch, onDelete }: 
             "transition-shadow hover:shadow-md",
             snapshot.isDragging && "shadow-lg rotate-2",
             isSub && "ml-6",
+            isDragDisabled && "opacity-95",
           )}
         >
           <CardContent className="p-3 sm:p-4 lg:p-6">
             <div className="flex items-center gap-3 sm:gap-4">
               {/* Drag Handle */}
               <div
-                {...provided.dragHandleProps}
-                className="flex h-8 w-8 items-center justify-center rounded text-muted-foreground hover:bg-muted cursor-grab active:cursor-grabbing flex-shrink-0"
+                {...(provided.dragHandleProps ?? {})}
+                className={cn(
+                  "flex h-8 w-8 items-center justify-center rounded text-muted-foreground hover:bg-muted flex-shrink-0",
+                  isDragDisabled ? "cursor-default opacity-40" : "cursor-grab active:cursor-grabbing",
+                )}
+                title={
+                  isDragDisabled
+                    ? "Solo el gestor central puede reorganizar categorías globales"
+                    : undefined
+                }
               >
                 <GripVertical className="h-4 w-4" />
               </div>
@@ -69,18 +95,22 @@ function CategoryCard({ category, index, balance, onEdit, onSearch, onDelete }: 
               <div className="flex-1 min-w-0">
                 <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
                   <div className="min-w-0">
-                    <h3 className={cn("font-semibold text-base sm:text-lg truncate", isSub && "font-medium")}>{category.nombre}</h3>
-                    <div className="flex items-center gap-2 mt-1 sm:mt-0">
-                      
-                      
-                      
-                    <AmountDisplay amount={balance} size="sm" />
-
-
+                    <div className="flex flex-wrap items-center gap-2">
+                      <h3 className={cn("font-semibold text-base sm:text-lg truncate", isSub && "font-medium")}>{category.nombre}</h3>
+                      {isGlobal && (
+                        <Badge
+                          variant="outline"
+                          className="flex items-center gap-1 border-blue-200 bg-blue-50 text-blue-700 dark:bg-blue-950/30 dark:text-blue-200"
+                        >
+                          <Globe2 className="h-3 w-3" />
+                          <span className="text-[10px] uppercase tracking-wide">Global</span>
+                        </Badge>
+                      )}
+                    </div>
+                    <div className="mt-1 text-xs text-muted-foreground">
+                      <AmountDisplay amount={balance} size="sm" />
                     </div>
                   </div>
-                  
-             
                 </div>
               </div>
 
@@ -100,7 +130,8 @@ function CategoryCard({ category, index, balance, onEdit, onSearch, onDelete }: 
                   size="icon"
                   className="h-8 w-8 sm:h-9 sm:w-9 text-gray-600 hover:bg-gray-50"
                   onClick={() => onEdit(category)}
-                  title="Editar categoría"
+                  title={canEdit ? "Editar categoría" : "Solo el gestor central puede editar categorías globales"}
+                  disabled={!canEdit}
                 >
                   <Edit className="h-3 w-3 sm:h-4 sm:w-4" />
                 </Button>
@@ -109,7 +140,8 @@ function CategoryCard({ category, index, balance, onEdit, onSearch, onDelete }: 
                   size="icon"
                   className="h-8 w-8 sm:h-9 sm:w-9 text-red-600 hover:bg-red-50"
                   onClick={() => onDelete(category)}
-                  title="Eliminar categoría"
+                  title={canDelete ? "Eliminar categoría" : "Solo el gestor central puede eliminar categorías globales"}
+                  disabled={!canDelete}
                 >
                   <Trash2 className="h-3 w-3 sm:h-4 sm:w-4" />
                 </Button>
@@ -124,6 +156,7 @@ function CategoryCard({ category, index, balance, onEdit, onSearch, onDelete }: 
 
 export function CategoryList() {
   const { selectedDelegation, getCurrentDelegation } = useDelegationContext()
+  const isCentralManager = useIsAdmin()
   const [searchTerm, setSearchTerm] = useState("")
   const [searchOpen, setSearchOpen] = useState(false)
   const [editingCategory, setEditingCategory] = useState<Categoria | null>(null)
@@ -137,7 +170,7 @@ export function CategoryList() {
   const currentDelegation = getCurrentDelegation()
   const organizacionId = currentDelegation?.organizacion_id
 
-  const { categorias: categories, loading, error, updateCategoria, fetchCategorias } = useCategorias(organizacionId)
+  const { categorias: categories, loading, error, updateCategoria, fetchCategorias } = useCategorias(selectedDelegation)
   const { movimientos } = useMovimientos(selectedDelegation || null)
   const searchParams = useSearchParams()
 
@@ -167,7 +200,12 @@ export function CategoryList() {
     setDateTo(newDateTo)
   }
 
+  const canEditCategory = (category: Categoria) => !category.es_global || isCentralManager
+  const canDeleteCategory = (category: Categoria) => !category.es_global || isCentralManager
+  const canReorderCategory = (category: Categoria) => !category.es_global || isCentralManager
+
   const handleEdit = (category: Categoria) => {
+    if (!canEditCategory(category)) return
     setEditingCategory(category)
     setEditSheetOpen(true)
   }
@@ -182,6 +220,7 @@ export function CategoryList() {
   }
 
   const handleDeleteRequest = (category: Categoria) => {
+    if (!canDeleteCategory(category)) return
     setDeletingCategory(category)
   }
 
@@ -202,27 +241,69 @@ export function CategoryList() {
   const handleSaveCategory = async (patch: Partial<Categoria>) => {
     try {
       if (editingCategory) {
-        await updateCategoria(editingCategory.id, patch)
+        const updates: Partial<Categoria> = {
+          nombre: patch.nombre,
+          emoji: patch.emoji,
+          tipo: patch.tipo,
+        }
+
         if (patch.color && editingCategory.categoria_padre_id === null) {
-          const children = categories.filter((c) => c.categoria_padre_id === editingCategory.id)
-          for (const child of children) {
-            await updateCategoria(child.id, { color: patch.color })
+          updates.color = patch.color
+        }
+
+        if (patch.es_global !== undefined) {
+          updates.es_global = patch.es_global
+          updates.delegacion_id = patch.es_global ? null : selectedDelegation || editingCategory.delegacion_id
+
+          if (
+            patch.es_global &&
+            editingCategory.categoria_padre_id &&
+            !categories.find((c) => c.id === editingCategory.categoria_padre_id)?.es_global
+          ) {
+            updates.categoria_padre_id = null
           }
         }
-      } else if (organizacionId) {
-        const maxOrder = Math.max(...categories.map((c) => c.orden), 0)
+
+        await updateCategoria(editingCategory.id, updates)
+
+        if (updates.color && editingCategory.categoria_padre_id === null) {
+          const children = categories.filter((c) => c.categoria_padre_id === editingCategory.id)
+          for (const child of children) {
+            await updateCategoria(child.id, { color: updates.color })
+          }
+        }
+      } else {
+        if (!organizacionId) {
+          throw new Error("No se ha podido determinar la organización")
+        }
+
+        const isGlobal = !!patch.es_global
+
+        if (!isGlobal && !selectedDelegation) {
+          alert("Selecciona una delegación para crear categorías locales")
+          return
+        }
+
+        const relevantCategories = categories.filter((category) =>
+          isGlobal ? category.es_global : !category.es_global && category.delegacion_id === selectedDelegation,
+        )
+        const maxOrder =
+          relevantCategories.length > 0 ? Math.max(...relevantCategories.map((c) => c.orden)) : 0
+
         await DatabaseService.createCategoria({
           organizacion_id: organizacionId,
+          delegacion_id: isGlobal ? null : selectedDelegation!,
           nombre: patch.nombre!,
           tipo: patch.tipo!,
           emoji: patch.emoji || "📁",
           color: patch.color || "#4ECDC4",
           orden: maxOrder + 1,
-          categoria_padre_id: null,
+          categoria_padre_id: patch.categoria_padre_id ?? null,
+          es_global: isGlobal,
         })
-        await fetchCategorias()
       }
 
+      await fetchCategorias()
       setEditSheetOpen(false)
       setCreateSheetOpen(false)
       setEditingCategory(null)
@@ -239,35 +320,54 @@ export function CategoryList() {
     const [moved] = items.splice(result.source.index, 1)
     items.splice(result.destination.index, 0, moved)
 
-    const newParentId = prev
-      ? (prev.categoria_padre_id === null
-          ? prev.id
-          : prev.categoria_padre_id)
-      : null
+    if (!canReorderCategory(moved)) return
+
+    const prev = items[result.destination.index - 1] ?? null
+    let newParentId: string | null = null
+
+    if (prev) {
+      newParentId = prev.categoria_padre_id === null ? prev.id : prev.categoria_padre_id
+    }
+
+    if (newParentId) {
+      const parent = items.find((c) => c.id === newParentId)
+      if (parent) {
+        if (moved.es_global && !parent.es_global) {
+          newParentId = null
+        } else if (!moved.es_global && parent.delegacion_id && parent.delegacion_id !== (moved.delegacion_id || selectedDelegation)) {
+          newParentId = parent.es_global ? parent.id : null
+        }
+      }
+    }
+
     const parentColor = newParentId ? items.find((c) => c.id === newParentId)?.color || moved.color : moved.color
 
     try {
-      // Only update items whose orden has changed, and for the moved item, also update parent/color
-      const updates = items.map((item, index) => {
-        const original = sortedCategories.find((c) => c.id === item.id)
-        const newOrden = index + 1
-        const isMoved = item.id === moved.id
-        const ordenChanged = original ? original.orden !== newOrden : true
-        if (isMoved) {
-          // Always update moved item with new orden, parent, and color
-          return updateCategoria(item.id, {
-            orden: newOrden,
-            categoria_padre_id: newParentId,
-            color: parentColor,
-          })
-        } else if (ordenChanged) {
-          // Only update orden if it changed
-          return updateCategoria(item.id, { orden: newOrden })
-        } else {
+      const updates = items
+        .map((item, index) => {
+          const original = sortedCategories.find((c) => c.id === item.id)
+          const newOrden = index + 1
+          const isMoved = item.id === moved.id
+          const ordenChanged = original ? original.orden !== newOrden : true
+
+          if (isMoved) {
+            const payload: Partial<Categoria> = {
+              orden: newOrden,
+              categoria_padre_id: newParentId,
+              color: parentColor,
+            }
+
+            return updateCategoria(item.id, payload)
+          } else if (ordenChanged) {
+            return updateCategoria(item.id, { orden: newOrden })
+          }
+
           return null
-        }
-      }).filter(Boolean)
+        })
+        .filter(Boolean) as Promise<void>[]
+
       await Promise.all(updates)
+      await fetchCategorias()
     } catch (error) {
       console.error("Error reordering categories:", error)
     }
@@ -278,7 +378,15 @@ export function CategoryList() {
     category.nombre.toLowerCase().includes(searchTerm.toLowerCase()),
   )
 
-  const sortedCategories = [...filteredCategories].sort((a, b) => a.orden - b.orden)
+  const sortedCategories = [...filteredCategories].sort((a, b) => {
+    if (a.es_global !== b.es_global) {
+      return a.es_global ? -1 : 1
+    }
+    return a.orden - b.orden
+  })
+
+  const globalCount = categories.filter((category) => category.es_global).length
+  const localCount = categories.length - globalCount
 
   // Renders condicionales al final
   if (!selectedDelegation) {
@@ -312,16 +420,21 @@ export function CategoryList() {
     <div className="space-y-4 sm:space-y-6">
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-        <div>
-          <h2 className="text-2xl sm:text-3xl font-bold">Categorías</h2>
-          <p className="text-muted-foreground mt-1 text-sm sm:text-base">
-            {categories.length} categorías • Arrastra para reordenar
-          </p>
-        </div>
-        <Button onClick={handleCreate} size="default" className="w-full sm:w-auto">
-          <Plus className="h-4 w-4 mr-2" />
-          Añadir categoría
-        </Button>
+      <div>
+        <h2 className="text-2xl sm:text-3xl font-bold">Categorías</h2>
+        <p className="text-muted-foreground mt-1 text-sm sm:text-base">
+          {localCount} locales • {globalCount} globales • Arrastra para reordenar
+        </p>
+      </div>
+      <Button
+        onClick={handleCreate}
+        size="default"
+        className="w-full sm:w-auto"
+        disabled={!organizacionId}
+      >
+        <Plus className="h-4 w-4 mr-2" />
+        Añadir categoría
+      </Button>
       </div>
 
       {/* Filters */}
@@ -412,6 +525,10 @@ export function CategoryList() {
                     onEdit={handleEdit}
                     onSearch={handleSearch}
                     onDelete={handleDeleteRequest}
+                    canEdit={canEditCategory(category)}
+                    canDelete={canDeleteCategory(category)}
+                    isDragDisabled={!canReorderCategory(category)}
+                    isGlobal={category.es_global}
                   />
                 ))}
                 {provided.placeholder}
@@ -443,6 +560,7 @@ export function CategoryList() {
               parentCategory={categories.find((c) => c.id === editingCategory.categoria_padre_id)}
               onSave={handleSaveCategory}
               onCancel={() => setEditSheetOpen(false)}
+              canManageGlobal={isCentralManager}
             />
           )}
         </SheetContent>
@@ -457,6 +575,7 @@ export function CategoryList() {
             category={{
               id: "",
               organizacion_id: organizacionId || "",
+              delegacion_id: selectedDelegation || null,
               nombre: "",
               tipo: "gasto",
               emoji: "📁",
@@ -464,9 +583,11 @@ export function CategoryList() {
               orden: 0,
               categoria_padre_id: null,
               creado_en: "",
+              es_global: false,
             }}
             onSave={handleSaveCategory}
             onCancel={() => setCreateSheetOpen(false)}
+            canManageGlobal={isCentralManager}
           />
         </SheetContent>
       </Sheet>

--- a/components/dashboard/activity-balance.tsx
+++ b/components/dashboard/activity-balance.tsx
@@ -26,7 +26,7 @@ export function ActivityBalanceDashboard() {
   const [timeframe, setTimeframe] = useState<Timeframe>("month")
   const [categoryIds, setCategoryIds] = useState<string[]>([])
 
-  const { categorias } = useCategorias(getCurrentDelegation()?.organizacion_id)
+  const { categorias } = useCategorias(selectedDelegation)
   const { from, to } = getTimeframeRange(timeframe)
   const { movimientos } = useMovimientos(selectedDelegation, {
     fechaDesde: from,

--- a/components/dashboard/category-analysis.tsx
+++ b/components/dashboard/category-analysis.tsx
@@ -31,7 +31,7 @@ export function CategoryAnalysisDashboard() {
   const [timeframe, setTimeframe] = useState<Timeframe>("month")
   const [categoryIds, setCategoryIds] = useState<string[]>([])
 
-  const { categorias } = useCategorias(getCurrentDelegation()?.organizacion_id)
+  const { categorias } = useCategorias(selectedDelegation)
   const { from, to } = getTimeframeRange(timeframe)
   const { movimientos } = useMovimientos(selectedDelegation, {
     fechaDesde: from,

--- a/components/transactions/related-movements-sheet.tsx
+++ b/components/transactions/related-movements-sheet.tsx
@@ -22,7 +22,7 @@ interface RelatedMovementsSheetProps {
 
 export function RelatedMovementsSheet({ account, category, open, onOpenChange }: RelatedMovementsSheetProps) {
   const { selectedDelegation, getCurrentDelegation } = useDelegationContext()
-  const { categorias: categories } = useCategorias(getCurrentDelegation()?.organizacion_id)
+  const { categorias: categories } = useCategorias(selectedDelegation)
   const { cuentas: accounts } = useCuentas(selectedDelegation)
 
   const { movimientos, loading, error, loadMore, hasMore } = useMovimientos(

--- a/components/transactions/transaction-import-panel.tsx
+++ b/components/transactions/transaction-import-panel.tsx
@@ -62,7 +62,7 @@ export function TransactionImportPanel({
 }: TransactionImportPanelProps) {
   // Obtener las categorías disponibles para matching
   // Por ahora usaremos un valor predeterminado, pero deberíamos obtener el organizacion_id del delegacionId
-  const { categorias: availableCategories } = useCategorias(delegacionId || undefined)
+  const { categorias: availableCategories } = useCategorias(delegacionId)
   
   const [source, setSource] = useState<SourceType | null>("manual")
   const [file, setFile] = useState<File | null>(null)

--- a/components/transactions/transaction-manager.tsx
+++ b/components/transactions/transaction-manager.tsx
@@ -67,8 +67,6 @@ export function TransactionManager({ onTransactionCountChange }: TransactionMana
   const searchParams = useSearchParams()
 
   const currentDelegation = getCurrentDelegation()
-  const organizacionId = currentDelegation?.organizacion_id
-
   console.log(`🏢 TransactionManager: selectedDelegation = ${selectedDelegation}, currentDelegation = ${currentDelegation?.nombre}`)
 
   const {
@@ -92,7 +90,7 @@ export function TransactionManager({ onTransactionCountChange }: TransactionMana
     uncategorized: filters.uncategorized,
   })
 
-  const { categorias: categories } = useCategorias(organizacionId)
+  const { categorias: categories } = useCategorias(selectedDelegation)
   const { cuentas: accounts } = useCuentas(selectedDelegation)
 
   const handleDownload = async () => {

--- a/hooks/use-categorias.ts
+++ b/hooks/use-categorias.ts
@@ -6,13 +6,17 @@ import type { Categoria } from "@/lib/types/database"
 import { useRevalidateOnFocusJitter } from "./use-app-status"
 import { runQuery } from "@/lib/db/query"
 
-export function useCategorias(organizacionId?: string) {
+export function useCategorias(
+  delegacionId?: string | null,
+  options?: { includeGlobal?: boolean },
+) {
   const [categorias, setCategorias] = useState<Categoria[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const abortRef = useRef<AbortController | null>(null)
   const timeoutRef = useRef<NodeJS.Timeout | null>(null)
   const TIMEOUT_MS = 12000
+  const includeGlobal = options?.includeGlobal ?? true
 
   const fetchCategorias = useCallback(async () => {
     if (abortRef.current) abortRef.current.abort()
@@ -21,6 +25,12 @@ export function useCategorias(organizacionId?: string) {
     const ac = new AbortController()
     abortRef.current = ac
     try {
+      if (!delegacionId && !includeGlobal) {
+        setCategorias([])
+        setLoading(false)
+        return
+      }
+
       setLoading(true)
 
       const { data, error } = await runQuery<any[]>({
@@ -33,7 +43,13 @@ export function useCategorias(organizacionId?: string) {
             .select("*")
             .order("orden", { ascending: true })
             .order("nombre", { ascending: true })
-          if (organizacionId) query = query.eq("organizacion_id", organizacionId)
+          if (delegacionId) {
+            query = includeGlobal
+              ? query.or(`delegacion_id.eq.${delegacionId},es_global.is.true`)
+              : query.eq("delegacion_id", delegacionId)
+          } else if (includeGlobal) {
+            query = query.eq("es_global", true)
+          }
           return await query.abortSignal(signal)
         }
       })
@@ -43,7 +59,14 @@ export function useCategorias(organizacionId?: string) {
         return
       }
 
-      setCategorias(data || [])
+      setCategorias(
+        (data || []).sort((a, b) => {
+          if (a.es_global !== b.es_global) {
+            return a.es_global ? -1 : 1
+          }
+          return a.orden - b.orden
+        }),
+      )
     } catch (err) {
       if (!ac.signal.aborted) {
         setError(err instanceof Error ? err.message : "Error desconocido")
@@ -55,7 +78,7 @@ export function useCategorias(organizacionId?: string) {
         timeoutRef.current = null
       }
     }
-  }, [organizacionId])
+  }, [delegacionId, includeGlobal])
 
   useEffect(() => {
     fetchCategorias()

--- a/hooks/use-movimientos.ts
+++ b/hooks/use-movimientos.ts
@@ -69,12 +69,15 @@ export function useMovimientos(
               categoria:categoria_id (
                 id,
                 organizacion_id,
+                delegacion_id,
                 nombre,
                 tipo,
                 emoji,
+                color,
                 orden,
                 categoria_padre_id,
-                creado_en
+                creado_en,
+                es_global
               ),
               archivos:movimiento_archivo!movimiento_id (
                 id,
@@ -186,12 +189,15 @@ export function useMovimientos(
           categoria:categoria_id (
             id,
             organizacion_id,
+            delegacion_id,
             nombre,
             tipo,
             emoji,
+            color,
             orden,
             categoria_padre_id,
-            creado_en
+            creado_en,
+            es_global
           ),
           archivos:movimiento_archivo!movimiento_id (
             id,

--- a/hooks/use-transacciones.ts
+++ b/hooks/use-transacciones.ts
@@ -83,7 +83,9 @@ export function useTransacciones({
             nombre,
             tipo,
             emoji,
-            color
+            color,
+            delegacion_id,
+            es_global
           )
         `)
         .eq("ignorado", false)

--- a/lib/services/database.ts
+++ b/lib/services/database.ts
@@ -15,19 +15,28 @@ export class DatabaseService {
   }
 
   // Categoria operations (client-side only)
-  static async getCategoriasByOrganizacion(organizacionId: string): Promise<Categoria[]> {
+  static async getCategoriasByDelegacion(
+    delegacionId: string,
+    options: { includeGlobal?: boolean } = {},
+  ): Promise<Categoria[]> {
     const supabase = this.getClient()
     const { data, error } = await supabase
       .from("categoria")
       .select("*")
-      .eq("organizacion_id", organizacionId)
+      .or(
+        options.includeGlobal !== false
+          ? `delegacion_id.eq.${delegacionId},es_global.is.true`
+          : `delegacion_id.eq.${delegacionId}`,
+      )
       .order("orden", { ascending: true })
 
     if (error) throw error
     return data || []
   }
 
-  static async createCategoria(categoria: Omit<Categoria, "id" | "creado_en">): Promise<Categoria> {
+  static async createCategoria(
+    categoria: Omit<Categoria, "id" | "creado_en">,
+  ): Promise<Categoria> {
     const supabase = this.getClient()
     const { data, error } = await supabase.from("categoria").insert(categoria).select().single()
 

--- a/lib/services/server-database.ts
+++ b/lib/services/server-database.ts
@@ -101,12 +101,15 @@ export class ServerDatabaseService {
         categoria:categoria_id (
           id,
           organizacion_id,
+          delegacion_id,
           nombre,
           tipo,
           emoji,
+          color,
           orden,
           categoria_padre_id,
-          creado_en
+          creado_en,
+          es_global
         )
       `)
       .eq("cuenta.delegacion_id", delegacionId)
@@ -135,12 +138,19 @@ export class ServerDatabaseService {
   }
 
   // Categoria operations (server-side)
-  static async getCategoriasByOrganizacion(organizacionId: string): Promise<Categoria[]> {
+  static async getCategoriasByDelegacion(
+    delegacionId: string,
+    options: { includeGlobal?: boolean } = {},
+  ): Promise<Categoria[]> {
     const supabase = this.getServerClient()
     const { data, error } = await supabase
       .from("categoria")
       .select("*")
-      .eq("organizacion_id", organizacionId)
+      .or(
+        options.includeGlobal !== false
+          ? `delegacion_id.eq.${delegacionId},es_global.is.true`
+          : `delegacion_id.eq.${delegacionId}`,
+      )
       .order("orden", { ascending: true })
 
     if (error) throw error

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -37,6 +37,7 @@ export interface Cuenta {
 export interface Categoria {
   id: UUID
   organizacion_id: UUID
+  delegacion_id: UUID | null
   nombre: string
   tipo: TipoCategoria
   emoji: string | null
@@ -44,6 +45,7 @@ export interface Categoria {
   orden: number
   categoria_padre_id: UUID | null
   creado_en: string
+  es_global: boolean
 }
 
 export interface Movimiento {

--- a/lib/types/database.ts
+++ b/lib/types/database.ts
@@ -152,32 +152,38 @@ export type Database = {
           color: string
           id: string
           organizacion_id: string
+          delegacion_id: string | null
           nombre: string
           tipo: string
           emoji: string | null
           orden: number
           categoria_padre_id: string | null
           creado_en: string
+          es_global: boolean
         }
         Insert: {
           id?: string
           organizacion_id: string
+          delegacion_id?: string | null
           nombre: string
           tipo: string
           emoji?: string | null
           orden?: number
           categoria_padre_id?: string | null
           creado_en?: string
+          es_global?: boolean
         }
         Update: {
           id?: string
           organizacion_id?: string
+          delegacion_id?: string | null
           nombre?: string
           tipo?: string
           emoji?: string | null
           orden?: number
           categoria_padre_id?: string | null
           creado_en?: string
+          es_global?: boolean
         }
       }
       membresia: {


### PR DESCRIPTION
## Summary
- add scope management in the category list so only global categories stay shared and delegation categories stay local
- allow gestores centrales to marcar/desmarcar categorías globales desde el formulario de edición y mostrar una insignia en la lista
- actualizar tipos y consultas de categorías para incluir `delegacion_id` y `es_global`

## Testing
- pnpm lint *(falla: falta @eslint/eslintrc)*

------
https://chatgpt.com/codex/tasks/task_e_68c9ac9df5a0832691924b80ebf2d4f8