### PR TITLE
feat: panel de propuestas de mejora

### DIFF
--- a/app/propuestas/page.tsx
+++ b/app/propuestas/page.tsx
@@ -1,0 +1,12 @@
+"use client"
+
+import { AppLayout } from "@/components/app-layout"
+import { ImprovementProposalsPanel } from "@/components/improvement-proposals/proposals-panel"
+
+export default function PropuestasPage() {
+  return (
+    <AppLayout>
+      <ImprovementProposalsPanel />
+    </AppLayout>
+  )
+}

--- a/components/improvement-proposals/create-proposal-dialog.tsx
+++ b/components/improvement-proposals/create-proposal-dialog.tsx
@@ -1,0 +1,152 @@
+"use client"
+
+import { useEffect, useState, type FormEvent } from "react"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { Badge } from "@/components/ui/badge"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Loader2, Sparkles } from "lucide-react"
+
+interface CreateProposalDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSubmit: (values: { title: string; description: string; impact?: string | null }) => Promise<void>
+}
+
+export function CreateProposalDialog({ open, onOpenChange, onSubmit }: CreateProposalDialogProps) {
+  const [title, setTitle] = useState("")
+  const [description, setDescription] = useState("")
+  const [impact, setImpact] = useState("")
+  const [submitting, setSubmitting] = useState(false)
+  const [formError, setFormError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!open) {
+      setFormError(null)
+      setSubmitting(false)
+    }
+  }, [open])
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setFormError(null)
+
+    try {
+      setSubmitting(true)
+      await onSubmit({ title, description, impact: impact || null })
+      setTitle("")
+      setDescription("")
+      setImpact("")
+      onOpenChange(false)
+    } catch (error) {
+      setFormError(
+        error instanceof Error
+          ? error.message
+          : "No pudimos guardar tu propuesta. Intenta otra vez",
+      )
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const disableSubmit = submitting || !title.trim() || !description.trim()
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-xl gap-0 overflow-hidden p-0">
+        <DialogHeader className="space-y-4 bg-gradient-to-br from-indigo-600 via-blue-600 to-sky-500 p-6 text-white">
+          <div className="flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-white/20 backdrop-blur">
+              <Sparkles className="h-5 w-5" />
+            </div>
+            <div className="text-left">
+              <DialogTitle className="text-xl font-semibold text-white">
+                Comparte una idea brillante
+              </DialogTitle>
+              <DialogDescription className="text-white/80">
+                Todas las personas registradas pueden proponer mejoras. Cuéntanos qué haría más especial a MCM
+                Bank.
+              </DialogDescription>
+            </div>
+          </div>
+          <div className="flex flex-wrap items-center gap-2 text-left text-sm text-white/80">
+            <Badge className="bg-white/20 text-white hover:bg-white/30">Sin moderación</Badge>
+            <span>Las propuestas se verán al instante en el panel de ideas.</span>
+          </div>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-6 bg-background p-6">
+          <div className="space-y-2">
+            <label htmlFor="proposal-title" className="text-sm font-medium text-foreground">
+              Título de tu propuesta
+            </label>
+            <Input
+              id="proposal-title"
+              placeholder="Añadir pagos con Bizum, unificar filtros, crear informes..."
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              maxLength={120}
+            />
+            <p className="text-xs text-muted-foreground">Sé concreto y resume la esencia de tu idea.</p>
+          </div>
+
+          <div className="space-y-2">
+            <label htmlFor="proposal-description" className="text-sm font-medium text-foreground">
+              ¿Qué problema resuelve o qué aporta?
+            </label>
+            <Textarea
+              id="proposal-description"
+              placeholder="Describe el contexto, qué mejorarías y qué impacto tendría para la comunidad."
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              rows={5}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <label htmlFor="proposal-impact" className="text-sm font-medium text-foreground">
+              Impacto esperado (opcional)
+            </label>
+            <Input
+              id="proposal-impact"
+              placeholder="Ej. Reducir el tiempo de conciliación un 50%, mejorar la transparencia..."
+              value={impact}
+              onChange={(event) => setImpact(event.target.value)}
+            />
+          </div>
+
+          {formError && (
+            <Alert variant="destructive">
+              <AlertTitle>Ups, algo salió mal</AlertTitle>
+              <AlertDescription>{formError}</AlertDescription>
+            </Alert>
+          )}
+
+          <div className="flex flex-col-reverse gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-sm text-muted-foreground">
+              Tu nombre se mostrará junto a la propuesta para celebrar quién la propuso.
+            </p>
+            <Button type="submit" disabled={disableSubmit} className="sm:w-auto">
+              {submitting ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Enviando idea...
+                </>
+              ) : (
+                "Publicar propuesta"
+              )}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/improvement-proposals/proposal-card.tsx
+++ b/components/improvement-proposals/proposal-card.tsx
@@ -1,0 +1,180 @@
+"use client"
+
+import { Avatar, AvatarFallback } from "@/components/ui/avatar"
+import { Badge } from "@/components/ui/badge"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { cn } from "@/lib/utils"
+import {
+  type ImprovementProposalStatus,
+  IMPROVEMENT_PROPOSAL_STATUS_LABELS,
+  type ImprovementProposalWithAuthor,
+  IMPROVEMENT_PROPOSAL_STATUSES,
+} from "@/lib/types/improvement-proposals"
+import type { ImprovementProposalStatusVisualConfig } from "./status-config"
+import { Clock, Sparkles } from "lucide-react"
+import { useMemo } from "react"
+
+interface ProposalCardProps {
+  proposal: ImprovementProposalWithAuthor
+  statusConfig: ImprovementProposalStatusVisualConfig
+  onStatusChange?: (status: ImprovementProposalStatus) => void
+  isAdmin?: boolean
+  disabled?: boolean
+}
+
+function getInitials(name?: string | null, email?: string | null) {
+  if (name && name.trim()) {
+    const parts = name.trim().split(/\s+/)
+    if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase()
+    return (parts[0].charAt(0) + parts[parts.length - 1].charAt(0)).toUpperCase()
+  }
+  if (email) {
+    const username = email.split("@")[0]
+    const sanitized = username.replace(/\./g, " ")
+    const segments = sanitized.split(/\s+/)
+    if (segments.length === 1) return segments[0].slice(0, 2).toUpperCase()
+    return (segments[0].charAt(0) + segments[segments.length - 1].charAt(0)).toUpperCase()
+  }
+  return "?"
+}
+
+function formatRelativeDate(value?: string | null) {
+  if (!value) return null
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return null
+
+  const now = new Date()
+  const diffMs = date.getTime() - now.getTime()
+  const diffSeconds = Math.round(diffMs / 1000)
+
+  const thresholds = [
+    { limit: 60, unit: "segundo", seconds: 1 },
+    { limit: 3600, unit: "minuto", seconds: 60 },
+    { limit: 86400, unit: "hora", seconds: 3600 },
+    { limit: 604800, unit: "día", seconds: 86400 },
+    { limit: 2629800, unit: "semana", seconds: 604800 },
+    { limit: 31557600, unit: "mes", seconds: 2629800 },
+  ] as const
+
+  const absoluteSeconds = Math.abs(diffSeconds)
+
+  for (const threshold of thresholds) {
+    if (absoluteSeconds < threshold.limit) {
+      const value = Math.floor(absoluteSeconds / threshold.seconds) || 1
+      const suffix = value === 1 ? threshold.unit : `${threshold.unit}s`
+      return diffSeconds >= 0 ? `en ${value} ${suffix}` : `hace ${value} ${suffix}`
+    }
+  }
+
+  const years = Math.floor(absoluteSeconds / 31557600)
+  return diffSeconds >= 0 ? `en ${years} ${years === 1 ? "año" : "años"}` : `hace ${years} ${years === 1 ? "año" : "años"}`
+}
+
+export function ProposalCard({
+  proposal,
+  statusConfig,
+  onStatusChange,
+  isAdmin = false,
+  disabled = false,
+}: ProposalCardProps) {
+  const createdAgo = useMemo(() => formatRelativeDate(proposal.creado_en), [proposal.creado_en])
+  const updatedAgo = useMemo(() => formatRelativeDate(proposal.actualizado_en), [proposal.actualizado_en])
+  const statusOptions = useMemo(() => IMPROVEMENT_PROPOSAL_STATUSES, [])
+
+  return (
+    <div
+      className="group relative overflow-hidden rounded-2xl border border-border/60 bg-card/80 shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg"
+    >
+      <div
+        className={cn(
+          "pointer-events-none absolute inset-x-5 top-4 h-1 rounded-full opacity-90",
+          "bg-gradient-to-r",
+          statusConfig.accentGradient,
+        )}
+      />
+
+      <div className="space-y-5 p-5">
+        <div className="flex items-start justify-between gap-3">
+          <div className="space-y-2">
+            <Badge
+              className={cn(
+                "border px-3 py-1 text-xs font-semibold uppercase tracking-wide",
+                statusConfig.badgeClassName,
+              )}
+            >
+              {statusConfig.label}
+            </Badge>
+            <h3 className="text-lg font-semibold text-foreground">{proposal.titulo}</h3>
+          </div>
+          {createdAgo && (
+            <span className="flex items-center gap-1 text-xs text-muted-foreground">
+              <Clock className="h-3.5 w-3.5" /> {createdAgo}
+            </span>
+          )}
+        </div>
+
+        <p
+          className="text-sm leading-relaxed text-muted-foreground"
+          style={{
+            display: "-webkit-box",
+            WebkitLineClamp: 4,
+            WebkitBoxOrient: "vertical",
+            overflow: "hidden",
+          }}
+        >
+          {proposal.descripcion}
+        </p>
+
+        {proposal.impacto && (
+          <div className="rounded-2xl border border-amber-200/60 bg-amber-50/80 px-4 py-3 text-sm text-amber-700 shadow-inner dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-200">
+            <div className="flex items-center gap-2 font-medium">
+              <Sparkles className="h-4 w-4" /> Impacto esperado
+            </div>
+            <p className="mt-1 text-xs leading-relaxed text-amber-800/80 dark:text-amber-100/90">
+              {proposal.impacto}
+            </p>
+          </div>
+        )}
+
+        <div className="flex flex-col gap-4 border-t border-dashed border-border/60 pt-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-3">
+            <Avatar className="h-10 w-10">
+              <AvatarFallback className="bg-muted text-sm font-semibold uppercase">
+                {getInitials(proposal.authorName, proposal.creado_por_email)}
+              </AvatarFallback>
+            </Avatar>
+            <div className="space-y-0.5 text-sm">
+              <p className="font-medium leading-tight text-foreground">{proposal.authorName}</p>
+              <p className="text-xs text-muted-foreground">
+                {updatedAgo ? `Actualizada ${updatedAgo}` : "Aún sin actualizar"}
+              </p>
+            </div>
+          </div>
+
+          {isAdmin && onStatusChange ? (
+            <Select
+              value={proposal.estado}
+              onValueChange={(value) => onStatusChange(value as ImprovementProposalStatus)}
+              disabled={disabled}
+            >
+              <SelectTrigger className="h-10 w-full rounded-xl border-border/60 bg-background/80 text-xs font-medium uppercase tracking-wide sm:w-[180px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {statusOptions.map((status) => (
+                  <SelectItem key={status} value={status} className="text-sm">
+                    {IMPROVEMENT_PROPOSAL_STATUS_LABELS[status]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          ) : (
+            <div className="rounded-xl border border-border/60 px-3 py-2 text-xs text-muted-foreground">
+              {statusConfig.description}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/improvement-proposals/proposals-board.tsx
+++ b/components/improvement-proposals/proposals-board.tsx
@@ -1,0 +1,153 @@
+"use client"
+
+import { useMemo } from "react"
+import { ProposalCard } from "./proposal-card"
+import { IMPROVEMENT_PROPOSAL_STATUS_CONFIG } from "./status-config"
+import {
+  type ImprovementProposalWithAuthor,
+  type ImprovementProposalStatus,
+  IMPROVEMENT_PROPOSAL_STATUSES,
+} from "@/lib/types/improvement-proposals"
+import { cn } from "@/lib/utils"
+import { LoadingSpinner } from "@/components/ui/loading-spinner"
+import { EmptyState } from "@/components/ui/empty-state"
+import { Lightbulb } from "lucide-react"
+
+interface ProposalsBoardProps {
+  proposals: ImprovementProposalWithAuthor[]
+  loading?: boolean
+  refreshing?: boolean
+  showCompleted?: boolean
+  isAdmin?: boolean
+  onStatusChange?: (proposalId: string, status: ImprovementProposalStatus) => Promise<void>
+  updatingId?: string | null
+}
+
+export function ProposalsBoard({
+  proposals,
+  loading = false,
+  refreshing = false,
+  showCompleted = false,
+  isAdmin = false,
+  onStatusChange,
+  updatingId,
+}: ProposalsBoardProps) {
+  const statusOrder = useMemo(() => {
+    return showCompleted
+      ? IMPROVEMENT_PROPOSAL_STATUSES
+      : IMPROVEMENT_PROPOSAL_STATUSES.filter((status) => status !== "hechisimo")
+  }, [showCompleted])
+
+  const grouped = useMemo(() => {
+    return statusOrder.map((status) => ({
+      status,
+      proposals: proposals.filter((proposal) => proposal.estado === status),
+    }))
+  }, [proposals, statusOrder])
+
+  const hiddenCompleted = !showCompleted
+    ? proposals.filter((proposal) => proposal.estado === "hechisimo").length
+    : 0
+
+  if (loading && proposals.length === 0) {
+    return (
+      <div className="flex min-h-[280px] flex-col items-center justify-center gap-4 rounded-3xl border border-dashed border-border/60 bg-muted/10 p-10 text-muted-foreground">
+        <LoadingSpinner />
+        <p>Cargando propuestas de mejora...</p>
+      </div>
+    )
+  }
+
+  if (proposals.length === 0) {
+    return (
+      <EmptyState
+        title="Aún no hay propuestas de mejora"
+        description="Sé la primera persona en compartir una idea para potenciar MCM Bank. ¡Queremos escucharte!"
+        icon={<Lightbulb className="h-6 w-6" />}
+      />
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {refreshing && (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <LoadingSpinner className="h-3.5 w-3.5" size="sm" /> Sincronizando ideas...
+        </div>
+      )}
+
+      <div className="overflow-x-auto pb-4">
+        <div
+          className={cn(
+            "flex gap-6",
+            statusOrder.length >= 3 ? "min-w-[960px]" : "min-w-full",
+          )}
+        >
+          {grouped.map(({ status, proposals: columnProposals }) => {
+            const config = IMPROVEMENT_PROPOSAL_STATUS_CONFIG[status]
+
+            return (
+              <div
+                key={status}
+                className="flex w-[260px] flex-shrink-0 flex-col gap-4 sm:w-[300px] lg:w-[340px] xl:w-[360px]"
+              >
+                <div
+                  className={cn(
+                    "rounded-3xl border border-border/50 bg-card/70 p-5 shadow-sm backdrop-blur-sm",
+                    config.headerBackground,
+                  )}
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <h3 className="text-base font-semibold text-foreground">{config.label}</h3>
+                      <p className="text-xs text-muted-foreground">{config.description}</p>
+                    </div>
+                    <span className="rounded-full bg-background/80 px-3 py-1 text-xs font-semibold text-muted-foreground">
+                      {columnProposals.length}
+                    </span>
+                  </div>
+                </div>
+
+                <div className="space-y-4">
+                  {columnProposals.length === 0 ? (
+                    <div className="rounded-2xl border border-dashed border-border/60 bg-muted/10 p-5 text-center text-xs text-muted-foreground">
+                      Aún no hay ideas en esta fase.
+                    </div>
+                  ) : (
+                    columnProposals.map((proposal) => (
+                      <ProposalCard
+                        key={proposal.id}
+                        proposal={proposal}
+                        statusConfig={config}
+                        isAdmin={isAdmin}
+                        disabled={updatingId === proposal.id}
+                        onStatusChange={
+                          onStatusChange
+                            ? async (nextStatus) => {
+                                try {
+                                  await onStatusChange(proposal.id, nextStatus)
+                                } catch (updateError) {
+                                  console.error("Error updating proposal status", updateError)
+                                }
+                              }
+                            : undefined
+                        }
+                      />
+                    ))
+                  )}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+
+      {hiddenCompleted > 0 && (
+        <div className="rounded-2xl border border-emerald-200/70 bg-emerald-50/80 px-4 py-3 text-sm text-emerald-700 shadow-inner dark:border-emerald-500/40 dark:bg-emerald-500/10 dark:text-emerald-100">
+          Hay {hiddenCompleted} propuesta{hiddenCompleted === 1 ? "" : "s"} celebrada{hiddenCompleted === 1 ? "" : "s"} en
+          Hechísimo. Usa el filtro para verlas y celebrar los logros.
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/improvement-proposals/proposals-panel.tsx
+++ b/components/improvement-proposals/proposals-panel.tsx
@@ -1,0 +1,213 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import { Sparkles, PartyPopper, EyeOff, Eye, RefreshCw } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { ProposalsBoard } from "./proposals-board"
+import { CreateProposalDialog } from "./create-proposal-dialog"
+import { useImprovementProposals } from "@/hooks/use-improvement-proposals"
+import useIsAdmin from "@/hooks/use-is-admin"
+import { toast } from "sonner"
+import { cn } from "@/lib/utils"
+import type { ImprovementProposalStatus } from "@/lib/types/improvement-proposals"
+
+export function ImprovementProposalsPanel() {
+  const {
+    proposals,
+    loading,
+    refreshing,
+    error,
+    createProposal,
+    updateProposalStatus,
+    refetch,
+    statusLabels,
+  } = useImprovementProposals()
+  const isAdmin = useIsAdmin()
+
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [showCompleted, setShowCompleted] = useState(false)
+  const [updatingId, setUpdatingId] = useState<string | null>(null)
+  const [manualRefresh, setManualRefresh] = useState(false)
+
+  const stats = useMemo(() => {
+    const total = proposals.length
+    const celebrating = proposals.filter((proposal) => proposal.estado === "hechisimo").length
+    const active = proposals.filter((proposal) => proposal.estado !== "hechisimo").length
+    const fresh = proposals.filter((proposal) => proposal.estado === "nueva_idea").length
+
+    return { total, celebrating, active, fresh }
+  }, [proposals])
+
+  const handleCreateProposal = async (values: { title: string; description: string; impact?: string | null }) => {
+    try {
+      await createProposal(values)
+      toast.success("¡Gracias por compartir tu idea! ✨")
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "No pudimos guardar tu propuesta. Intenta de nuevo más tarde."
+      toast.error(message)
+      throw err
+    }
+  }
+
+  const handleStatusChange = async (proposalId: string, status: ImprovementProposalStatus) => {
+    try {
+      setUpdatingId(proposalId)
+      await updateProposalStatus(proposalId, status)
+      toast.success(`Estado actualizado a ${statusLabels[status]}`)
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "No pudimos actualizar el estado de la idea. Intenta más tarde."
+      toast.error(message)
+      throw err
+    } finally {
+      setUpdatingId(null)
+    }
+  }
+
+  const handleRefresh = async () => {
+    try {
+      setManualRefresh(true)
+      await refetch()
+      toast.success("Ideas actualizadas")
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "No pudimos actualizar la lista de ideas. Vuelve a intentarlo."
+      toast.error(message)
+    } finally {
+      setManualRefresh(false)
+    }
+  }
+
+  const showCelebratedToggle = proposals.some((proposal) => proposal.estado === "hechisimo")
+
+  return (
+    <div className="space-y-8">
+      <section className="relative overflow-hidden rounded-3xl border border-primary/10 bg-gradient-to-br from-indigo-600 via-blue-600 to-sky-500 text-white shadow-lg">
+        <div className="pointer-events-none absolute -left-20 -top-16 h-56 w-56 rounded-full bg-white/20 blur-3xl" />
+        <div className="pointer-events-none absolute -bottom-24 right-0 h-64 w-64 rounded-full bg-sky-400/30 blur-3xl" />
+
+        <div className="relative grid gap-8 p-8 md:grid-cols-[2fr_1fr] md:p-10">
+          <div className="space-y-6">
+            <div className="inline-flex items-center gap-2 rounded-full bg-white/20 px-4 py-1 text-sm font-medium uppercase tracking-wide text-white/90">
+              <Sparkles className="h-4 w-4" /> Propuestas de mejora
+            </div>
+            <div className="space-y-3">
+              <h1 className="text-3xl font-semibold leading-tight md:text-4xl">
+                Impulsemos juntos el futuro de MCM Bank
+              </h1>
+              <p className="text-base text-white/80 md:max-w-xl">
+                Comparte ideas, inspírate con otras personas y sigue cómo evolucionan las mejoras que marcarán la diferencia.
+              </p>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-3">
+              <Button
+                type="button"
+                size="lg"
+                onClick={() => setDialogOpen(true)}
+                className="rounded-full bg-white text-indigo-700 shadow-lg shadow-indigo-900/20 transition hover:bg-white/90"
+              >
+                <PartyPopper className="mr-2 h-5 w-5" /> Compartir idea
+              </Button>
+
+              {showCelebratedToggle && (
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="lg"
+                  onClick={() => setShowCompleted((prev) => !prev)}
+                  className={cn(
+                    "rounded-full border-white/30 bg-white/20 text-white hover:bg-white/30",
+                    showCompleted && "bg-white text-indigo-700 hover:bg-white/90",
+                  )}
+                >
+                  {showCompleted ? (
+                    <>
+                      <EyeOff className="mr-2 h-5 w-5" /> Ocultar Hechísimo
+                    </>
+                  ) : (
+                    <>
+                      <Eye className="mr-2 h-5 w-5" /> Mostrar Hechísimo
+                    </>
+                  )}
+                </Button>
+              )}
+
+              <Button
+                type="button"
+                variant="secondary"
+                size="lg"
+                onClick={handleRefresh}
+                disabled={manualRefresh || loading}
+                className="rounded-full border-white/30 bg-white/10 text-white hover:bg-white/20"
+              >
+                <RefreshCw className={cn("mr-2 h-5 w-5", manualRefresh && "animate-spin")} />
+                Refrescar
+              </Button>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-3 text-sm text-white/80">
+              <Badge className="bg-white/20 text-white hover:bg-white/30">Todos ven todo</Badge>
+              <Badge className="bg-white/20 text-white hover:bg-white/30">Sin moderación previa</Badge>
+              {isAdmin && <Badge className="bg-white text-indigo-700 hover:bg-white">Control gestor central</Badge>}
+            </div>
+          </div>
+
+          <div className="relative rounded-3xl border border-white/30 bg-white/10 p-6 text-white shadow-inner backdrop-blur">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-white/70">Panorama actual</h2>
+            <div className="mt-4 space-y-4">
+              <div>
+                <p className="text-4xl font-semibold">{stats.total}</p>
+                <p className="text-sm text-white/70">ideas activas en el panel</p>
+              </div>
+              <div className="grid grid-cols-2 gap-4 text-sm">
+                <div>
+                  <p className="text-2xl font-semibold">{stats.fresh}</p>
+                  <p className="text-xs text-white/70">recién llegadas</p>
+                </div>
+                <div>
+                  <p className="text-2xl font-semibold">{stats.active}</p>
+                  <p className="text-xs text-white/70">en movimiento</p>
+                </div>
+                <div>
+                  <p className="text-2xl font-semibold">{stats.celebrating}</p>
+                  <p className="text-xs text-white/70">celebradas</p>
+                </div>
+                <div>
+                  <p className="text-2xl font-semibold">{showCompleted ? stats.celebrating : stats.active}</p>
+                  <p className="text-xs text-white/70">{showCompleted ? "visibles" : "a la vista"}</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {error && (
+        <Alert variant="destructive">
+          <AlertTitle>Ha ocurrido un problema</AlertTitle>
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      <ProposalsBoard
+        proposals={proposals}
+        loading={loading}
+        refreshing={refreshing || manualRefresh}
+        showCompleted={showCompleted}
+        isAdmin={isAdmin}
+        updatingId={updatingId}
+        onStatusChange={isAdmin ? handleStatusChange : undefined}
+      />
+
+      <CreateProposalDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        onSubmit={handleCreateProposal}
+      />
+    </div>
+  )
+}

--- a/components/improvement-proposals/status-config.ts
+++ b/components/improvement-proposals/status-config.ts
@@ -1,0 +1,74 @@
+import type { LucideIcon } from "lucide-react"
+import {
+  Sparkles,
+  Search,
+  CalendarCheck,
+  Hammer,
+  Trophy,
+} from "lucide-react"
+import type { ImprovementProposalStatus } from "@/lib/types/improvement-proposals"
+
+export interface ImprovementProposalStatusVisualConfig {
+  label: string
+  description: string
+  accentGradient: string
+  badgeClassName: string
+  headerBackground: string
+  icon: LucideIcon
+}
+
+export const IMPROVEMENT_PROPOSAL_STATUS_CONFIG: Record<
+  ImprovementProposalStatus,
+  ImprovementProposalStatusVisualConfig
+> = {
+  nueva_idea: {
+    label: "Nueva idea",
+    description: "Chispazos creativos recién llegados",
+    accentGradient: "from-pink-500 via-rose-500 to-orange-400",
+    badgeClassName:
+      "bg-rose-100 text-rose-700 border-rose-200 dark:bg-rose-500/20 dark:text-rose-100 dark:border-rose-500/40",
+    headerBackground:
+      "bg-gradient-to-br from-rose-500/10 via-orange-400/10 to-transparent",
+    icon: Sparkles,
+  },
+  en_estudio: {
+    label: "En estudio",
+    description: "Analizando viabilidad y alcance",
+    accentGradient: "from-indigo-500 via-purple-500 to-sky-500",
+    badgeClassName:
+      "bg-indigo-100 text-indigo-700 border-indigo-200 dark:bg-indigo-500/20 dark:text-indigo-100 dark:border-indigo-500/40",
+    headerBackground:
+      "bg-gradient-to-br from-indigo-500/10 via-purple-500/10 to-transparent",
+    icon: Search,
+  },
+  lo_haremos: {
+    label: "Lo haremos",
+    description: "Priorizadas y listas para planificarse",
+    accentGradient: "from-amber-400 via-orange-400 to-yellow-500",
+    badgeClassName:
+      "bg-amber-100 text-amber-700 border-amber-200 dark:bg-amber-500/20 dark:text-amber-100 dark:border-amber-500/40",
+    headerBackground:
+      "bg-gradient-to-br from-amber-500/10 via-orange-500/10 to-transparent",
+    icon: CalendarCheck,
+  },
+  en_desarrollo: {
+    label: "En desarrollo",
+    description: "El equipo está construyendo la mejora",
+    accentGradient: "from-teal-400 via-cyan-400 to-blue-500",
+    badgeClassName:
+      "bg-teal-100 text-teal-700 border-teal-200 dark:bg-teal-500/20 dark:text-teal-100 dark:border-teal-500/40",
+    headerBackground:
+      "bg-gradient-to-br from-teal-500/10 via-cyan-500/10 to-transparent",
+    icon: Hammer,
+  },
+  hechisimo: {
+    label: "Hechísimo",
+    description: "Listas para celebrarlo 🎉",
+    accentGradient: "from-emerald-400 via-lime-400 to-green-500",
+    badgeClassName:
+      "bg-emerald-100 text-emerald-700 border-emerald-200 dark:bg-emerald-500/20 dark:text-emerald-100 dark:border-emerald-500/40",
+    headerBackground:
+      "bg-gradient-to-br from-emerald-500/10 via-lime-500/10 to-transparent",
+    icon: Trophy,
+  },
+}

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -18,6 +18,7 @@ import {
   Menu,
   ChevronLeft,
   ChevronRight,
+  Sparkles,
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
@@ -38,6 +39,13 @@ function SidebarContent({ className, collapsed = false, transactionCount }: Side
       name: "Dashboard",
       href: "/",
       icon: LayoutDashboard,
+      count: null,
+      enabled: true,
+    },
+    {
+      name: "Propuestas",
+      href: "/propuestas",
+      icon: Sparkles,
       count: null,
       enabled: true,
     },

--- a/hooks/use-improvement-proposals.ts
+++ b/hooks/use-improvement-proposals.ts
@@ -1,0 +1,244 @@
+"use client"
+
+import { useState, useCallback, useEffect, useRef } from "react"
+import { supabase } from "@/lib/supabase/client"
+import { runQuery } from "@/lib/db/query"
+import type {
+  ImprovementProposal,
+  ImprovementProposalInsert,
+  ImprovementProposalStatus,
+  ImprovementProposalWithAuthor,
+} from "@/lib/types/improvement-proposals"
+import { IMPROVEMENT_PROPOSAL_STATUS_LABELS } from "@/lib/types/improvement-proposals"
+
+interface CreateImprovementProposalInput {
+  title: string
+  description: string
+  impact?: string | null
+}
+
+export function useImprovementProposals() {
+  const [proposals, setProposals] = useState<ImprovementProposalWithAuthor[]>([])
+  const [loading, setLoading] = useState(true)
+  const [refreshing, setRefreshing] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const hasFetchedRef = useRef(false)
+
+  const enrichWithAuthor = useCallback(async (rows: ImprovementProposal[]) => {
+    if (rows.length === 0) return [] as ImprovementProposalWithAuthor[]
+
+    const userIds = Array.from(
+      new Set(rows.map((row) => row.creado_por).filter(Boolean)),
+    ) as string[]
+
+    let profilesMap: Record<string, string> = {}
+
+    if (userIds.length > 0) {
+      try {
+        const { data: profiles, error: profilesError } = await supabase
+          .from("perfil")
+          .select("usuario_id, nombre_completo")
+          .in("usuario_id", userIds)
+
+        if (profilesError) {
+          console.error("Error fetching profiles for proposals", profilesError)
+        } else if (profiles) {
+          profilesMap = profiles.reduce<Record<string, string>>((acc, perfil) => {
+            if (perfil.nombre_completo && perfil.nombre_completo.trim()) {
+              acc[perfil.usuario_id] = perfil.nombre_completo
+            }
+            return acc
+          }, {})
+        }
+      } catch (profilesErr) {
+        console.error("Unexpected error loading proposal profiles", profilesErr)
+      }
+    }
+
+    return rows.map((row) => ({
+      ...row,
+      authorName:
+        row.creado_por_nombre?.trim() ||
+        profilesMap[row.creado_por] ||
+        row.creado_por_email?.split("@")[0]?.replace(/\./g, " ")?.replace(/\b\w/g, (match) => match.toUpperCase()) ||
+        "Usuario anónimo",
+    }))
+  }, [])
+
+  const fetchProposals = useCallback(async () => {
+    if (!hasFetchedRef.current) {
+      setLoading(true)
+    } else {
+      setRefreshing(true)
+    }
+
+    try {
+      setError(null)
+      const { data, error: fetchError } = await runQuery<ImprovementProposal[]>({
+        label: "fetch-improvement-proposals",
+        table: "propuesta_mejora",
+        build: async (signal) =>
+          await supabase
+            .from("propuesta_mejora")
+            .select("*")
+            .order("estado", { ascending: true })
+            .order("creado_en", { ascending: false })
+            .abortSignal(signal),
+      })
+
+      if (fetchError) {
+        console.error("Error fetching improvement proposals", fetchError)
+        setError(
+          fetchError?.message ||
+            "No pudimos cargar las propuestas de mejora. Intenta de nuevo más tarde.",
+        )
+        return
+      }
+
+      const enriched = await enrichWithAuthor(data ?? [])
+      setProposals(enriched)
+    } catch (err) {
+      console.error("Unexpected error loading improvement proposals", err)
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Ha ocurrido un error al cargar las propuestas.",
+      )
+    } finally {
+      hasFetchedRef.current = true
+      setLoading(false)
+      setRefreshing(false)
+    }
+  }, [enrichWithAuthor])
+
+  const createProposal = useCallback(
+    async ({ title, description, impact }: CreateImprovementProposalInput) => {
+      const trimmedTitle = title.trim()
+      const trimmedDescription = description.trim()
+      const trimmedImpact = impact?.trim()
+
+      if (!trimmedTitle) throw new Error("El título es obligatorio")
+      if (!trimmedDescription) throw new Error("Cuéntanos un poco sobre tu idea")
+
+      const {
+        data: { user },
+        error: authError,
+      } = await supabase.auth.getUser()
+
+      if (authError) throw authError
+      if (!user) throw new Error("Necesitas iniciar sesión para proponer una mejora")
+
+      let authorName = user.email?.split("@")[0] || "Usuario"
+
+      try {
+        const { data: perfil } = await supabase
+          .from("perfil")
+          .select("nombre_completo")
+          .eq("usuario_id", user.id)
+          .maybeSingle()
+        if (perfil?.nombre_completo && perfil.nombre_completo.trim()) {
+          authorName = perfil.nombre_completo
+        } else if (user.user_metadata?.full_name) {
+          authorName = user.user_metadata.full_name
+        }
+      } catch (profileError) {
+        console.warn("No pudimos obtener el perfil del usuario", profileError)
+      }
+
+      const payload: ImprovementProposalInsert = {
+        titulo: trimmedTitle,
+        descripcion: trimmedDescription,
+        impacto: trimmedImpact || null,
+        estado: "nueva_idea",
+        creado_por: user.id,
+        creado_por_nombre: authorName,
+        creado_por_email: user.email ?? null,
+      }
+
+      const { data, error: insertError } = await supabase
+        .from("propuesta_mejora")
+        .insert(payload)
+        .select("*")
+        .single()
+
+      if (insertError) {
+        console.error("Error creating improvement proposal", insertError)
+        throw insertError
+      }
+
+      const newProposal: ImprovementProposalWithAuthor = {
+        ...(data as ImprovementProposal),
+        authorName,
+      }
+
+      setProposals((prev) => [newProposal, ...prev])
+      return newProposal
+    },
+    [],
+  )
+
+  const updateProposalStatus = useCallback(
+    async (id: string, status: ImprovementProposalStatus) => {
+      if (!id) throw new Error("Identificador de propuesta no válido")
+
+      const { data, error: updateError } = await supabase
+        .from("propuesta_mejora")
+        .update({
+          estado: status,
+          actualizado_en: new Date().toISOString(),
+        })
+        .eq("id", id)
+        .select("*")
+        .single()
+
+      if (updateError) {
+        console.error("Error updating proposal status", updateError)
+        throw updateError
+      }
+
+      setProposals((prev) =>
+        prev.map((proposal) =>
+          proposal.id === id
+            ? {
+                ...(data as ImprovementProposal),
+                authorName: proposal.authorName,
+              }
+            : proposal,
+        ),
+      )
+    },
+    [],
+  )
+
+  useEffect(() => {
+    fetchProposals()
+  }, [fetchProposals])
+
+  useEffect(() => {
+    const channel = supabase
+      .channel("propuestas-mejora-channel")
+      .on(
+        "postgres_changes",
+        { event: "*", schema: "public", table: "propuesta_mejora" },
+        () => {
+          fetchProposals()
+        },
+      )
+      .subscribe()
+
+    return () => {
+      supabase.removeChannel(channel)
+    }
+  }, [fetchProposals])
+
+  return {
+    proposals,
+    loading,
+    refreshing,
+    error,
+    createProposal,
+    updateProposalStatus,
+    refetch: fetchProposals,
+    statusLabels: IMPROVEMENT_PROPOSAL_STATUS_LABELS,
+  }
+}

--- a/lib/types/database.ts
+++ b/lib/types/database.ts
@@ -261,6 +261,44 @@ export type Database = {
           subido_en?: string
         }
       }
+      propuesta_mejora: {
+        Row: {
+          id: string
+          titulo: string
+          descripcion: string
+          impacto: string | null
+          estado: "nueva_idea" | "en_estudio" | "lo_haremos" | "en_desarrollo" | "hechisimo"
+          creado_por: string
+          creado_por_nombre: string | null
+          creado_por_email: string | null
+          creado_en: string
+          actualizado_en: string | null
+        }
+        Insert: {
+          id?: string
+          titulo: string
+          descripcion: string
+          impacto?: string | null
+          estado?: "nueva_idea" | "en_estudio" | "lo_haremos" | "en_desarrollo" | "hechisimo"
+          creado_por: string
+          creado_por_nombre?: string | null
+          creado_por_email?: string | null
+          creado_en?: string
+          actualizado_en?: string | null
+        }
+        Update: {
+          id?: string
+          titulo?: string
+          descripcion?: string
+          impacto?: string | null
+          estado?: "nueva_idea" | "en_estudio" | "lo_haremos" | "en_desarrollo" | "hechisimo"
+          creado_por?: string
+          creado_por_nombre?: string | null
+          creado_por_email?: string | null
+          creado_en?: string
+          actualizado_en?: string | null
+        }
+      }
     }
   }
 }
@@ -273,6 +311,7 @@ export type Categoria = Database["public"]["Tables"]["categoria"]["Row"]
 export type Membresia = Database["public"]["Tables"]["membresia"]["Row"]
 export type Perfil = Database["public"]["Tables"]["perfil"]["Row"]
 export type MovimientoArchivo = Database["public"]["Tables"]["movimiento_archivo"]["Row"]
+export type PropuestaMejora = Database["public"]["Tables"]["propuesta_mejora"]["Row"]
 
 // Extended types with relations
 export type MovimientoConRelaciones = Movimiento & {

--- a/lib/types/improvement-proposals.ts
+++ b/lib/types/improvement-proposals.ts
@@ -1,0 +1,26 @@
+import type { Database } from "./database"
+
+export type ImprovementProposal = Database["public"]["Tables"]["propuesta_mejora"]["Row"]
+export type ImprovementProposalInsert = Database["public"]["Tables"]["propuesta_mejora"]["Insert"]
+export type ImprovementProposalUpdate = Database["public"]["Tables"]["propuesta_mejora"]["Update"]
+export type ImprovementProposalStatus = ImprovementProposal["estado"]
+
+export interface ImprovementProposalWithAuthor extends ImprovementProposal {
+  authorName: string
+}
+
+export const IMPROVEMENT_PROPOSAL_STATUSES: ImprovementProposalStatus[] = [
+  "nueva_idea",
+  "en_estudio",
+  "lo_haremos",
+  "en_desarrollo",
+  "hechisimo",
+]
+
+export const IMPROVEMENT_PROPOSAL_STATUS_LABELS: Record<ImprovementProposalStatus, string> = {
+  nueva_idea: "Nueva idea",
+  en_estudio: "En estudio",
+  lo_haremos: "Lo haremos",
+  en_desarrollo: "En desarrollo",
+  hechisimo: "Hechísimo",
+}

--- a/scripts/008_create_propuesta_mejora_table.sql
+++ b/scripts/008_create_propuesta_mejora_table.sql
@@ -1,0 +1,66 @@
+-- Tabla de propuestas de mejora para el panel colaborativo
+CREATE TABLE IF NOT EXISTS public.propuesta_mejora (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  titulo TEXT NOT NULL,
+  descripcion TEXT NOT NULL,
+  impacto TEXT,
+  estado TEXT NOT NULL DEFAULT 'nueva_idea' CHECK (
+    estado IN ('nueva_idea', 'en_estudio', 'lo_haremos', 'en_desarrollo', 'hechisimo')
+  ),
+  creado_por UUID NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+  creado_por_nombre TEXT,
+  creado_por_email TEXT,
+  creado_en TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now()),
+  actualizado_en TIMESTAMPTZ
+);
+
+COMMENT ON TABLE public.propuesta_mejora IS 'Ideas y propuestas de mejora de la aplicación aportadas por la comunidad';
+COMMENT ON COLUMN public.propuesta_mejora.estado IS 'Workflow: nueva_idea, en_estudio, lo_haremos, en_desarrollo, hechisimo';
+
+ALTER TABLE public.propuesta_mejora ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY IF NOT EXISTS "Propuestas visibles para usuarios" ON public.propuesta_mejora
+  FOR SELECT
+  USING (auth.role() = 'authenticated');
+
+CREATE POLICY IF NOT EXISTS "Cualquier persona autenticada puede proponer" ON public.propuesta_mejora
+  FOR INSERT
+  WITH CHECK (auth.uid() = creado_por);
+
+CREATE POLICY IF NOT EXISTS "Quien crea puede editar su idea" ON public.propuesta_mejora
+  FOR UPDATE
+  USING (auth.uid() = creado_por)
+  WITH CHECK (auth.uid() = creado_por);
+
+CREATE POLICY IF NOT EXISTS "Gestor central puede gestionar propuestas" ON public.propuesta_mejora
+  FOR UPDATE
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.membresia m
+      WHERE m.usuario_id = auth.uid()
+        AND m.rol = 'gestor_central'
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.membresia m
+      WHERE m.usuario_id = auth.uid()
+        AND m.rol = 'gestor_central'
+    )
+  );
+
+CREATE POLICY IF NOT EXISTS "Gestor central puede eliminar propuestas" ON public.propuesta_mejora
+  FOR DELETE
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.membresia m
+      WHERE m.usuario_id = auth.uid()
+        AND m.rol = 'gestor_central'
+    )
+  );
+
+CREATE INDEX IF NOT EXISTS propuesta_mejora_estado_idx ON public.propuesta_mejora (estado);
+CREATE INDEX IF NOT EXISTS propuesta_mejora_creado_en_idx ON public.propuesta_mejora (creado_en DESC);


### PR DESCRIPTION
## Summary
- incorpora un panel de propuestas de mejora con hero inspiracional, estadísticas y tablero kanban con filtros
- añade diálogo de envío de ideas, tarjetas enriquecidas y hook cliente para gestionar creación y cambios de estado vía Supabase
- actualiza tipos, navegación lateral y documenta la tabla/protecciones en un script SQL

## Testing
- pnpm lint *(falla por advertencias/errores previos en el repositorio)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c09bcba483269d28a62e955f9484