### PR TITLE
feat: mostrar totales reales en la sidebar

### DIFF
--- a/app/transacciones/page.tsx
+++ b/app/transacciones/page.tsx
@@ -1,20 +1,17 @@
 "use client"
 
-import { useState } from "react"
 import { AppLayout } from "@/components/app-layout"
 import { TransactionManager } from "@/components/transactions/transaction-manager"
 
 export default function TransaccionesPage() {
-  const [transactionCount, setTransactionCount] = useState<number>(0)
-
   return (
-    <AppLayout transactionCount={transactionCount}>
+    <AppLayout>
       <div className="space-y-6">
         <div>
           <h1 className="text-3xl font-bold tracking-tight">Movimientos</h1>
           <p className="text-muted-foreground">Categoriza los ingresos o gastos en el banco y del efectivo</p>
         </div>
-        <TransactionManager onTransactionCountChange={setTransactionCount} />
+        <TransactionManager />
       </div>
     </AppLayout>
   )

--- a/components/app-layout.tsx
+++ b/components/app-layout.tsx
@@ -11,10 +11,9 @@ import { cn } from "@/lib/utils"
 
 interface AppLayoutProps {
   children: React.ReactNode
-  transactionCount?: number // Added prop for transaction count
 }
 
-export function AppLayout({ children, transactionCount }: AppLayoutProps) {
+export function AppLayout({ children }: AppLayoutProps) {
   const { selectedDelegation, setSelectedDelegation } = useDelegationContext()
   const { user, loading } = useAuth()
   const router = useRouter()
@@ -72,7 +71,6 @@ export function AppLayout({ children, transactionCount }: AppLayoutProps) {
       <Sidebar
         collapsed={sidebarCollapsed}
         onToggleCollapse={() => setSidebarCollapsed(!sidebarCollapsed)}
-        transactionCount={transactionCount} // Pass transaction count to sidebar
         showMobileTrigger={false}
       />
 

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -22,16 +22,26 @@ import {
 import { Button } from "@/components/ui/button"
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
 import useIsAdmin from "@/hooks/use-is-admin"
+import { useDelegationCounts } from "@/hooks/use-delegation-counts"
+import type { DelegationCounts } from "@/hooks/use-delegation-counts"
 
 interface SidebarContentProps {
   className?: string
   collapsed?: boolean
-  transactionCount?: number // Added transaction count prop
+  counts: DelegationCounts
+  countsLoading: boolean
 }
 
-function SidebarContent({ className, collapsed = false, transactionCount }: SidebarContentProps) {
+function SidebarContent({ className, collapsed = false, counts, countsLoading }: SidebarContentProps) {
   const pathname = usePathname()
   const isAdmin = useIsAdmin()
+
+  const getCountBadge = (value: number | null) => {
+    if (typeof value === "number") {
+      return value
+    }
+    return countsLoading ? "…" : null
+  }
 
   const navigation = [
     {
@@ -45,42 +55,42 @@ function SidebarContent({ className, collapsed = false, transactionCount }: Side
       name: "Movimientos",
       href: "/transacciones",
       icon: ArrowLeftRight,
-      count: transactionCount || 6, // Use dynamic transaction count
+      count: getCountBadge(counts.movimientos),
       enabled: true,
     },
     {
       name: "Categorías",
       href: "/categorias",
       icon: Tag,
-      count: 7,
+      count: getCountBadge(counts.categorias),
       enabled: true,
     },
     {
       name: "Cuentas",
       href: "/cuentas",
       icon: Banknote,
-      count: 3,
+      count: getCountBadge(counts.cuentas),
       enabled: true,
     },
     {
       name: "Facturas",
       href: "/facturas",
       icon: FileText,
-      count: 0,
+      count: null,
       enabled: false,
     },
     {
       name: "Informes",
       href: "/informes",
       icon: BarChart3,
-      count: 0,
+      count: null,
       enabled: false,
     },
     {
       name: "Contactos",
       href: "/contactos",
       icon: Users,
-      count: 14,
+      count: null,
       enabled: false,
     },
     ...(isAdmin
@@ -178,7 +188,6 @@ function SidebarContent({ className, collapsed = false, transactionCount }: Side
 interface SidebarProps {
   collapsed?: boolean
   onToggleCollapse?: () => void
-  transactionCount?: number // Added transaction count prop
   showDesktop?: boolean
   showMobileTrigger?: boolean
 }
@@ -186,10 +195,11 @@ interface SidebarProps {
 export function Sidebar({
   collapsed = false,
   onToggleCollapse,
-  transactionCount,
   showDesktop = true,
   showMobileTrigger = true,
 }: SidebarProps) {
+  const { counts, loading: countsLoading } = useDelegationCounts()
+
   return (
     <>
       {/* Desktop Sidebar */}
@@ -200,7 +210,7 @@ export function Sidebar({
             collapsed ? "lg:w-16" : "lg:w-72",
           )}
         >
-          <SidebarContent collapsed={collapsed} transactionCount={transactionCount} />
+          <SidebarContent collapsed={collapsed} counts={counts} countsLoading={countsLoading} />
 
           {/* Collapse Toggle Button */}
           <div className="absolute -right-3 top-8">
@@ -226,7 +236,7 @@ export function Sidebar({
             </Button>
           </SheetTrigger>
           <SheetContent side="left" className="w-72 p-0">
-            <SidebarContent transactionCount={transactionCount} />
+            <SidebarContent counts={counts} countsLoading={countsLoading} />
           </SheetContent>
         </Sheet>
       )}

--- a/components/transactions/transaction-manager.tsx
+++ b/components/transactions/transaction-manager.tsx
@@ -42,11 +42,7 @@ export interface TransactionFilters {
   uncategorized?: boolean
 }
 
-interface TransactionManagerProps {
-  onTransactionCountChange?: (count: number) => void
-}
-
-export function TransactionManager({ onTransactionCountChange }: TransactionManagerProps) {
+export function TransactionManager() {
   const {
     selectedDelegation,
     setSelectedDelegation,
@@ -189,12 +185,6 @@ export function TransactionManager({ onTransactionCountChange }: TransactionMana
     }
     return value !== undefined && value !== "" && value !== false
   })
-
-  useEffect(() => {
-    if (onTransactionCountChange) {
-      onTransactionCountChange(movements.length)
-    }
-  }, [movements.length, onTransactionCountChange])
 
   useEffect(() => {
     if (!selectedMovementId) {

--- a/hooks/use-delegation-counts.ts
+++ b/hooks/use-delegation-counts.ts
@@ -1,0 +1,157 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+import { supabase } from "@/lib/supabase/client"
+import { useDelegationContext } from "@/contexts/delegation-context"
+import { runQuery } from "@/lib/db/query"
+import { useRevalidateOnFocusJitter } from "@/hooks/use-app-status"
+
+export interface DelegationCounts {
+  movimientos: number | null
+  categorias: number | null
+  cuentas: number | null
+}
+
+const INITIAL_COUNTS: DelegationCounts = {
+  movimientos: null,
+  categorias: null,
+  cuentas: null,
+}
+
+const QUERY_TIMEOUT_MS = 10000
+
+export function useDelegationCounts() {
+  const { selectedDelegation, getCurrentDelegation } = useDelegationContext()
+
+  const [counts, setCounts] = useState<DelegationCounts>(INITIAL_COUNTS)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const requestRef = useRef(0)
+  const lastDelegationRef = useRef<string | null>(null)
+
+  const fetchCounts = useCallback(async () => {
+    const delegationId = selectedDelegation
+
+    if (!delegationId) {
+      lastDelegationRef.current = null
+      setCounts(INITIAL_COUNTS)
+      setLoading(false)
+      setError(null)
+      return
+    }
+
+    if (lastDelegationRef.current !== delegationId) {
+      lastDelegationRef.current = delegationId
+      setCounts(INITIAL_COUNTS)
+    }
+
+    const fetchId = ++requestRef.current
+    setLoading(true)
+    setError(null)
+
+    const delegation = getCurrentDelegation()
+    const organizacionId = delegation?.organizacion_id ?? null
+
+    try {
+      const [movimientosRes, cuentasRes, categoriasRes] = await Promise.all([
+        runQuery<{ count: number | null }>({
+          label: "count-movimientos",
+          table: "movimiento",
+          timeoutMs: QUERY_TIMEOUT_MS,
+          build: async (signal) => {
+            const { count, error } = await supabase
+              .from("movimiento")
+              .select("id", { head: true, count: "exact" })
+              .eq("delegacion_id", delegationId)
+              .abortSignal(signal)
+            return { data: { count: typeof count === "number" ? count : 0 }, error }
+          },
+        }),
+        runQuery<{ count: number | null }>({
+          label: "count-cuentas",
+          table: "cuenta",
+          timeoutMs: QUERY_TIMEOUT_MS,
+          build: async (signal) => {
+            const { count, error } = await supabase
+              .from("cuenta")
+              .select("id", { head: true, count: "exact" })
+              .eq("delegacion_id", delegationId)
+              .abortSignal(signal)
+            return { data: { count: typeof count === "number" ? count : 0 }, error }
+          },
+        }),
+        organizacionId
+          ? runQuery<{ count: number | null }>({
+              label: "count-categorias",
+              table: "categoria",
+              timeoutMs: QUERY_TIMEOUT_MS,
+              build: async (signal) => {
+                const { count, error } = await supabase
+                  .from("categoria")
+                  .select("id", { head: true, count: "exact" })
+                  .eq("organizacion_id", organizacionId)
+                  .abortSignal(signal)
+                return { data: { count: typeof count === "number" ? count : 0 }, error }
+              },
+            })
+          : Promise.resolve({ data: { count: null }, error: null }),
+      ])
+
+      if (requestRef.current !== fetchId) return
+
+      const nextCounts: DelegationCounts = {
+        movimientos: movimientosRes.error ? null : movimientosRes.data?.count ?? 0,
+        cuentas: cuentasRes.error ? null : cuentasRes.data?.count ?? 0,
+        categorias:
+          organizacionId === null
+            ? null
+            : categoriasRes.error
+              ? null
+              : categoriasRes.data?.count ?? 0,
+      }
+
+      const hasError =
+        Boolean(movimientosRes.error) ||
+        Boolean(cuentasRes.error) ||
+        (organizacionId !== null && Boolean(categoriasRes.error))
+
+      if (hasError) {
+        console.warn("⚠️ useDelegationCounts: error loading counts", {
+          movimientosError: movimientosRes.error,
+          cuentasError: cuentasRes.error,
+          categoriasError: categoriasRes.error,
+        })
+        setError("No se pudieron cargar todos los totales")
+      } else {
+        setError(null)
+      }
+
+      setCounts(nextCounts)
+    } catch (err) {
+      if (requestRef.current !== fetchId) return
+      console.error("❌ useDelegationCounts: unexpected error", err)
+      setCounts(INITIAL_COUNTS)
+      setError(err instanceof Error ? err.message : "No se pudieron cargar los totales")
+    } finally {
+      if (requestRef.current === fetchId) {
+        setLoading(false)
+      }
+    }
+  }, [selectedDelegation, getCurrentDelegation])
+
+  useEffect(() => {
+    fetchCounts()
+  }, [fetchCounts])
+
+  useRevalidateOnFocusJitter(fetchCounts, { minMs: 80, maxMs: 180 })
+
+  return {
+    counts,
+    loading,
+    error,
+    refresh: fetchCounts,
+  }
+}
+
+export { INITIAL_COUNTS as INITIAL_DELEGATION_COUNTS }


### PR DESCRIPTION
## Summary
- crear el hook `useDelegationCounts` para contar movimientos, cuentas y categorías desde Supabase usando solo consultas de conteo
- actualizar el sidebar para consumir los totales dinámicos de la delegación seleccionada y ocultar los badges de secciones no implementadas
- simplificar el layout de movimientos eliminando el recuento manual basado en la tabla paginada

## Testing
- `pnpm lint` *(falla por errores de lint preexistentes en archivos no modificados)*

------
https://chatgpt.com/codex/tasks/task_e_68c9ac9a9bb88326b86b3d2754efb9fe