### PR TITLE
Fetch sidebar counters from Supabase

### DIFF
--- a/app/transacciones/page.tsx
+++ b/app/transacciones/page.tsx
@@ -1,20 +1,17 @@
 "use client"
 
-import { useState } from "react"
 import { AppLayout } from "@/components/app-layout"
 import { TransactionManager } from "@/components/transactions/transaction-manager"
 
 export default function TransaccionesPage() {
-  const [transactionCount, setTransactionCount] = useState<number>(0)
-
   return (
-    <AppLayout transactionCount={transactionCount}>
+    <AppLayout>
       <div className="space-y-6">
         <div>
           <h1 className="text-3xl font-bold tracking-tight">Movimientos</h1>
           <p className="text-muted-foreground">Categoriza los ingresos o gastos en el banco y del efectivo</p>
         </div>
-        <TransactionManager onTransactionCountChange={setTransactionCount} />
+        <TransactionManager />
       </div>
     </AppLayout>
   )

--- a/components/app-layout.tsx
+++ b/components/app-layout.tsx
@@ -11,10 +11,9 @@ import { cn } from "@/lib/utils"
 
 interface AppLayoutProps {
   children: React.ReactNode
-  transactionCount?: number // Added prop for transaction count
 }
 
-export function AppLayout({ children, transactionCount }: AppLayoutProps) {
+export function AppLayout({ children }: AppLayoutProps) {
   const { selectedDelegation, setSelectedDelegation } = useDelegationContext()
   const { user, loading } = useAuth()
   const router = useRouter()
@@ -72,7 +71,6 @@ export function AppLayout({ children, transactionCount }: AppLayoutProps) {
       <Sidebar
         collapsed={sidebarCollapsed}
         onToggleCollapse={() => setSidebarCollapsed(!sidebarCollapsed)}
-        transactionCount={transactionCount} // Pass transaction count to sidebar
         showMobileTrigger={false}
       />
 

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -9,11 +9,9 @@ import {
   Building2,
   FileText,
   BarChart3,
-  Bell,
   Banknote,
   Settings,
   Users,
-  Zap,
   Activity,
   Menu,
   ChevronLeft,
@@ -22,16 +20,23 @@ import {
 import { Button } from "@/components/ui/button"
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
 import useIsAdmin from "@/hooks/use-is-admin"
+import { useDelegationContext } from "@/contexts/delegation-context"
+import { useEntityCounts } from "@/hooks/use-entity-counts"
 
 interface SidebarContentProps {
   className?: string
   collapsed?: boolean
-  transactionCount?: number // Added transaction count prop
 }
 
-function SidebarContent({ className, collapsed = false, transactionCount }: SidebarContentProps) {
+function SidebarContent({ className, collapsed = false }: SidebarContentProps) {
   const pathname = usePathname()
   const isAdmin = useIsAdmin()
+  const { selectedDelegation, getCurrentDelegation } = useDelegationContext()
+  const currentDelegation = getCurrentDelegation()
+  const { counts } = useEntityCounts({
+    delegacionId: selectedDelegation,
+    organizacionId: currentDelegation?.organizacion_id ?? null,
+  })
 
   const navigation = [
     {
@@ -45,42 +50,42 @@ function SidebarContent({ className, collapsed = false, transactionCount }: Side
       name: "Movimientos",
       href: "/transacciones",
       icon: ArrowLeftRight,
-      count: transactionCount || 6, // Use dynamic transaction count
+      count: counts.movimientos,
       enabled: true,
     },
     {
       name: "Categorías",
       href: "/categorias",
       icon: Tag,
-      count: 7,
+      count: counts.categorias,
       enabled: true,
     },
     {
       name: "Cuentas",
       href: "/cuentas",
       icon: Banknote,
-      count: 3,
+      count: counts.cuentas,
       enabled: true,
     },
     {
       name: "Facturas",
       href: "/facturas",
       icon: FileText,
-      count: 0,
+      count: null,
       enabled: false,
     },
     {
       name: "Informes",
       href: "/informes",
       icon: BarChart3,
-      count: 0,
+      count: null,
       enabled: false,
     },
     {
       name: "Contactos",
       href: "/contactos",
       icon: Users,
-      count: 14,
+      count: null,
       enabled: false,
     },
     ...(isAdmin
@@ -178,7 +183,6 @@ function SidebarContent({ className, collapsed = false, transactionCount }: Side
 interface SidebarProps {
   collapsed?: boolean
   onToggleCollapse?: () => void
-  transactionCount?: number // Added transaction count prop
   showDesktop?: boolean
   showMobileTrigger?: boolean
 }
@@ -186,7 +190,6 @@ interface SidebarProps {
 export function Sidebar({
   collapsed = false,
   onToggleCollapse,
-  transactionCount,
   showDesktop = true,
   showMobileTrigger = true,
 }: SidebarProps) {
@@ -200,7 +203,7 @@ export function Sidebar({
             collapsed ? "lg:w-16" : "lg:w-72",
           )}
         >
-          <SidebarContent collapsed={collapsed} transactionCount={transactionCount} />
+          <SidebarContent collapsed={collapsed} />
 
           {/* Collapse Toggle Button */}
           <div className="absolute -right-3 top-8">
@@ -226,7 +229,7 @@ export function Sidebar({
             </Button>
           </SheetTrigger>
           <SheetContent side="left" className="w-72 p-0">
-            <SidebarContent transactionCount={transactionCount} />
+            <SidebarContent />
           </SheetContent>
         </Sheet>
       )}

--- a/components/transactions/transaction-manager.tsx
+++ b/components/transactions/transaction-manager.tsx
@@ -42,11 +42,7 @@ export interface TransactionFilters {
   uncategorized?: boolean
 }
 
-interface TransactionManagerProps {
-  onTransactionCountChange?: (count: number) => void
-}
-
-export function TransactionManager({ onTransactionCountChange }: TransactionManagerProps) {
+export function TransactionManager() {
   const {
     selectedDelegation,
     setSelectedDelegation,
@@ -189,12 +185,6 @@ export function TransactionManager({ onTransactionCountChange }: TransactionMana
     }
     return value !== undefined && value !== "" && value !== false
   })
-
-  useEffect(() => {
-    if (onTransactionCountChange) {
-      onTransactionCountChange(movements.length)
-    }
-  }, [movements.length, onTransactionCountChange])
 
   useEffect(() => {
     if (!selectedMovementId) {

--- a/hooks/use-entity-counts.ts
+++ b/hooks/use-entity-counts.ts
@@ -1,0 +1,199 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import { supabase } from "@/lib/supabase/client"
+
+type EntityCounts = {
+  movimientos: number | null
+  categorias: number | null
+  cuentas: number | null
+}
+
+interface UseEntityCountsOptions {
+  delegacionId: string | null
+  organizacionId: string | null
+  timeoutMs?: number
+}
+
+const DEFAULT_TIMEOUT_MS = 15000
+
+function isAbortError(error: unknown): boolean {
+  if (error instanceof DOMException) {
+    return error.name === "AbortError"
+  }
+  if (typeof error === "object" && error !== null && "name" in error) {
+    const name = (error as { name?: unknown }).name
+    return typeof name === "string" && name === "AbortError"
+  }
+  return false
+}
+
+export function useEntityCounts({
+  delegacionId,
+  organizacionId,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+}: UseEntityCountsOptions) {
+  const [counts, setCounts] = useState<EntityCounts>({
+    movimientos: null,
+    categorias: null,
+    cuentas: null,
+  })
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchCount = useCallback(
+    async (
+      table: "movimiento" | "cuenta" | "categoria",
+      filters: ReadonlyArray<{ column: string; value: string | number | boolean | null }>,
+      signal: AbortSignal,
+    ) => {
+      let query = supabase.from(table).select("id", { count: "exact", head: true })
+      for (const filter of filters) {
+        query = query.eq(filter.column, filter.value)
+      }
+      const { count, error } = await query.abortSignal(signal)
+      if (error) {
+        throw error
+      }
+      return count ?? 0
+    },
+    [],
+  )
+
+  const loadCounts = useCallback(
+    async (signal: AbortSignal): Promise<EntityCounts> => {
+      if (!delegacionId) {
+        return {
+          movimientos: null,
+          categorias: null,
+          cuentas: null,
+        }
+      }
+
+      const tasks: Array<[keyof EntityCounts, Promise<number>]> = [
+        [
+          "movimientos",
+          fetchCount(
+            "movimiento",
+            [{ column: "delegacion_id", value: delegacionId }],
+            signal,
+          ),
+        ],
+        [
+          "cuentas",
+          fetchCount(
+            "cuenta",
+            [{ column: "delegacion_id", value: delegacionId }],
+            signal,
+          ),
+        ],
+      ]
+
+      if (organizacionId) {
+        tasks.push([
+          "categorias",
+          fetchCount(
+            "categoria",
+            [{ column: "organizacion_id", value: organizacionId }],
+            signal,
+          ),
+        ])
+      }
+
+      const results = await Promise.all(tasks.map(([, promise]) => promise))
+
+      const nextCounts: EntityCounts = {
+        movimientos: 0,
+        categorias: organizacionId ? 0 : null,
+        cuentas: 0,
+      }
+
+      tasks.forEach(([key], index) => {
+        nextCounts[key] = results[index]
+      })
+
+      if (!organizacionId) {
+        nextCounts.categorias = null
+      }
+
+      return nextCounts
+    },
+    [delegacionId, organizacionId, fetchCount],
+  )
+
+  const refetch = useCallback(async () => {
+    if (!delegacionId) {
+      const emptyCounts: EntityCounts = {
+        movimientos: null,
+        categorias: null,
+        cuentas: null,
+      }
+      setCounts(emptyCounts)
+      setError(null)
+      setLoading(false)
+      return emptyCounts
+    }
+
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+
+    try {
+      setLoading(true)
+      setError(null)
+      const result = await loadCounts(controller.signal)
+      setCounts(result)
+      return result
+    } catch (err) {
+      if (isAbortError(err)) {
+        return counts
+      }
+      const message = err instanceof Error ? err.message : "Error al obtener los contadores"
+      setError(message)
+      throw err
+    } finally {
+      clearTimeout(timeoutId)
+      setLoading(false)
+    }
+  }, [counts, delegacionId, loadCounts, timeoutMs])
+
+  useEffect(() => {
+    if (!delegacionId) {
+      setCounts({ movimientos: null, categorias: null, cuentas: null })
+      setError(null)
+      setLoading(false)
+      return
+    }
+
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+    let isActive = true
+
+    setLoading(true)
+    setError(null)
+
+    loadCounts(controller.signal)
+      .then((result) => {
+        if (!isActive) return
+        setCounts(result)
+      })
+      .catch((err) => {
+        if (!isActive || isAbortError(err)) return
+        const message = err instanceof Error ? err.message : "Error al obtener los contadores"
+        setError(message)
+      })
+      .finally(() => {
+        clearTimeout(timeoutId)
+        if (isActive) {
+          setLoading(false)
+        }
+      })
+
+    return () => {
+      isActive = false
+      clearTimeout(timeoutId)
+      controller.abort()
+    }
+  }, [delegacionId, loadCounts, timeoutMs])
+
+  return { counts, loading, error, refetch }
+}


### PR DESCRIPTION
## Summary
- add a `useEntityCounts` hook that requests Supabase head counts for movimientos, cuentas y categorías scoped to la delegación actual
- connect the sidebar badges to the new hook so it shows real per-delegación totals and hides unfinished sections
- drop the manual transaction count plumbing from the layout and movimientos page now that counts come from Supabase

## Testing
- pnpm exec eslint hooks/use-entity-counts.ts
- pnpm lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c9ac9a9bb88326b86b3d2754efb9fe