### PR TITLE
feat(transacciones): selección múltiple con acciones masivas

### DIFF
--- a/components/transactions/category-mega-selector.tsx
+++ b/components/transactions/category-mega-selector.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useMemo, useState, useEffect, useRef, type CSSProperties } from "react"
-import { X, Search, Plus } from "lucide-react"
+import { X, Search, Plus, Tags } from "lucide-react"
 import { Input } from "@/components/ui/input"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -19,6 +19,7 @@ interface CategoryMegaSelectorProps {
   movement?: Movimiento | null
   account?: Cuenta | null
   onCreateCategory?: () => void
+  selectionSummary?: string
 }
 
 interface CategoryGroup {
@@ -34,6 +35,7 @@ export function CategoryMegaSelector({
   movement,
   account,
   onCreateCategory,
+  selectionSummary,
 }: CategoryMegaSelectorProps) {
   const [searchValue, setSearchValue] = useState("")
   const inputRef = useRef<HTMLInputElement>(null)
@@ -108,7 +110,7 @@ export function CategoryMegaSelector({
     <div className="bg-background shadow-xl border border-border/40 w-full max-w-3xl h-full sm:h-auto max-h-screen sm:max-h-[calc(100vh-4rem)] rounded-t-3xl sm:rounded-3xl overflow-hidden flex flex-col">
       <div className="border-b bg-muted/40 p-4 sm:p-6">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:gap-6">
-          {movement && (
+          {movement ? (
             <div className="flex flex-1 items-start gap-3 sm:items-center">
               <div className="flex-shrink-0 rounded-full p-0.5 border border-border/40 shadow-sm">
                 <BankAvatar account={account || undefined} size="sm" />
@@ -125,7 +127,22 @@ export function CategoryMegaSelector({
                 )}
               </div>
             </div>
-          )}
+          ) : selectionSummary ? (
+            <div className="flex flex-1 items-start gap-3 sm:items-center">
+              <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+                <Tags className="h-5 w-5" />
+              </div>
+              <div className="space-y-1 min-w-0">
+                <p className="text-[11px] uppercase tracking-wide text-muted-foreground">Selección múltiple</p>
+                <h2 className="text-base font-semibold leading-tight line-clamp-2 sm:line-clamp-1">
+                  {selectionSummary}
+                </h2>
+                <p className="text-xs text-muted-foreground">
+                  Elige una categoría para aplicarla a todas las transacciones seleccionadas.
+                </p>
+              </div>
+            </div>
+          ) : null}
 
           <div className="flex items-start justify-between gap-2 sm:flex-col sm:items-end sm:justify-start">
             {movement && (

--- a/components/transactions/transaction-list-row.tsx
+++ b/components/transactions/transaction-list-row.tsx
@@ -11,7 +11,7 @@ import { Input } from "@/components/ui/input"
 import { LoadingSpinner } from "@/components/ui/loading-spinner"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
-import { Pencil } from "lucide-react"
+import { Pencil, Check } from "lucide-react"
 import type { Movimiento, MovimientoConRelaciones, Cuenta, Categoria } from "@/lib/types/database"
 
 interface TransactionListRowProps {
@@ -22,6 +22,9 @@ interface TransactionListRowProps {
   onMovementUpdate: (movementId: string, patch: Partial<Movimiento>) => Promise<void>
   onClick: (movement: MovimientoConRelaciones, e: React.MouseEvent) => void
   onOpenFiles?: (movement: MovimientoConRelaciones) => void
+  isSelected?: boolean
+  selectionActive?: boolean
+  onToggleSelection?: (movementId: string, nextSelected: boolean) => void
 }
 
 export const TransactionListRow = memo(function TransactionListRow({
@@ -32,6 +35,9 @@ export const TransactionListRow = memo(function TransactionListRow({
   onMovementUpdate,
   onClick,
   onOpenFiles,
+  isSelected = false,
+  selectionActive = false,
+  onToggleSelection,
 }: TransactionListRowProps) {
   const [isUpdating, setIsUpdating] = useState(false)
   const [editing, setEditing] = useState(false)
@@ -69,12 +75,19 @@ export const TransactionListRow = memo(function TransactionListRow({
     setEditing(false)
   }
 
+  const handleSelectionToggle = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation()
+    onToggleSelection?.(movement.id, !isSelected)
+  }
+
   return (
     <div className="relative" data-testid="transaction-row">
       <div
         className={cn(
           "bg-card rounded-lg border border-border/50 p-3 hover:bg-muted/50 hover:border-border transition-all duration-200 cursor-pointer shadow-sm hover:shadow-md",
-          !category && "border-l-4 border-l-amber-400/60 bg-amber-50/30 dark:bg-amber-950/10"
+          !category && "border-l-4 border-l-amber-400/60 bg-amber-50/30 dark:bg-amber-950/10",
+          isSelected && "border-primary/60 bg-primary/10 shadow-md hover:border-primary/60 hover:bg-primary/10",
+          selectionActive && !isSelected && "border-primary/30"
         )}
         onClick={(e) => onClick(movement, e)}
         data-account-id={movement.cuenta_id}
@@ -82,13 +95,45 @@ export const TransactionListRow = memo(function TransactionListRow({
       >
         <div className="flex items-start gap-3">
           <AccountTooltip account={account}>
-            <div
-              className="rounded-full p-0.5 cursor-pointer hover:scale-105 transition-transform flex-shrink-0 shadow-sm"
-              style={{ backgroundColor: account?.color || "#4ECDC4" }}
-              data-testid="account-info"
-              title={`Cuenta: ${account?.nombre || 'Sin nombre'} - Delegación ID: ${account?.delegacion_id || 'Sin delegación'}`}
-            >
-              <BankAvatar account={account} />
+            <div className="relative flex-shrink-0" data-testid="account-info">
+              <div
+                className="group/account relative h-10 w-10"
+                title={`Cuenta: ${account?.nombre || "Sin nombre"} - Delegación ID: ${account?.delegacion_id || "Sin delegación"}`}
+              >
+                <button
+                  type="button"
+                  onClick={handleSelectionToggle}
+                  aria-pressed={isSelected}
+                  aria-label={isSelected ? "Quitar de la selección" : "Seleccionar transacción"}
+                  className={`absolute left-0 top-0 flex h-10 w-10 items-center justify-center rounded-full border border-primary/40 bg-background/90 text-primary shadow-sm transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 ${
+                    isSelected
+                      ? "opacity-100 scale-100 pointer-events-auto bg-primary text-primary-foreground border-primary"
+                      : selectionActive
+                        ? "opacity-100 scale-100 pointer-events-auto"
+                        : "opacity-0 scale-95 pointer-events-none group-hover/account:opacity-100 group-hover/account:scale-100 group-hover/account:pointer-events-auto"
+                  }`}
+                >
+                  {isSelected ? (
+                    <Check className="h-4 w-4" />
+                  ) : (
+                    <span className="h-2.5 w-2.5 rounded-full border border-primary/50" />
+                  )}
+                </button>
+
+                <div
+                  className={cn(
+                    "relative h-10 w-10 rounded-full p-0.5 shadow-sm transition-all duration-200",
+                    isSelected
+                      ? "opacity-0 scale-90"
+                      : selectionActive
+                        ? "opacity-0 scale-95"
+                        : "opacity-100 scale-100 group-hover/account:opacity-0 group-hover/account:scale-95",
+                  )}
+                  style={{ backgroundColor: account?.color || "#4ECDC4" }}
+                >
+                  <BankAvatar account={account} />
+                </div>
+              </div>
             </div>
           </AccountTooltip>
 

--- a/components/transactions/transaction-list.tsx
+++ b/components/transactions/transaction-list.tsx
@@ -25,6 +25,9 @@ interface TransactionListProps {
   onLoadMore?: () => void
   hasMore?: boolean
   onOpenFiles?: (movement: MovimientoConRelaciones) => void
+  selectedMovementIds?: string[]
+  selectionActive?: boolean
+  onToggleMovementSelection?: (movementId: string, nextSelected: boolean) => void
 }
 
 export function TransactionList({
@@ -39,6 +42,9 @@ export function TransactionList({
   onLoadMore,
   hasMore,
   onOpenFiles,
+  selectedMovementIds,
+  selectionActive,
+  onToggleMovementSelection,
 }: TransactionListProps) {
   const loadMoreRef = useRef<HTMLDivElement | null>(null)
 
@@ -101,6 +107,8 @@ export function TransactionList({
     )
   }
 
+  const selectionActiveState = selectionActive ?? Boolean(selectedMovementIds && selectedMovementIds.length > 0)
+
   return (
     <div className="space-y-1 p-2 sm:p-4">
       <div className="flex items-center justify-between mb-3 px-1 sm:px-0">
@@ -117,6 +125,9 @@ export function TransactionList({
           onMovementUpdate={onMovementUpdate}
           onClick={onMovementClick}
           onOpenFiles={onOpenFiles}
+          isSelected={selectedMovementIds?.includes(movement.id) ?? false}
+          selectionActive={selectionActiveState}
+          onToggleSelection={onToggleMovementSelection}
         />
       ))}
       {hasMore && (

--- a/components/transactions/transaction-manager.tsx
+++ b/components/transactions/transaction-manager.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useMemo, useCallback } from "react"
 import { useSearchParams } from "next/navigation"
 import { TransactionFiltersComponent } from "./transaction-filters"
 import { TransactionList } from "./transaction-list"
@@ -14,6 +14,16 @@ import { useCuentas } from "@/hooks/use-cuentas"
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
 import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import {
   ChevronRight,
   ChevronLeft,
   Plus,
@@ -22,13 +32,21 @@ import {
   Filter,
   ChevronUp,
   Check,
+  Minus,
+  Square,
+  Tags,
+  Trash2,
+  TextCursorInput,
+  NotebookPen,
+  X,
+  AlertTriangle,
 } from "lucide-react"
 import { toast } from "sonner"
 import { LoadingSpinner } from "@/components/ui/loading-spinner"
 import { exportMovementsToExcel } from "@/lib/utils/export-to-excel"
 import type { MovimientoConRelaciones, Categoria, Cuenta } from "@/lib/types/database"
 import { TransactionImportPanel } from "./transaction-import-panel"
-import { isDebugEnabled } from "@/lib/utils/debug"
+import { CategoryMegaSelector } from "./category-mega-selector"
 
 export interface TransactionFilters {
   dateFrom?: string
@@ -59,6 +77,15 @@ export function TransactionManager() {
   const [createFormOpen, setCreateFormOpen] = useState(false)
   const [importOpen, setImportOpen] = useState(false)
   const [downloadState, setDownloadState] = useState<"idle" | "downloading" | "success">("idle")
+  const [selectedMovementIds, setSelectedMovementIds] = useState<string[]>([])
+  const [categorySelectorOpen, setCategorySelectorOpen] = useState(false)
+  const [conceptDialogOpen, setConceptDialogOpen] = useState(false)
+  const [descriptionDialogOpen, setDescriptionDialogOpen] = useState(false)
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
+  const [isBulkUpdating, setIsBulkUpdating] = useState(false)
+  const [isDeleteLoading, setIsDeleteLoading] = useState(false)
+  const [bulkConceptValue, setBulkConceptValue] = useState("")
+  const [bulkDescriptionValue, setBulkDescriptionValue] = useState("")
   const searchParams = useSearchParams()
 
   const currentDelegation = getCurrentDelegation()
@@ -70,6 +97,9 @@ export function TransactionManager() {
     error,
     updateCategoria,
     updateMovimiento,
+    bulkUpdateMovimientos,
+    deleteMovimientos,
+    appendDescripcion,
     createMovimiento,
     refetch,
     loadMore,
@@ -85,8 +115,85 @@ export function TransactionManager() {
     uncategorized: filters.uncategorized,
   })
 
+  const selectedIdsSet = useMemo(() => new Set(selectedMovementIds), [selectedMovementIds])
+  const visibleMovementIds = useMemo(() => movements.map((movement) => movement.id), [movements])
+  const selectionCount = selectedMovementIds.length
+  const selectionActive = selectionCount > 0
+  const allVisibleSelected =
+    visibleMovementIds.length > 0 && visibleMovementIds.every((id) => selectedIdsSet.has(id))
+  const partiallySelected = selectionActive && !allVisibleSelected
+  const selectedMovements = useMemo(
+    () => movements.filter((movement) => selectedIdsSet.has(movement.id)),
+    [movements, selectedIdsSet],
+  )
+  const sharedCategoryId = useMemo(() => {
+    if (!selectionActive || selectedMovements.length === 0) return undefined
+    const first = selectedMovements[0].categoria_id ?? null
+    const allSame = selectedMovements.every((movement) => (movement.categoria_id ?? null) === first)
+    if (!allSame) {
+      return undefined
+    }
+    return first ?? undefined
+  }, [selectionActive, selectedMovements])
+  const sharedConcept = useMemo(() => {
+    if (!selectionActive || selectedMovements.length === 0) return ""
+    const first = selectedMovements[0].concepto ?? ""
+    const allSame = selectedMovements.every((movement) => (movement.concepto ?? "") === first)
+    return allSame ? first : ""
+  }, [selectionActive, selectedMovements])
+
+  useEffect(() => {
+    if (!selectionActive) return
+
+    setSelectedMovementIds((prev) => {
+      if (prev.length === 0) return prev
+      const visibleSet = new Set(visibleMovementIds)
+      const filtered = prev.filter((id) => visibleSet.has(id))
+      return filtered.length === prev.length ? prev : filtered
+    })
+  }, [visibleMovementIds, selectionActive])
+
+  useEffect(() => {
+    if (conceptDialogOpen) {
+      setBulkConceptValue(sharedConcept)
+    }
+  }, [conceptDialogOpen, sharedConcept])
+
+  const selectionSummaryText =
+    selectionCount > 0
+      ? `${selectionCount} transacción${selectionCount !== 1 ? "es" : ""} seleccionada${selectionCount !== 1 ? "s" : ""}`
+      : ""
+  const selectionHelperText = allVisibleSelected
+    ? "Todas las transacciones visibles están seleccionadas"
+    : partiallySelected
+      ? "Selecciona todas las visibles con un clic"
+      : "Selecciona varias para aplicar acciones en lote"
+  const actionsDisabled = isBulkUpdating || isDeleteLoading
+
   const { categorias: categories } = useCategorias(selectedDelegation)
   const { cuentas: accounts } = useCuentas(selectedDelegation)
+
+  const toggleMovementSelection = useCallback((movementId: string, nextSelected: boolean) => {
+    setSelectedMovementIds((prev) => {
+      if (nextSelected) {
+        if (prev.includes(movementId)) return prev
+        return [...prev, movementId]
+      }
+      return prev.filter((id) => id !== movementId)
+    })
+  }, [])
+
+  const clearSelection = useCallback(() => {
+    setSelectedMovementIds([])
+  }, [])
+
+  const handleToggleSelectAllVisible = useCallback(() => {
+    if (allVisibleSelected) {
+      setSelectedMovementIds([])
+    } else {
+      setSelectedMovementIds([...visibleMovementIds])
+    }
+  }, [allVisibleSelected, visibleMovementIds])
 
   const handleDownload = async () => {
     setDownloadState("downloading")
@@ -149,6 +256,112 @@ export function TransactionManager() {
     } catch (error) {
       console.error("Error updating movement:", error)
       throw error
+    }
+  }
+
+  const handleBulkCategorySelect = async (categoryId: string) => {
+    const ids = [...selectedMovementIds]
+    if (ids.length === 0) return
+
+    setIsBulkUpdating(true)
+    try {
+      await bulkUpdateMovimientos(ids, { categoria_id: categoryId })
+      if (selectedMovementId && ids.includes(selectedMovementId)) {
+        setSelectedMovementSnapshot((prev) =>
+          prev ? { ...prev, categoria_id: categoryId } : prev,
+        )
+      }
+      toast.success(
+        `Categoría actualizada en ${ids.length} transacción${ids.length !== 1 ? "es" : ""}`,
+      )
+      clearSelection()
+      setCategorySelectorOpen(false)
+    } catch (error) {
+      console.error("Error updating categories:", error)
+      toast.error("No se pudieron actualizar las categorías")
+    } finally {
+      setIsBulkUpdating(false)
+    }
+  }
+
+  const handleBulkConceptSubmit = async () => {
+    const trimmed = bulkConceptValue.trim()
+    const ids = [...selectedMovementIds]
+    if (!trimmed || ids.length === 0) return
+
+    setIsBulkUpdating(true)
+    try {
+      await bulkUpdateMovimientos(ids, { concepto: trimmed })
+      if (selectedMovementId && ids.includes(selectedMovementId)) {
+        setSelectedMovementSnapshot((prev) =>
+          prev ? { ...prev, concepto: trimmed } : prev,
+        )
+      }
+      toast.success(
+        `Concepto actualizado en ${ids.length} transacción${ids.length !== 1 ? "es" : ""}`,
+      )
+      setConceptDialogOpen(false)
+      setBulkConceptValue("")
+      clearSelection()
+    } catch (error) {
+      console.error("Error updating concept:", error)
+      toast.error("No se pudo actualizar el concepto")
+    } finally {
+      setIsBulkUpdating(false)
+    }
+  }
+
+  const handleBulkDescriptionSubmit = async () => {
+    const trimmed = bulkDescriptionValue.trim()
+    const ids = [...selectedMovementIds]
+    if (!trimmed || ids.length === 0) return
+
+    setIsBulkUpdating(true)
+    try {
+      await appendDescripcion(ids, trimmed)
+      if (selectedMovementId && ids.includes(selectedMovementId)) {
+        setSelectedMovementSnapshot((prev) => {
+          if (!prev) return prev
+          const base = prev.descripcion ? prev.descripcion.trimEnd() : ""
+          const descripcion = base ? `${base}\n${trimmed}` : trimmed
+          return { ...prev, descripcion }
+        })
+      }
+      toast.success(
+        `Descripción actualizada en ${ids.length} transacción${ids.length !== 1 ? "es" : ""}`,
+      )
+      setDescriptionDialogOpen(false)
+      setBulkDescriptionValue("")
+      clearSelection()
+    } catch (error) {
+      console.error("Error updating description:", error)
+      toast.error("No se pudo actualizar la descripción")
+    } finally {
+      setIsBulkUpdating(false)
+    }
+  }
+
+  const handleBulkDelete = async () => {
+    const ids = [...selectedMovementIds]
+    if (ids.length === 0) return
+
+    setIsDeleteLoading(true)
+    try {
+      await deleteMovimientos(ids)
+      if (selectedMovementId && ids.includes(selectedMovementId)) {
+        setSelectedMovementId(null)
+        setSelectedMovementSnapshot(null)
+      }
+      toast.success(
+        `${ids.length} transacción${ids.length !== 1 ? "es" : ""} eliminada${ids.length !== 1 ? "s" : ""}`,
+      )
+      clearSelection()
+      setDeleteDialogOpen(false)
+    } catch (error) {
+      console.error("Error deleting movements:", error)
+      toast.error("No se pudieron eliminar las transacciones seleccionadas")
+    } finally {
+      setIsDeleteLoading(false)
     }
   }
 
@@ -386,6 +599,107 @@ export function TransactionManager() {
             </div>
           </div>
 
+          {selectionActive && (
+            <div className="rounded-2xl border border-primary/30 bg-primary/5 px-3 py-3 sm:px-4 sm:py-3 shadow-sm">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div className="flex flex-1 items-center gap-3 min-w-0">
+                  <button
+                    type="button"
+                    role="checkbox"
+                    aria-checked={allVisibleSelected ? true : partiallySelected ? "mixed" : false}
+                    onClick={handleToggleSelectAllVisible}
+                    disabled={actionsDisabled}
+                    className={`flex h-10 w-10 items-center justify-center rounded-full border text-sm shadow-sm transition hover:border-primary hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60 ${
+                      allVisibleSelected
+                        ? "bg-primary text-primary-foreground border-primary"
+                        : partiallySelected
+                          ? "bg-primary/10 border-primary/60 text-primary"
+                          : "bg-background/80 border-primary/40 text-primary"
+                    }`}
+                    aria-label={
+                      allVisibleSelected
+                        ? "Deseleccionar transacciones visibles"
+                        : "Seleccionar todas las transacciones visibles"
+                    }
+                  >
+                    {allVisibleSelected ? (
+                      <Check className="h-4 w-4" />
+                    ) : partiallySelected ? (
+                      <Minus className="h-4 w-4" />
+                    ) : (
+                      <Square className="h-4 w-4 text-muted-foreground" />
+                    )}
+                  </button>
+
+                  <div className="min-w-0 space-y-0.5">
+                    <p className="text-sm font-semibold text-primary">{selectionSummaryText}</p>
+                    {isBulkUpdating ? (
+                      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                        <LoadingSpinner size="sm" />
+                        <span className="truncate">Aplicando cambios...</span>
+                      </div>
+                    ) : (
+                      <p className="text-xs text-muted-foreground truncate">{selectionHelperText}</p>
+                    )}
+                  </div>
+                </div>
+
+                <div className="flex flex-wrap items-center justify-start gap-2 sm:justify-end">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setCategorySelectorOpen(true)}
+                    className="flex items-center gap-2"
+                    disabled={actionsDisabled}
+                  >
+                    <Tags className="h-4 w-4" />
+                    <span className="text-xs font-medium">Editar categoría</span>
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setConceptDialogOpen(true)}
+                    className="flex items-center gap-2"
+                    disabled={actionsDisabled}
+                  >
+                    <TextCursorInput className="h-4 w-4" />
+                    <span className="text-xs font-medium">Cambiar concepto</span>
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setDescriptionDialogOpen(true)}
+                    className="flex items-center gap-2"
+                    disabled={actionsDisabled}
+                  >
+                    <NotebookPen className="h-4 w-4" />
+                    <span className="text-xs font-medium">Añadir nota</span>
+                  </Button>
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    onClick={() => setDeleteDialogOpen(true)}
+                    className="flex items-center gap-2"
+                    disabled={isDeleteLoading || isBulkUpdating}
+                  >
+                    {isDeleteLoading ? <LoadingSpinner size="sm" /> : <Trash2 className="h-4 w-4" />}
+                    <span className="text-xs font-medium">Eliminar</span>
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={clearSelection}
+                    className="h-8 px-3"
+                    disabled={actionsDisabled}
+                  >
+                    <X className="h-4 w-4 mr-1.5" />
+                    <span className="text-xs font-medium">Limpiar</span>
+                  </Button>
+                </div>
+              </div>
+            </div>
+          )}
+
           {filtersOpen && (
             <Card className="lg:hidden p-4 border-2 border-blue-200 bg-blue-50/50 dark:bg-blue-950/20 dark:border-blue-800">
               <div className="flex items-center justify-between mb-4">
@@ -433,6 +747,9 @@ export function TransactionManager() {
             onLoadMore={loadMore}
             hasMore={hasMore}
             onOpenFiles={(movement) => handleOpenFiles(movement as unknown as MovimientoConRelaciones)}
+            selectedMovementIds={selectedMovementIds}
+            selectionActive={selectionActive}
+            onToggleMovementSelection={toggleMovementSelection}
           />
         </div>
       </div>
@@ -479,6 +796,166 @@ export function TransactionManager() {
           }, 1000)
         }}
       />
+
+      {categorySelectorOpen && (
+        <div
+          className="fixed inset-0 z-[95] flex items-end justify-center bg-black/60 backdrop-blur-sm p-3 sm:items-center sm:p-6"
+          onClick={() => {
+            if (isBulkUpdating) return
+            setCategorySelectorOpen(false)
+          }}
+        >
+          <div
+            className="w-full max-w-3xl"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <CategoryMegaSelector
+              categories={categories as unknown as Categoria[]}
+              selectedCategoryId={typeof sharedCategoryId === "string" ? sharedCategoryId : undefined}
+              onSelect={handleBulkCategorySelect}
+              onClose={() => {
+                if (isBulkUpdating) return
+                setCategorySelectorOpen(false)
+              }}
+              selectionSummary={selectionSummaryText}
+            />
+          </div>
+        </div>
+      )}
+
+      <Dialog
+        open={conceptDialogOpen}
+        onOpenChange={(open) => {
+          if (isBulkUpdating) return
+          setConceptDialogOpen(open)
+          if (!open) {
+            setBulkConceptValue("")
+          }
+        }}
+      >
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Cambiar concepto</DialogTitle>
+            <DialogDescription>
+              {selectionSummaryText || "Selecciona transacciones para aplicar cambios."}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            <Input
+              value={bulkConceptValue}
+              onChange={(event) => setBulkConceptValue(event.target.value)}
+              placeholder="Nuevo concepto"
+              autoFocus
+            />
+            <p className="text-xs text-muted-foreground">
+              El concepto reemplazará al actual en todas las transacciones seleccionadas.
+            </p>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConceptDialogOpen(false)} disabled={isBulkUpdating}>
+              Cancelar
+            </Button>
+            <Button
+              onClick={handleBulkConceptSubmit}
+              disabled={isBulkUpdating || !bulkConceptValue.trim()}
+            >
+              {isBulkUpdating ? <LoadingSpinner size="sm" /> : "Guardar"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={descriptionDialogOpen}
+        onOpenChange={(open) => {
+          if (isBulkUpdating) return
+          setDescriptionDialogOpen(open)
+          if (!open) {
+            setBulkDescriptionValue("")
+          }
+        }}
+      >
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Añadir nota a la descripción</DialogTitle>
+            <DialogDescription>
+              {selectionSummaryText || "Selecciona transacciones para añadir notas."}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            <Textarea
+              value={bulkDescriptionValue}
+              onChange={(event) => setBulkDescriptionValue(event.target.value)}
+              placeholder="Texto a añadir al final de la descripción"
+              rows={4}
+              autoFocus
+            />
+            <p className="text-xs text-muted-foreground">
+              El texto se añadirá al final de la descripción existente, sin eliminar lo anterior.
+            </p>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDescriptionDialogOpen(false)} disabled={isBulkUpdating}>
+              Cancelar
+            </Button>
+            <Button
+              onClick={handleBulkDescriptionSubmit}
+              disabled={isBulkUpdating || !bulkDescriptionValue.trim()}
+            >
+              {isBulkUpdating ? <LoadingSpinner size="sm" /> : "Aplicar"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={deleteDialogOpen}
+        onOpenChange={(open) => {
+          if (isDeleteLoading) return
+          setDeleteDialogOpen(open)
+        }}
+      >
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle className="text-red-600">Eliminar transacciones</DialogTitle>
+            <DialogDescription>
+              Esta acción no se puede deshacer. Se eliminarán permanentemente las transacciones seleccionadas.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="rounded-2xl border border-red-500/40 bg-red-500/10 p-5 text-center space-y-3">
+            <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-red-500/20 text-red-600 dramatic-wiggle">
+              <AlertTriangle className="h-8 w-8" />
+            </div>
+            <p className="text-sm font-semibold text-red-600 uppercase tracking-wide">
+              ¿Estás absolutamente seguro de que quieres eliminar las {selectionCount} transacciones seleccionadas?
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Esta acción no se puede deshacer. Respira hondo y confirma solo si estás totalmente seguro.
+            </p>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDeleteDialogOpen(false)} disabled={isDeleteLoading}>
+              Cancelar
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleBulkDelete}
+              disabled={isDeleteLoading || selectionCount === 0}
+            >
+              {isDeleteLoading ? <LoadingSpinner size="sm" /> : "Eliminar definitivamente"}
+            </Button>
+          </DialogFooter>
+          <style>{`
+            @keyframes dramatic-wiggle {
+              0%, 100% { transform: rotate(-8deg); }
+              50% { transform: rotate(8deg); }
+            }
+            .dramatic-wiggle {
+              animation: dramatic-wiggle 1.2s ease-in-out infinite;
+            }
+          `}</style>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/hooks/use-movimientos.ts
+++ b/hooks/use-movimientos.ts
@@ -380,8 +380,28 @@ export function useMovimientos(
         .update(patch as any)
         .eq("id", movimientoId)
       if (error) throw error
-      setMovimientos(prev =>
-        prev.map(mov => (mov.id === movimientoId ? { ...mov, ...patch } : mov)),
+      setMovimientos((prev) =>
+        prev.map((mov) => (mov.id === movimientoId ? { ...mov, ...patch } : mov)),
+      )
+    } catch (err) {
+      throw err
+    }
+  }
+
+  const bulkUpdateMovimientos = async (
+    movimientoIds: string[],
+    patch: Partial<MovimientoConRelaciones>,
+  ) => {
+    if (movimientoIds.length === 0) return
+    const idSet = new Set(movimientoIds)
+    try {
+      const { error } = await supabase
+        .from("movimiento")
+        .update(patch as any)
+        .in("id", movimientoIds)
+      if (error) throw error
+      setMovimientos((prev) =>
+        prev.map((mov) => (idSet.has(mov.id) ? { ...mov, ...patch } : mov)),
       )
     } catch (err) {
       throw err
@@ -390,9 +410,58 @@ export function useMovimientos(
 
   const updateCategoria = async (movimientoId: string, categoriaId: string | null) => {
     try {
-      const { error } = await supabase.from("movimiento").update({ categoria_id: categoriaId }).eq("id", movimientoId)
+      const { error } = await supabase
+        .from("movimiento")
+        .update({ categoria_id: categoriaId })
+        .eq("id", movimientoId)
       if (error) throw error
-      setMovimientos(prev => prev.map(mov => (mov.id === movimientoId ? { ...mov, categoria_id: categoriaId } : mov)))
+      setMovimientos((prev) =>
+        prev.map((mov) => (mov.id === movimientoId ? { ...mov, categoria_id: categoriaId } : mov)),
+      )
+    } catch (err) {
+      throw err
+    }
+  }
+
+  const deleteMovimientos = async (movimientoIds: string[]) => {
+    if (movimientoIds.length === 0) return
+    const idSet = new Set(movimientoIds)
+    try {
+      const { error } = await supabase.from("movimiento").delete().in("id", movimientoIds)
+      if (error) throw error
+      setMovimientos((prev) => prev.filter((mov) => !idSet.has(mov.id)))
+    } catch (err) {
+      throw err
+    }
+  }
+
+  const appendDescripcion = async (movimientoIds: string[], text: string) => {
+    const trimmed = text.trim()
+    if (!trimmed || movimientoIds.length === 0) return
+
+    const idSet = new Set(movimientoIds)
+    const updates = movimientos
+      .filter((mov) => idSet.has(mov.id))
+      .map((mov) => {
+        const base = mov.descripcion ? mov.descripcion.trimEnd() : ""
+        const descripcion = base ? `${base}\n${trimmed}` : trimmed
+        return { id: mov.id, descripcion }
+      })
+
+    if (updates.length === 0) return
+
+    try {
+      await Promise.all(
+        updates.map(({ id, descripcion }) =>
+          supabase.from("movimiento").update({ descripcion }).eq("id", id),
+        ),
+      )
+      const updateMap = new Map(updates.map((item) => [item.id, item.descripcion]))
+      setMovimientos((prev) =>
+        prev.map((mov) =>
+          updateMap.has(mov.id) ? { ...mov, descripcion: updateMap.get(mov.id) ?? mov.descripcion } : mov,
+        ),
+      )
     } catch (err) {
       throw err
     }
@@ -412,6 +481,9 @@ export function useMovimientos(
     refetch,
     updateCategoria,
     updateMovimiento,
+    bulkUpdateMovimientos,
+    deleteMovimientos,
+    appendDescripcion,
     createMovimiento,
     loadMore,
     hasMore,


### PR DESCRIPTION
## Summary
- habilita selección múltiple de transacciones con barra de acciones masivas y diálogos para editar, anotar o eliminar en bloque
- ajusta filas y listado para mostrar checkboxes animados y propagar los cambios de selección
- añade operaciones bulk en el hook de movimientos y muestra el resumen de selección en el selector de categorías

## Testing
- pnpm lint *(warnings conocidos de unused vars fuera del scope de este cambio)*

------
https://chatgpt.com/codex/tasks/task_e_68c9cf46a4d48326a6bc867924c053eb