### PR TITLE
feat: selección múltiple de transacciones

### DIFF
--- a/components/transactions/category-mega-selector.tsx
+++ b/components/transactions/category-mega-selector.tsx
@@ -19,6 +19,7 @@ interface CategoryMegaSelectorProps {
   movement?: Movimiento | null
   account?: Cuenta | null
   onCreateCategory?: () => void
+  bulkSelectionLabel?: string
 }
 
 interface CategoryGroup {
@@ -34,6 +35,7 @@ export function CategoryMegaSelector({
   movement,
   account,
   onCreateCategory,
+  bulkSelectionLabel,
 }: CategoryMegaSelectorProps) {
   const [searchValue, setSearchValue] = useState("")
   const inputRef = useRef<HTMLInputElement>(null)
@@ -108,24 +110,39 @@ export function CategoryMegaSelector({
     <div className="bg-background shadow-xl border border-border/40 w-full max-w-3xl h-full sm:h-auto max-h-screen sm:max-h-[calc(100vh-4rem)] rounded-t-3xl sm:rounded-3xl overflow-hidden flex flex-col">
       <div className="border-b bg-muted/40 p-4 sm:p-6">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:gap-6">
-          {movement && (
-            <div className="flex flex-1 items-start gap-3 sm:items-center">
-              <div className="flex-shrink-0 rounded-full p-0.5 border border-border/40 shadow-sm">
-                <BankAvatar account={account || undefined} size="sm" />
-              </div>
-              <div className="space-y-1 min-w-0">
-                <p className="text-[11px] tracking-wide text-muted-foreground uppercase">
-                  {account?.nombre || account?.banco_nombre || "Cuenta sin nombre"}
-                </p>
-                <h2 className="text-base font-semibold leading-tight line-clamp-2 sm:line-clamp-1">{movement.concepto}</h2>
-                {(movement.contraparte || movement.descripcion) && (
-                  <p className="text-sm text-muted-foreground line-clamp-1">
-                    {movement.contraparte || movement.descripcion}
+          <div className="flex flex-1 items-start gap-3 sm:items-center">
+            {movement ? (
+              <>
+                <div className="flex-shrink-0 rounded-full p-0.5 border border-border/40 shadow-sm">
+                  <BankAvatar account={account || undefined} size="sm" />
+                </div>
+                <div className="space-y-1 min-w-0">
+                  <p className="text-[11px] tracking-wide text-muted-foreground uppercase">
+                    {account?.nombre || account?.banco_nombre || "Cuenta sin nombre"}
                   </p>
-                )}
+                  <h2 className="text-base font-semibold leading-tight line-clamp-2 sm:line-clamp-1">{movement.concepto}</h2>
+                  {(movement.contraparte || movement.descripcion) && (
+                    <p className="text-sm text-muted-foreground line-clamp-1">
+                      {movement.contraparte || movement.descripcion}
+                    </p>
+                  )}
+                </div>
+              </>
+            ) : bulkSelectionLabel ? (
+              <div className="flex items-start gap-3">
+                <div className="hidden h-11 w-11 flex-shrink-0 items-center justify-center rounded-full bg-primary/15 text-xl text-primary sm:flex">
+                  ✨
+                </div>
+                <div className="space-y-1">
+                  <p className="text-[11px] uppercase tracking-wide text-muted-foreground">Selección múltiple</p>
+                  <h2 className="text-base font-semibold leading-tight sm:text-lg">{bulkSelectionLabel}</h2>
+                  <p className="text-xs text-muted-foreground">
+                    Todas recibirán la misma categoría en un abrir y cerrar de ojos.
+                  </p>
+                </div>
               </div>
-            </div>
-          )}
+            ) : null}
+          </div>
 
           <div className="flex items-start justify-between gap-2 sm:flex-col sm:items-end sm:justify-start">
             {movement && (

--- a/components/transactions/transaction-list-row.tsx
+++ b/components/transactions/transaction-list-row.tsx
@@ -11,6 +11,7 @@ import { Input } from "@/components/ui/input"
 import { LoadingSpinner } from "@/components/ui/loading-spinner"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
 import { Pencil } from "lucide-react"
 import type { Movimiento, MovimientoConRelaciones, Cuenta, Categoria } from "@/lib/types/database"
 
@@ -22,6 +23,9 @@ interface TransactionListRowProps {
   onMovementUpdate: (movementId: string, patch: Partial<Movimiento>) => Promise<void>
   onClick: (movement: MovimientoConRelaciones, e: React.MouseEvent) => void
   onOpenFiles?: (movement: MovimientoConRelaciones) => void
+  isSelected: boolean
+  selectionActive: boolean
+  onSelectionChange: (selected: boolean) => void
 }
 
 export const TransactionListRow = memo(function TransactionListRow({
@@ -32,6 +36,9 @@ export const TransactionListRow = memo(function TransactionListRow({
   onMovementUpdate,
   onClick,
   onOpenFiles,
+  isSelected,
+  selectionActive,
+  onSelectionChange,
 }: TransactionListRowProps) {
   const [isUpdating, setIsUpdating] = useState(false)
   const [editing, setEditing] = useState(false)
@@ -81,16 +88,51 @@ export const TransactionListRow = memo(function TransactionListRow({
         data-delegation-id={account?.delegacion_id}
       >
         <div className="flex items-start gap-3">
-          <AccountTooltip account={account}>
+          <div className="relative flex-shrink-0 group" data-testid="transaction-selection">
+            <AccountTooltip account={account}>
+              <div
+                className={cn(
+                  "rounded-full p-0.5 cursor-pointer transition-all duration-200 shadow-sm",
+                  isSelected
+                    ? "scale-90 opacity-0"
+                    : selectionActive
+                    ? "scale-95 opacity-0"
+                    : "group-hover:scale-95 group-hover:opacity-0 group-hover:rotate-3",
+                )}
+                style={{ backgroundColor: account?.color || "#4ECDC4" }}
+                data-testid="account-info"
+                title={`Cuenta: ${account?.nombre || 'Sin nombre'} - Delegación ID: ${account?.delegacion_id || 'Sin delegación'}`}
+              >
+                <BankAvatar account={account} />
+              </div>
+            </AccountTooltip>
+
             <div
-              className="rounded-full p-0.5 cursor-pointer hover:scale-105 transition-transform flex-shrink-0 shadow-sm"
-              style={{ backgroundColor: account?.color || "#4ECDC4" }}
-              data-testid="account-info"
-              title={`Cuenta: ${account?.nombre || 'Sin nombre'} - Delegación ID: ${account?.delegacion_id || 'Sin delegación'}`}
+              className={cn(
+                "absolute inset-0 flex items-center justify-center transition-all duration-200",
+                isSelected
+                  ? "opacity-100 scale-100"
+                  : selectionActive
+                  ? "opacity-90 scale-100 pointer-events-auto"
+                  : "pointer-events-none opacity-0 scale-75 group-hover:pointer-events-auto group-hover:opacity-100 group-hover:scale-100",
+              )}
             >
-              <BankAvatar account={account} />
+              <Checkbox
+                checked={isSelected}
+                onCheckedChange={(checked) => {
+                  const isChecked = checked === true
+                  onSelectionChange(isChecked)
+                }}
+                className={cn(
+                  "h-6 w-6 border-2 text-base", // enlarge for better hit area
+                  isSelected ? "shadow-lg" : "shadow-sm",
+                )}
+                onClick={(event) => event.stopPropagation()}
+                onPointerDown={(event) => event.stopPropagation()}
+                aria-label={isSelected ? "Quitar de la selección" : "Añadir a la selección"}
+              />
             </div>
-          </AccountTooltip>
+          </div>
 
           <div className="flex-1 min-w-0">
             <div className="flex items-start justify-between gap-3">

--- a/components/transactions/transaction-list.tsx
+++ b/components/transactions/transaction-list.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useEffect, useRef, useMemo } from "react"
+import type React from "react"
 import { LoadingSpinner } from "@/components/ui/loading-spinner"
 import { ErrorMessage } from "@/components/ui/error-message"
 import { TransactionListRow } from "./transaction-list-row"
@@ -20,11 +21,13 @@ interface TransactionListProps {
   loading: boolean
   error: string | null
   total: number
-  onMovementClick: (movement: MovimientoConRelaciones) => void
+  onMovementClick: (movement: MovimientoConRelaciones, event?: React.MouseEvent) => void
   onMovementUpdate: (movementId: string, patch: Partial<Movimiento>) => Promise<void>
   onLoadMore?: () => void
   hasMore?: boolean
   onOpenFiles?: (movement: MovimientoConRelaciones) => void
+  selectedMovementIds: string[]
+  onMovementSelectionChange: (movementId: string, selected: boolean) => void
 }
 
 export function TransactionList({
@@ -39,6 +42,8 @@ export function TransactionList({
   onLoadMore,
   hasMore,
   onOpenFiles,
+  selectedMovementIds,
+  onMovementSelectionChange,
 }: TransactionListProps) {
   const loadMoreRef = useRef<HTMLDivElement | null>(null)
 
@@ -115,8 +120,11 @@ export function TransactionList({
           category={movement.categoria_id ? categoriesById[movement.categoria_id] : undefined}
           categories={categories}
           onMovementUpdate={onMovementUpdate}
-          onClick={onMovementClick}
+          onClick={(item, event) => onMovementClick(item, event)}
           onOpenFiles={onOpenFiles}
+          isSelected={selectedMovementIds.includes(movement.id)}
+          selectionActive={selectedMovementIds.length > 0}
+          onSelectionChange={(selected) => onMovementSelectionChange(movement.id, selected)}
         />
       ))}
       {hasMore && (

--- a/components/transactions/transaction-manager.tsx
+++ b/components/transactions/transaction-manager.tsx
@@ -1,12 +1,13 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useMemo } from "react"
 import { useSearchParams } from "next/navigation"
 import { TransactionFiltersComponent } from "./transaction-filters"
 import { TransactionList } from "./transaction-list"
 import { TransactionDetail } from "./transaction-detail"
 import { TransactionCreatePanel } from "./transaction-create-panel"
 import { DateRangeFilter } from "./date-range-filter"
+import { CategoryMegaSelector } from "./category-mega-selector"
 import { useDelegationContext } from "@/contexts/delegation-context"
 import { useMovimientos } from "@/hooks/use-movimientos"
 import { useCategorias } from "@/hooks/use-categorias"
@@ -22,13 +23,28 @@ import {
   Filter,
   ChevronUp,
   Check,
+  Tag,
+  Trash2,
+  Type,
+  FilePlus,
+  AlertTriangle,
 } from "lucide-react"
 import { toast } from "sonner"
 import { LoadingSpinner } from "@/components/ui/loading-spinner"
 import { exportMovementsToExcel } from "@/lib/utils/export-to-excel"
 import type { MovimientoConRelaciones, Categoria, Cuenta } from "@/lib/types/database"
 import { TransactionImportPanel } from "./transaction-import-panel"
-import { isDebugEnabled } from "@/lib/utils/debug"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
 
 export interface TransactionFilters {
   dateFrom?: string
@@ -59,6 +75,17 @@ export function TransactionManager() {
   const [createFormOpen, setCreateFormOpen] = useState(false)
   const [importOpen, setImportOpen] = useState(false)
   const [downloadState, setDownloadState] = useState<"idle" | "downloading" | "success">("idle")
+  const [selectedMovementIds, setSelectedMovementIds] = useState<string[]>([])
+  const [bulkCategoryOpen, setBulkCategoryOpen] = useState(false)
+  const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false)
+  const [bulkConceptOpen, setBulkConceptOpen] = useState(false)
+  const [bulkDescriptionOpen, setBulkDescriptionOpen] = useState(false)
+  const [bulkConceptValue, setBulkConceptValue] = useState("")
+  const [bulkDescriptionValue, setBulkDescriptionValue] = useState("")
+  const [bulkCategoryLoading, setBulkCategoryLoading] = useState(false)
+  const [bulkDeleting, setBulkDeleting] = useState(false)
+  const [bulkConceptLoading, setBulkConceptLoading] = useState(false)
+  const [bulkDescriptionLoading, setBulkDescriptionLoading] = useState(false)
   const searchParams = useSearchParams()
 
   const currentDelegation = getCurrentDelegation()
@@ -71,6 +98,7 @@ export function TransactionManager() {
     updateCategoria,
     updateMovimiento,
     createMovimiento,
+    deleteMovimientos,
     refetch,
     loadMore,
     hasMore,
@@ -87,6 +115,63 @@ export function TransactionManager() {
 
   const { categorias: categories } = useCategorias(selectedDelegation)
   const { cuentas: accounts } = useCuentas(selectedDelegation)
+
+  useEffect(() => {
+    if (movements.length === 0) {
+      setSelectedMovementIds((prev) => (prev.length === 0 ? prev : []))
+      return
+    }
+
+    const availableIds = new Set(movements.map((movement) => movement.id))
+    setSelectedMovementIds((prev) => {
+      const filtered = prev.filter((id) => availableIds.has(id))
+      return filtered.length === prev.length ? prev : filtered
+    })
+  }, [movements])
+
+  const selectedMovements = useMemo(
+    () => movements.filter((movement) => selectedMovementIds.includes(movement.id)),
+    [movements, selectedMovementIds],
+  )
+
+  const allVisibleMovementIds = useMemo(
+    () => movements.map((movement) => movement.id),
+    [movements],
+  )
+
+  const selectionCount = selectedMovementIds.length
+  const allVisibleSelected =
+    selectionCount > 0 && selectionCount === allVisibleMovementIds.length && allVisibleMovementIds.length > 0
+
+  const masterSelectionState: boolean | "indeterminate" = selectionCount
+    ? allVisibleSelected
+      ? true
+      : "indeterminate"
+    : false
+
+  const selectionActive = selectionCount > 0
+
+  const clearSelection = () => setSelectedMovementIds([])
+
+  const handleMovementSelectionChange = (movementId: string, selected: boolean) => {
+    setSelectedMovementIds((prev) => {
+      if (selected) {
+        if (prev.includes(movementId)) {
+          return prev
+        }
+        return [...prev, movementId]
+      }
+      return prev.filter((id) => id !== movementId)
+    })
+  }
+
+  const handleToggleSelectAllVisible = () => {
+    if (allVisibleSelected) {
+      clearSelection()
+    } else {
+      setSelectedMovementIds(allVisibleMovementIds)
+    }
+  }
 
   const handleDownload = async () => {
     setDownloadState("downloading")
@@ -109,6 +194,108 @@ export function TransactionManager() {
     setSelectedMovementId(movement.id)
     setSelectedMovementSnapshot(movement)
     setDetailInitialTab("datos")
+  }
+
+  const handleBulkCategorySelect = async (categoryId: string) => {
+    if (!selectionCount) {
+      return
+    }
+
+    setBulkCategoryLoading(true)
+    try {
+      await Promise.all(
+        selectedMovementIds.map((movementId) =>
+          handleMovementUpdate(movementId, { categoria_id: categoryId } as Partial<MovimientoConRelaciones>),
+        ),
+      )
+      toast.success(`Categoría actualizada en ${selectionCount} transacciones`)
+      setBulkCategoryOpen(false)
+      clearSelection()
+    } catch (error) {
+      console.error("Error updating categories in bulk", error)
+      toast.error("No se pudieron actualizar las categorías seleccionadas")
+    } finally {
+      setBulkCategoryLoading(false)
+    }
+  }
+
+  const handleBulkConceptSubmit = async () => {
+    const nextConcept = bulkConceptValue.trim()
+    if (!nextConcept) {
+      toast.error("Escribe un concepto para actualizar")
+      return
+    }
+
+    setBulkConceptLoading(true)
+    try {
+      await Promise.all(
+        selectedMovementIds.map((movementId) =>
+          handleMovementUpdate(movementId, { concepto: nextConcept }),
+        ),
+      )
+      toast.success(`Concepto actualizado en ${selectionCount} transacciones`)
+      setBulkConceptOpen(false)
+      setBulkConceptValue("")
+      clearSelection()
+    } catch (error) {
+      console.error("Error updating concept in bulk", error)
+      toast.error("No se pudieron actualizar los conceptos seleccionados")
+    } finally {
+      setBulkConceptLoading(false)
+    }
+  }
+
+  const handleBulkDescriptionSubmit = async () => {
+    const appendText = bulkDescriptionValue.trim()
+    if (!appendText) {
+      toast.error("Escribe un texto para añadir a la descripción")
+      return
+    }
+
+    setBulkDescriptionLoading(true)
+    try {
+      await Promise.all(
+        selectedMovements.map((movement) => {
+          const currentDescription = (movement.descripcion || "").trimEnd()
+          const newDescription = currentDescription
+            ? `${currentDescription}\n${appendText}`
+            : appendText
+          return handleMovementUpdate(movement.id, { descripcion: newDescription })
+        }),
+      )
+      toast.success(`Descripción ampliada en ${selectionCount} transacciones`)
+      setBulkDescriptionOpen(false)
+      setBulkDescriptionValue("")
+      clearSelection()
+    } catch (error) {
+      console.error("Error appending description in bulk", error)
+      toast.error("No se pudieron actualizar las descripciones seleccionadas")
+    } finally {
+      setBulkDescriptionLoading(false)
+    }
+  }
+
+  const handleBulkDelete = async () => {
+    if (!selectionCount) {
+      return
+    }
+
+    setBulkDeleting(true)
+    try {
+      await deleteMovimientos(selectedMovementIds)
+      if (selectedMovementId && selectedMovementIds.includes(selectedMovementId)) {
+        setSelectedMovementId(null)
+        setSelectedMovementSnapshot(null)
+      }
+      toast.success(`Has eliminado ${selectionCount} transacciones. ¡Adiós!`)
+      clearSelection()
+      setBulkDeleteOpen(false)
+    } catch (error) {
+      console.error("Error deleting movements in bulk", error)
+      toast.error("No se pudieron eliminar las transacciones seleccionadas")
+    } finally {
+      setBulkDeleting(false)
+    }
   }
 
   const handleOpenFiles = (movement: MovimientoConRelaciones) => {
@@ -386,6 +573,68 @@ export function TransactionManager() {
             </div>
           </div>
 
+          {selectionActive && (
+            <div className="rounded-xl border border-primary/30 bg-primary/10 p-3 sm:p-4 shadow-sm">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div className="flex flex-1 items-start gap-3">
+                  <Checkbox
+                    checked={masterSelectionState}
+                    onCheckedChange={handleToggleSelectAllVisible}
+                    className="mt-1 h-5 w-5 border-2"
+                    aria-label="Seleccionar todo lo visible"
+                  />
+                  <div className="space-y-1">
+                    <p className="text-sm font-semibold tracking-tight">
+                      {selectionCount} transacciones seleccionadas
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      Estas acciones aplican a las transacciones visibles, sin importar la cuenta de origen.
+                    </p>
+                  </div>
+                </div>
+
+                <div className="flex flex-wrap items-center gap-2">
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => setBulkCategoryOpen(true)}
+                    className="flex items-center gap-1"
+                  >
+                    <Tag className="h-4 w-4" />
+                    <span>Editar categoría</span>
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setBulkConceptOpen(true)}
+                    className="flex items-center gap-1"
+                  >
+                    <Type className="h-4 w-4" />
+                    <span>Unificar concepto</span>
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setBulkDescriptionOpen(true)}
+                    className="flex items-center gap-1"
+                  >
+                    <FilePlus className="h-4 w-4" />
+                    <span>Añadir nota</span>
+                  </Button>
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    onClick={() => setBulkDeleteOpen(true)}
+                    className="flex items-center gap-1"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                    <span>Eliminar</span>
+                  </Button>
+                </div>
+              </div>
+            </div>
+          )}
+
           {filtersOpen && (
             <Card className="lg:hidden p-4 border-2 border-blue-200 bg-blue-50/50 dark:bg-blue-950/20 dark:border-blue-800">
               <div className="flex items-center justify-between mb-4">
@@ -433,6 +682,8 @@ export function TransactionManager() {
             onLoadMore={loadMore}
             hasMore={hasMore}
             onOpenFiles={(movement) => handleOpenFiles(movement as unknown as MovimientoConRelaciones)}
+            selectedMovementIds={selectedMovementIds}
+            onMovementSelectionChange={handleMovementSelectionChange}
           />
         </div>
       </div>
@@ -479,6 +730,175 @@ export function TransactionManager() {
           }, 1000)
         }}
       />
+
+      <Dialog
+        open={bulkCategoryOpen}
+        onOpenChange={(open) => {
+          if (!bulkCategoryLoading) {
+            setBulkCategoryOpen(open)
+          }
+        }}
+      >
+        <DialogContent className="max-w-4xl w-full p-0 overflow-hidden">
+          <CategoryMegaSelector
+            categories={categories as unknown as Categoria[]}
+            selectedCategoryId={undefined}
+            onSelect={handleBulkCategorySelect}
+            onClose={() => setBulkCategoryOpen(false)}
+            bulkSelectionLabel={`${selectionCount} transacciones seleccionadas`}
+          />
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={bulkConceptOpen}
+        onOpenChange={(open) => {
+          if (!bulkConceptLoading) {
+            setBulkConceptOpen(open)
+            if (!open) {
+              setBulkConceptValue("")
+            }
+          }
+        }}
+      >
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Unificar concepto</DialogTitle>
+            <DialogDescription>
+              El nuevo concepto se aplicará a las {selectionCount} transacciones seleccionadas.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            <Input
+              value={bulkConceptValue}
+              onChange={(event) => setBulkConceptValue(event.target.value)}
+              placeholder="Introduce el concepto que compartirán todas"
+              autoFocus
+            />
+            <p className="text-xs text-muted-foreground">
+              Usa un nombre claro y con cariño. Si te arrepientes siempre puedes volver a editarlo individualmente.
+            </p>
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => {
+                if (!bulkConceptLoading) {
+                  setBulkConceptOpen(false)
+                  setBulkConceptValue("")
+                }
+              }}
+            >
+              Cancelar
+            </Button>
+            <Button type="button" onClick={handleBulkConceptSubmit} disabled={bulkConceptLoading}>
+              {bulkConceptLoading ? <LoadingSpinner size="sm" /> : "Aplicar concepto"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={bulkDescriptionOpen}
+        onOpenChange={(open) => {
+          if (!bulkDescriptionLoading) {
+            setBulkDescriptionOpen(open)
+            if (!open) {
+              setBulkDescriptionValue("")
+            }
+          }
+        }}
+      >
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Añadir nota a la descripción</DialogTitle>
+            <DialogDescription>
+              El texto que escribas se colocará al final de la descripción existente de cada transacción seleccionada.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            <Textarea
+              value={bulkDescriptionValue}
+              onChange={(event) => setBulkDescriptionValue(event.target.value)}
+              rows={4}
+              placeholder="Escribe la nota extra que quieres añadir"
+            />
+            <p className="text-xs text-muted-foreground">
+              Añadiremos la nota con un salto de línea. Perfecto para matices, chistes internos o recordatorios del futuro.
+            </p>
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => {
+                if (!bulkDescriptionLoading) {
+                  setBulkDescriptionOpen(false)
+                  setBulkDescriptionValue("")
+                }
+              }}
+            >
+              Cancelar
+            </Button>
+            <Button type="button" onClick={handleBulkDescriptionSubmit} disabled={bulkDescriptionLoading}>
+              {bulkDescriptionLoading ? <LoadingSpinner size="sm" /> : "Añadir a todas"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={bulkDeleteOpen}
+        onOpenChange={(open) => {
+          if (!bulkDeleting) {
+            setBulkDeleteOpen(open)
+          }
+        }}
+      >
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2 text-destructive">
+              <AlertTriangle className="h-5 w-5 animate-bounce" />
+              ¡Alerta roja!
+            </DialogTitle>
+            <DialogDescription>
+              Esta operación eliminará para siempre las {selectionCount} transacciones seleccionadas.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <p className="text-sm font-semibold uppercase tracking-wide text-destructive animate-pulse">
+              ¿ESTÁS ABSOLUTAMENTE SEGURO DE QUE QUIERES ELIMINARLAS?
+            </p>
+            <div className="flex items-center gap-3 rounded-lg border border-destructive/40 bg-destructive/10 p-3">
+              <span className="text-3xl animate-bounce">🤯</span>
+              <div className="text-sm text-destructive">
+                Respira hondo, revisa la selección y confirma solo si no hay vuelta atrás.
+              </div>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Esta acción no se puede deshacer. Si mañana te arrepientes prometemos enviarte un gif de ánimo, pero los datos no
+              volverán.
+            </p>
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => {
+                if (!bulkDeleting) {
+                  setBulkDeleteOpen(false)
+                }
+              }}
+            >
+              Mejor no
+            </Button>
+            <Button type="button" variant="destructive" onClick={handleBulkDelete} disabled={bulkDeleting}>
+              {bulkDeleting ? <LoadingSpinner size="sm" /> : "Eliminar para siempre"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import * as React from "react"
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
+import { Check, Minus } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Checkbox = React.forwardRef<
+  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      "peer h-4 w-4 shrink-0 rounded-md border border-input bg-background ring-offset-background transition-all duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground data-[state=indeterminate]:border-primary data-[state=indeterminate]:bg-primary data-[state=indeterminate]:text-primary-foreground",
+      className,
+    )}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator className="group flex h-full w-full items-center justify-center text-current">
+      <Check className="h-3.5 w-3.5 group-data-[state=indeterminate]:hidden" strokeWidth={3} />
+      <Minus className="hidden h-3.5 w-3.5 group-data-[state=indeterminate]:block" strokeWidth={3} />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+))
+Checkbox.displayName = CheckboxPrimitive.Root.displayName
+
+export { Checkbox }

--- a/hooks/use-movimientos.ts
+++ b/hooks/use-movimientos.ts
@@ -388,6 +388,21 @@ export function useMovimientos(
     }
   }
 
+  const deleteMovimientos = async (movimientoIds: string[]) => {
+    if (movimientoIds.length === 0) {
+      return
+    }
+
+    try {
+      const { error } = await supabase.from("movimiento").delete().in("id", movimientoIds)
+      if (error) throw error
+      const idsToDelete = new Set(movimientoIds)
+      setMovimientos((prev) => prev.filter((mov) => !idsToDelete.has(mov.id)))
+    } catch (err) {
+      throw err
+    }
+  }
+
   const updateCategoria = async (movimientoId: string, categoriaId: string | null) => {
     try {
       const { error } = await supabase.from("movimiento").update({ categoria_id: categoriaId }).eq("id", movimientoId)
@@ -412,6 +427,7 @@ export function useMovimientos(
     refetch,
     updateCategoria,
     updateMovimiento,
+    deleteMovimientos,
     createMovimiento,
     loadMore,
     hasMore,


### PR DESCRIPTION
## Summary
- añade un componente Checkbox reutilizable y estado de selección múltiple en el gestor de transacciones
- muestra una barra de acciones masivas (categoría, concepto, nota y borrado) con los diálogos correspondientes
- actualiza las filas de la lista para alternar el avatar por checkboxes y adapta el mega selector de categorías al modo bulk; incorpora `deleteMovimientos`

## Testing
- pnpm lint *(con avisos existentes de lint en archivos no modificados)*

------
https://chatgpt.com/codex/tasks/task_e_68c9cf46a4d48326a6bc867924c053eb