### PR TITLE
feat(transacciones): allow bulk actions

### DIFF
--- a/components/transactions/category-mega-selector.tsx
+++ b/components/transactions/category-mega-selector.tsx
@@ -19,6 +19,7 @@ interface CategoryMegaSelectorProps {
   movement?: Movimiento | null
   account?: Cuenta | null
   onCreateCategory?: () => void
+  headline?: string
 }
 
 interface CategoryGroup {
@@ -34,6 +35,7 @@ export function CategoryMegaSelector({
   movement,
   account,
   onCreateCategory,
+  headline,
 }: CategoryMegaSelectorProps) {
   const [searchValue, setSearchValue] = useState("")
   const inputRef = useRef<HTMLInputElement>(null)
@@ -108,22 +110,40 @@ export function CategoryMegaSelector({
     <div className="bg-background shadow-xl border border-border/40 w-full max-w-3xl h-full sm:h-auto max-h-screen sm:max-h-[calc(100vh-4rem)] rounded-t-3xl sm:rounded-3xl overflow-hidden flex flex-col">
       <div className="border-b bg-muted/40 p-4 sm:p-6">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:gap-6">
-          {movement && (
+          {(movement || headline) && (
             <div className="flex flex-1 items-start gap-3 sm:items-center">
-              <div className="flex-shrink-0 rounded-full p-0.5 border border-border/40 shadow-sm">
-                <BankAvatar account={account || undefined} size="sm" />
-              </div>
-              <div className="space-y-1 min-w-0">
-                <p className="text-[11px] tracking-wide text-muted-foreground uppercase">
-                  {account?.nombre || account?.banco_nombre || "Cuenta sin nombre"}
-                </p>
-                <h2 className="text-base font-semibold leading-tight line-clamp-2 sm:line-clamp-1">{movement.concepto}</h2>
-                {(movement.contraparte || movement.descripcion) && (
-                  <p className="text-sm text-muted-foreground line-clamp-1">
-                    {movement.contraparte || movement.descripcion}
+              {movement ? (
+                <>
+                  <div className="flex-shrink-0 rounded-full p-0.5 border border-border/40 shadow-sm">
+                    <BankAvatar account={account || undefined} size="sm" />
+                  </div>
+                  <div className="space-y-1 min-w-0">
+                    <p className="text-[11px] tracking-wide text-muted-foreground uppercase">
+                      {account?.nombre || account?.banco_nombre || "Cuenta sin nombre"}
+                    </p>
+                    <h2 className="text-base font-semibold leading-tight line-clamp-2 sm:line-clamp-1">
+                      {movement.concepto}
+                    </h2>
+                    {(movement.contraparte || movement.descripcion) && (
+                      <p className="text-sm text-muted-foreground line-clamp-1">
+                        {movement.contraparte || movement.descripcion}
+                      </p>
+                    )}
+                  </div>
+                </>
+              ) : (
+                <div className="space-y-2">
+                  <p className="text-[11px] tracking-wide text-muted-foreground uppercase">
+                    Selección múltiple
                   </p>
-                )}
-              </div>
+                  <h2 className="text-base font-semibold leading-tight">
+                    {headline}
+                  </h2>
+                  <p className="text-sm text-muted-foreground">
+                    Aplica una sola categoría a todas las transacciones seleccionadas.
+                  </p>
+                </div>
+              )}
             </div>
           )}
 

--- a/components/transactions/transaction-list-row.tsx
+++ b/components/transactions/transaction-list-row.tsx
@@ -12,6 +12,7 @@ import { LoadingSpinner } from "@/components/ui/loading-spinner"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { Pencil } from "lucide-react"
+import { SelectionCheckbox } from "@/components/ui/checkbox"
 import type { Movimiento, MovimientoConRelaciones, Cuenta, Categoria } from "@/lib/types/database"
 
 interface TransactionListRowProps {
@@ -22,6 +23,9 @@ interface TransactionListRowProps {
   onMovementUpdate: (movementId: string, patch: Partial<Movimiento>) => Promise<void>
   onClick: (movement: MovimientoConRelaciones, e: React.MouseEvent) => void
   onOpenFiles?: (movement: MovimientoConRelaciones) => void
+  onSelectionChange: (movement: MovimientoConRelaciones, checked: boolean) => void
+  isSelected: boolean
+  selectionMode: boolean
 }
 
 export const TransactionListRow = memo(function TransactionListRow({
@@ -32,10 +36,16 @@ export const TransactionListRow = memo(function TransactionListRow({
   onMovementUpdate,
   onClick,
   onOpenFiles,
+  onSelectionChange,
+  isSelected,
+  selectionMode,
 }: TransactionListRowProps) {
   const [isUpdating, setIsUpdating] = useState(false)
   const [editing, setEditing] = useState(false)
   const [conceptValue, setConceptValue] = useState(movement.concepto)
+  const [accountHovered, setAccountHovered] = useState(false)
+
+  const checkboxVisible = isSelected || selectionMode || accountHovered
 
   const handleCategoryChange = async (categoryId: string | null) => {
     setIsUpdating(true)
@@ -74,7 +84,9 @@ export const TransactionListRow = memo(function TransactionListRow({
       <div
         className={cn(
           "bg-card rounded-lg border border-border/50 p-3 hover:bg-muted/50 hover:border-border transition-all duration-200 cursor-pointer shadow-sm hover:shadow-md",
-          !category && "border-l-4 border-l-amber-400/60 bg-amber-50/30 dark:bg-amber-950/10"
+          !category && "border-l-4 border-l-amber-400/60 bg-amber-50/30 dark:bg-amber-950/10",
+          isSelected &&
+            "border-primary/40 bg-primary/5 shadow-md ring-1 ring-primary/20 hover:bg-primary/10 hover:border-primary/60"
         )}
         onClick={(e) => onClick(movement, e)}
         data-account-id={movement.cuenta_id}
@@ -83,12 +95,43 @@ export const TransactionListRow = memo(function TransactionListRow({
         <div className="flex items-start gap-3">
           <AccountTooltip account={account}>
             <div
-              className="rounded-full p-0.5 cursor-pointer hover:scale-105 transition-transform flex-shrink-0 shadow-sm"
-              style={{ backgroundColor: account?.color || "#4ECDC4" }}
+              className="relative h-11 w-11 flex-shrink-0"
               data-testid="account-info"
-              title={`Cuenta: ${account?.nombre || 'Sin nombre'} - Delegación ID: ${account?.delegacion_id || 'Sin delegación'}`}
+              title={`Cuenta: ${account?.nombre || "Sin nombre"} - Delegación ID: ${account?.delegacion_id || "Sin delegación"}`}
+              onMouseEnter={() => setAccountHovered(true)}
+              onMouseLeave={() => setAccountHovered(false)}
             >
-              <BankAvatar account={account} />
+              <div
+                className={cn(
+                  "absolute inset-0 rounded-full p-0.5 shadow-sm transition-all duration-200 ease-out",
+                  checkboxVisible ? "opacity-0 scale-75" : "opacity-100",
+                )}
+                style={{ backgroundColor: account?.color || "#4ECDC4" }}
+              >
+                <div className="h-full w-full overflow-hidden rounded-full">
+                  <BankAvatar account={account} />
+                </div>
+              </div>
+
+              <div
+                className={cn(
+                  "absolute inset-0 flex items-center justify-center transition-all duration-200 ease-out",
+                  checkboxVisible
+                    ? "opacity-100 scale-100 pointer-events-auto"
+                    : "opacity-0 scale-75 pointer-events-none"
+                )}
+                data-selection-control
+                onClick={(event) => event.stopPropagation()}
+                onMouseDown={(event) => event.stopPropagation()}
+              >
+                <SelectionCheckbox
+                  checked={isSelected}
+                  onCheckedChange={(checked) => {
+                    onSelectionChange(movement, checked === true)
+                  }}
+                  className="h-10 w-10 border-2 cursor-pointer"
+                />
+              </div>
             </div>
           </AccountTooltip>
 
@@ -159,6 +202,7 @@ export const TransactionListRow = memo(function TransactionListRow({
                     onClick(movement, e)
                   }}
                   aria-label="Editar transacción"
+                  data-force-detail="true"
                 >
                   <Pencil className="h-4 w-4" />
                 </Button>

--- a/components/transactions/transaction-list.tsx
+++ b/components/transactions/transaction-list.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useEffect, useRef, useMemo } from "react"
+import type React from "react"
 import { LoadingSpinner } from "@/components/ui/loading-spinner"
 import { ErrorMessage } from "@/components/ui/error-message"
 import { TransactionListRow } from "./transaction-list-row"
@@ -20,11 +21,14 @@ interface TransactionListProps {
   loading: boolean
   error: string | null
   total: number
-  onMovementClick: (movement: MovimientoConRelaciones) => void
+  onMovementClick: (movement: MovimientoConRelaciones, event: React.MouseEvent) => void
   onMovementUpdate: (movementId: string, patch: Partial<Movimiento>) => Promise<void>
   onLoadMore?: () => void
   hasMore?: boolean
   onOpenFiles?: (movement: MovimientoConRelaciones) => void
+  selectedMovements: string[]
+  onSelectionChange: (movement: MovimientoConRelaciones, checked: boolean) => void
+  selectionMode: boolean
 }
 
 export function TransactionList({
@@ -39,6 +43,9 @@ export function TransactionList({
   onLoadMore,
   hasMore,
   onOpenFiles,
+  selectedMovements,
+  onSelectionChange,
+  selectionMode,
 }: TransactionListProps) {
   const loadMoreRef = useRef<HTMLDivElement | null>(null)
 
@@ -117,6 +124,9 @@ export function TransactionList({
           onMovementUpdate={onMovementUpdate}
           onClick={onMovementClick}
           onOpenFiles={onOpenFiles}
+          onSelectionChange={onSelectionChange}
+          isSelected={selectedMovements.includes(movement.id)}
+          selectionMode={selectionMode}
         />
       ))}
       {hasMore && (

--- a/components/transactions/transaction-manager.tsx
+++ b/components/transactions/transaction-manager.tsx
@@ -1,11 +1,13 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useEffect, useMemo, useState } from "react"
+import type React from "react"
 import { useSearchParams } from "next/navigation"
 import { TransactionFiltersComponent } from "./transaction-filters"
 import { TransactionList } from "./transaction-list"
 import { TransactionDetail } from "./transaction-detail"
 import { TransactionCreatePanel } from "./transaction-create-panel"
+import { CategoryMegaSelector } from "./category-mega-selector"
 import { DateRangeFilter } from "./date-range-filter"
 import { useDelegationContext } from "@/contexts/delegation-context"
 import { useMovimientos } from "@/hooks/use-movimientos"
@@ -13,6 +15,16 @@ import { useCategorias } from "@/hooks/use-categorias"
 import { useCuentas } from "@/hooks/use-cuentas"
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
+import { SelectionCheckbox } from "@/components/ui/checkbox"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
 import {
   ChevronRight,
   ChevronLeft,
@@ -22,13 +34,17 @@ import {
   Filter,
   ChevronUp,
   Check,
+  Tags,
+  Trash2,
+  Type,
+  FileText,
+  Skull,
 } from "lucide-react"
 import { toast } from "sonner"
 import { LoadingSpinner } from "@/components/ui/loading-spinner"
 import { exportMovementsToExcel } from "@/lib/utils/export-to-excel"
 import type { MovimientoConRelaciones, Categoria, Cuenta } from "@/lib/types/database"
 import { TransactionImportPanel } from "./transaction-import-panel"
-import { isDebugEnabled } from "@/lib/utils/debug"
 
 export interface TransactionFilters {
   dateFrom?: string
@@ -59,6 +75,15 @@ export function TransactionManager() {
   const [createFormOpen, setCreateFormOpen] = useState(false)
   const [importOpen, setImportOpen] = useState(false)
   const [downloadState, setDownloadState] = useState<"idle" | "downloading" | "success">("idle")
+  const [selectedMovementIds, setSelectedMovementIds] = useState<string[]>([])
+  const [bulkCategoryOpen, setBulkCategoryOpen] = useState(false)
+  const [bulkConceptOpen, setBulkConceptOpen] = useState(false)
+  const [bulkDescriptionOpen, setBulkDescriptionOpen] = useState(false)
+  const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false)
+  const [bulkActionLoading, setBulkActionLoading] = useState(false)
+  const [bulkCategoryLoading, setBulkCategoryLoading] = useState(false)
+  const [bulkConceptValue, setBulkConceptValue] = useState("")
+  const [bulkAppendValue, setBulkAppendValue] = useState("")
   const searchParams = useSearchParams()
 
   const currentDelegation = getCurrentDelegation()
@@ -70,6 +95,9 @@ export function TransactionManager() {
     error,
     updateCategoria,
     updateMovimiento,
+    updateManyCategorias,
+    updateManyMovimientos,
+    deleteMovimientos,
     createMovimiento,
     refetch,
     loadMore,
@@ -87,6 +115,39 @@ export function TransactionManager() {
 
   const { categorias: categories } = useCategorias(selectedDelegation)
   const { cuentas: accounts } = useCuentas(selectedDelegation)
+
+  const visibleMovementIds = useMemo(() => movements.map((movement) => movement.id), [movements])
+  const visibleSelectionCount = useMemo(
+    () => selectedMovementIds.filter((id) => visibleMovementIds.includes(id)).length,
+    [selectedMovementIds, visibleMovementIds],
+  )
+  const allVisibleSelected = visibleMovementIds.length > 0 && visibleSelectionCount === visibleMovementIds.length
+  const someVisibleSelected = visibleSelectionCount > 0 && !allVisibleSelected
+  const isSelectionMode = selectedMovementIds.length > 0
+  const selectedMovements = useMemo(
+    () => movements.filter((movement) => selectedMovementIds.includes(movement.id)),
+    [movements, selectedMovementIds],
+  )
+  const hiddenSelectionCount = Math.max(0, selectedMovementIds.length - visibleSelectionCount)
+
+  useEffect(() => {
+    setSelectedMovementIds((prev) => {
+      const filtered = prev.filter((id) => visibleMovementIds.includes(id))
+      if (filtered.length === prev.length) {
+        return prev
+      }
+      return filtered
+    })
+  }, [visibleMovementIds])
+
+  useEffect(() => {
+    if (selectedMovementIds.length === 0) {
+      setBulkCategoryOpen(false)
+      setBulkConceptOpen(false)
+      setBulkDescriptionOpen(false)
+      setBulkDeleteOpen(false)
+    }
+  }, [selectedMovementIds.length])
 
   const handleDownload = async () => {
     setDownloadState("downloading")
@@ -152,6 +213,53 @@ export function TransactionManager() {
     }
   }
 
+  const handleToggleSelection = (movementId: string, checked: boolean) => {
+    setSelectedMovementIds((prev) => {
+      if (checked) {
+        if (prev.includes(movementId)) {
+          return prev
+        }
+        return [...prev, movementId]
+      }
+      return prev.filter((id) => id !== movementId)
+    })
+  }
+
+  const handleToggleAllVisible = () => {
+    setSelectedMovementIds((prev) => {
+      if (allVisibleSelected) {
+        return prev.filter((id) => !visibleMovementIds.includes(id))
+      }
+      const next = new Set(prev)
+      visibleMovementIds.forEach((id) => next.add(id))
+      return Array.from(next)
+    })
+  }
+
+  const handleClearSelection = () => {
+    setSelectedMovementIds([])
+  }
+
+  const handleSelectionChange = (movement: MovimientoConRelaciones, checked: boolean) => {
+    handleToggleSelection(movement.id, checked)
+  }
+
+  const handleRowClick = (movement: MovimientoConRelaciones, event: React.MouseEvent) => {
+    const target = event.currentTarget as HTMLElement | null
+    if (target?.dataset.forceDetail === "true") {
+      handleMovementClick(movement)
+      return
+    }
+
+    if (isSelectionMode) {
+      const isCurrentlySelected = selectedMovementIds.includes(movement.id)
+      handleToggleSelection(movement.id, !isCurrentlySelected)
+      return
+    }
+
+    handleMovementClick(movement)
+  }
+
   const handleCreateMovement = async (
     data: Partial<MovimientoConRelaciones>,
   ) => {
@@ -173,6 +281,115 @@ export function TransactionManager() {
       console.error("Error creating movement:", error)
       toast.error("Error al crear la transacción")
       throw error
+    }
+  }
+
+  const handleBulkCategoryApply = async (categoryId: string) => {
+    if (selectedMovementIds.length === 0) {
+      return
+    }
+
+    setBulkCategoryLoading(true)
+    try {
+      await updateManyCategorias(selectedMovementIds, categoryId)
+      toast.success(
+        `Categoría actualizada en ${selectedMovementIds.length} transacciones`,
+      )
+      setBulkCategoryOpen(false)
+      handleClearSelection()
+    } catch (error) {
+      console.error("Error updating categories in bulk:", error)
+      toast.error("No se pudieron actualizar las categorías seleccionadas")
+    } finally {
+      setBulkCategoryLoading(false)
+    }
+  }
+
+  const handleBulkConceptSubmit = async () => {
+    const newConcept = bulkConceptValue.trim()
+    if (!newConcept) {
+      toast.error("Introduce un concepto para continuar")
+      return
+    }
+
+    setBulkActionLoading(true)
+    try {
+      await updateManyMovimientos(selectedMovementIds, { concepto: newConcept })
+      toast.success(
+        `Concepto actualizado en ${selectedMovementIds.length} transacciones`,
+      )
+      setBulkConceptOpen(false)
+      setBulkConceptValue("")
+      handleClearSelection()
+    } catch (error) {
+      console.error("Error updating concepts in bulk:", error)
+      toast.error("No se pudieron actualizar los conceptos seleccionados")
+    } finally {
+      setBulkActionLoading(false)
+    }
+  }
+
+  const handleBulkDescriptionSubmit = async () => {
+    const textToAppend = bulkAppendValue.trim()
+    if (!textToAppend) {
+      toast.error("Introduce un texto para añadir a la descripción")
+      return
+    }
+
+    setBulkActionLoading(true)
+    try {
+      const updates = selectedMovements
+        .map((movement) => {
+          if (!movement) {
+            return null
+          }
+          const base = movement.descripcion?.trim() ?? ""
+          const separator = base ? " " : ""
+          return {
+            id: movement.id,
+            descripcion: `${base}${separator}${textToAppend}`,
+          }
+        })
+        .filter(Boolean) as { id: string; descripcion: string }[]
+
+      await Promise.all(
+        updates.map(({ id, descripcion }) => updateMovimiento(id, { descripcion })),
+      )
+
+      toast.success(
+        `Descripción actualizada en ${updates.length} transacciones`,
+      )
+      setBulkDescriptionOpen(false)
+      setBulkAppendValue("")
+      handleClearSelection()
+    } catch (error) {
+      console.error("Error appending descriptions in bulk:", error)
+      toast.error("No se pudieron actualizar las descripciones seleccionadas")
+    } finally {
+      setBulkActionLoading(false)
+    }
+  }
+
+  const handleBulkDeleteConfirm = async () => {
+    if (selectedMovementIds.length === 0) {
+      return
+    }
+
+    setBulkActionLoading(true)
+    try {
+      await deleteMovimientos(selectedMovementIds)
+      toast.success(
+        selectedMovementIds.length === 1
+          ? "Transacción eliminada"
+          : `${selectedMovementIds.length} transacciones eliminadas`,
+      )
+      setBulkDeleteOpen(false)
+      handleClearSelection()
+    } catch (error) {
+      console.error("Error deleting movements in bulk:", error)
+      toast.error("No se pudieron eliminar las transacciones seleccionadas")
+    } finally {
+      setBulkActionLoading(false)
     }
   }
 
@@ -386,6 +603,111 @@ export function TransactionManager() {
             </div>
           </div>
 
+          {isSelectionMode && (
+            <div className="rounded-xl border border-primary/40 bg-primary/5 px-3 py-3 sm:px-4 sm:py-3 shadow-sm">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div className="flex flex-1 items-center gap-3">
+                  <SelectionCheckbox
+                    checked={
+                      allVisibleSelected
+                        ? true
+                        : someVisibleSelected
+                        ? "indeterminate"
+                        : false
+                    }
+                    onCheckedChange={() => handleToggleAllVisible()}
+                    disabled={bulkCategoryLoading || bulkActionLoading}
+                    className="h-10 w-10"
+                  />
+                  <div className="min-w-0 space-y-1">
+                    <p className="text-sm font-semibold leading-tight">
+                      {selectedMovementIds.length === 1
+                        ? "1 transacción seleccionada"
+                        : `${selectedMovementIds.length} transacciones seleccionadas`}
+                    </p>
+                    <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                      {hiddenSelectionCount > 0 && (
+                        <span>
+                          {hiddenSelectionCount === 1
+                            ? "1 fuera de la vista"
+                            : `${hiddenSelectionCount} fuera de la vista`}
+                        </span>
+                      )}
+                      {(bulkCategoryLoading || bulkActionLoading) && (
+                        <span className="flex items-center gap-1 font-medium text-primary">
+                          <LoadingSpinner size="sm" className="h-3 w-3 border" /> Procesando...
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="hidden sm:inline-flex"
+                    onClick={handleClearSelection}
+                    disabled={bulkCategoryLoading || bulkActionLoading}
+                  >
+                    Limpiar
+                  </Button>
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setBulkCategoryOpen(true)}
+                    disabled={bulkCategoryLoading || bulkActionLoading}
+                  >
+                    <Tags className="h-4 w-4" />
+                    <span className="ml-2">Editar categoría</span>
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => {
+                      setBulkConceptValue(selectedMovements[0]?.concepto ?? "")
+                      setBulkConceptOpen(true)
+                    }}
+                    disabled={bulkCategoryLoading || bulkActionLoading}
+                  >
+                    <Type className="h-4 w-4" />
+                    <span className="ml-2">Cambiar concepto</span>
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => {
+                      setBulkAppendValue("")
+                      setBulkDescriptionOpen(true)
+                    }}
+                    disabled={bulkCategoryLoading || bulkActionLoading}
+                  >
+                    <FileText className="h-4 w-4" />
+                    <span className="ml-2">Añadir descripción</span>
+                  </Button>
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    onClick={() => setBulkDeleteOpen(true)}
+                    disabled={bulkCategoryLoading || bulkActionLoading}
+                    className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                    <span className="ml-2">Eliminar</span>
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="sm:hidden"
+                    onClick={handleClearSelection}
+                    disabled={bulkCategoryLoading || bulkActionLoading}
+                  >
+                    Limpiar
+                  </Button>
+                </div>
+              </div>
+            </div>
+          )}
+
           {filtersOpen && (
             <Card className="lg:hidden p-4 border-2 border-blue-200 bg-blue-50/50 dark:bg-blue-950/20 dark:border-blue-800">
               <div className="flex items-center justify-between mb-4">
@@ -425,7 +747,9 @@ export function TransactionManager() {
             loading={loading}
             error={error}
             total={movements.length}
-            onMovementClick={(movement) => handleMovementClick(movement as unknown as MovimientoConRelaciones)}
+            onMovementClick={(movement, event) =>
+              handleRowClick(movement as unknown as MovimientoConRelaciones, event)
+            }
             onMovementUpdate={async (movementId, patch) => {
               const fullPatch: Partial<MovimientoConRelaciones> = patch
               await handleMovementUpdate(movementId, fullPatch)
@@ -433,9 +757,180 @@ export function TransactionManager() {
             onLoadMore={loadMore}
             hasMore={hasMore}
             onOpenFiles={(movement) => handleOpenFiles(movement as unknown as MovimientoConRelaciones)}
+            selectedMovements={selectedMovementIds}
+            onSelectionChange={(movement, checked) =>
+              handleSelectionChange(movement as unknown as MovimientoConRelaciones, checked)
+            }
+            selectionMode={isSelectionMode}
           />
         </div>
       </div>
+
+      {bulkCategoryOpen && selectedMovementIds.length > 0 && (
+        <div
+          className="fixed inset-0 z-[95] bg-black/50 flex items-end sm:items-center justify-center p-0 sm:p-6"
+          onClick={() => {
+            if (!bulkCategoryLoading) {
+              setBulkCategoryOpen(false)
+            }
+          }}
+        >
+          <div onClick={(event) => event.stopPropagation()}>
+            <CategoryMegaSelector
+              categories={categories}
+              selectedCategoryId={null}
+              onSelect={(categoryId) => handleBulkCategoryApply(categoryId)}
+              onClose={() => {
+                if (!bulkCategoryLoading) {
+                  setBulkCategoryOpen(false)
+                }
+              }}
+              headline={
+                selectedMovementIds.length === 1
+                  ? "1 transacción seleccionada"
+                  : `${selectedMovementIds.length} transacciones seleccionadas`
+              }
+            />
+          </div>
+        </div>
+      )}
+
+      <Dialog
+        open={bulkConceptOpen && selectedMovementIds.length > 0}
+        onOpenChange={(open) => {
+          if (!bulkActionLoading) {
+            setBulkConceptOpen(open)
+          }
+        }}
+      >
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Cambiar concepto</DialogTitle>
+            <DialogDescription>
+              El nuevo concepto se aplicará a {selectedMovementIds.length} transacciones.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <Input
+              value={bulkConceptValue}
+              onChange={(event) => setBulkConceptValue(event.target.value)}
+              placeholder="Nuevo concepto"
+              autoFocus
+            />
+            <div className="flex justify-end gap-2">
+              <Button
+                variant="outline"
+                onClick={() => setBulkConceptOpen(false)}
+                disabled={bulkActionLoading}
+                className="bg-transparent"
+              >
+                Cancelar
+              </Button>
+              <Button
+                onClick={handleBulkConceptSubmit}
+                disabled={bulkActionLoading || bulkConceptValue.trim() === ""}
+              >
+                {bulkActionLoading ? "Aplicando..." : "Aplicar"}
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={bulkDescriptionOpen && selectedMovementIds.length > 0}
+        onOpenChange={(open) => {
+          if (!bulkActionLoading) {
+            setBulkDescriptionOpen(open)
+          }
+        }}
+      >
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Añadir descripción</DialogTitle>
+            <DialogDescription>
+              El texto se sumará al final de la descripción existente de cada transacción seleccionada.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <Textarea
+              value={bulkAppendValue}
+              onChange={(event) => setBulkAppendValue(event.target.value)}
+              placeholder="Texto a añadir"
+              rows={4}
+            />
+            <div className="flex justify-end gap-2">
+              <Button
+                variant="outline"
+                onClick={() => setBulkDescriptionOpen(false)}
+                disabled={bulkActionLoading}
+                className="bg-transparent"
+              >
+                Cancelar
+              </Button>
+              <Button
+                onClick={handleBulkDescriptionSubmit}
+                disabled={bulkActionLoading || bulkAppendValue.trim() === ""}
+              >
+                {bulkActionLoading ? "Añadiendo..." : "Añadir"}
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={bulkDeleteOpen && selectedMovementIds.length > 0}
+        onOpenChange={(open) => {
+          if (!bulkActionLoading) {
+            setBulkDeleteOpen(open)
+          }
+        }}
+      >
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle className="text-destructive">
+              ¿ESTÁS ABSOLUTAMENTE SEGURO DE QUE QUIERES ELIMINAR ESTAS TRANSACCIONES?
+            </DialogTitle>
+            <DialogDescription className="text-destructive">
+              Esta acción no se puede deshacer.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-6">
+            <div className="flex flex-col items-center gap-3 text-center">
+              <div className="flex items-center gap-3">
+                <Skull className="h-12 w-12 text-destructive animate-bounce" />
+                <span className="text-lg font-semibold text-destructive">
+                  {selectedMovementIds.length === 1
+                    ? "1 transacción será eliminada"
+                    : `${selectedMovementIds.length} transacciones serán eliminadas`}
+                </span>
+              </div>
+              <p className="text-sm text-muted-foreground">
+                Respira hondo, tómate un segundo y confirma solo si estás segurísimo.
+              </p>
+            </div>
+            <div className="flex flex-col gap-2 sm:flex-row sm:justify-end">
+              <Button
+                variant="outline"
+                onClick={() => setBulkDeleteOpen(false)}
+                disabled={bulkActionLoading}
+                className="bg-transparent"
+              >
+                Cancelar
+              </Button>
+              <Button
+                variant="destructive"
+                onClick={handleBulkDeleteConfirm}
+                disabled={bulkActionLoading}
+                className="flex-1 sm:flex-none"
+              >
+                {bulkActionLoading ? "Eliminando..." : "Eliminar para siempre"}
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
 
       <TransactionDetail
         movement={selectedMovementSnapshot}

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import * as React from "react"
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
+import { Check, Minus } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+export type CheckboxProps = React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+
+export const Checkbox = React.forwardRef<
+  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  CheckboxProps
+>(({ className, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      "peer h-4 w-4 shrink-0 rounded-sm border border-primary/50 bg-background shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+      className,
+    )}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator className="flex items-center justify-center text-primary">
+      <Check className="h-3 w-3 data-[state=indeterminate]:hidden" />
+      <Minus className="hidden h-3 w-3 data-[state=indeterminate]:block" />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+))
+Checkbox.displayName = CheckboxPrimitive.Root.displayName
+
+export const SelectionCheckbox = React.forwardRef<
+  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  CheckboxProps
+>(({ className, children, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      "group relative flex h-9 w-9 items-center justify-center rounded-full border-2 border-primary/60 bg-background text-primary shadow-sm transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+      className,
+    )}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator className="flex h-full w-full items-center justify-center text-primary">
+      <Check className="h-5 w-5 data-[state=indeterminate]:hidden" />
+      <Minus className="hidden h-5 w-5 data-[state=indeterminate]:block" />
+    </CheckboxPrimitive.Indicator>
+    {children}
+  </CheckboxPrimitive.Root>
+))
+SelectionCheckbox.displayName = "SelectionCheckbox"

--- a/hooks/use-movimientos.ts
+++ b/hooks/use-movimientos.ts
@@ -398,6 +398,75 @@ export function useMovimientos(
     }
   }
 
+  const updateManyMovimientos = async (
+    movimientoIds: string[],
+    patch: Partial<MovimientoConRelaciones>,
+  ) => {
+    if (movimientoIds.length === 0) {
+      return
+    }
+
+    try {
+      const sanitizedPatch = { ...patch }
+      if (Object.keys(sanitizedPatch).length === 0) {
+        return
+      }
+
+      const { error } = await supabase
+        .from("movimiento")
+        .update(sanitizedPatch as any)
+        .in("id", movimientoIds)
+      if (error) throw error
+
+      const idSet = new Set(movimientoIds)
+      setMovimientos((prev) =>
+        prev.map((mov) => (idSet.has(mov.id) ? { ...mov, ...sanitizedPatch } : mov)),
+      )
+    } catch (err) {
+      throw err
+    }
+  }
+
+  const updateManyCategorias = async (
+    movimientoIds: string[],
+    categoriaId: string | null,
+  ) => {
+    if (movimientoIds.length === 0) {
+      return
+    }
+
+    try {
+      const { error } = await supabase
+        .from("movimiento")
+        .update({ categoria_id: categoriaId ?? null })
+        .in("id", movimientoIds)
+      if (error) throw error
+
+      const idSet = new Set(movimientoIds)
+      setMovimientos((prev) =>
+        prev.map((mov) => (idSet.has(mov.id) ? { ...mov, categoria_id: categoriaId ?? null } : mov)),
+      )
+    } catch (err) {
+      throw err
+    }
+  }
+
+  const deleteMovimientos = async (movimientoIds: string[]) => {
+    if (movimientoIds.length === 0) {
+      return
+    }
+
+    try {
+      const { error } = await supabase.from("movimiento").delete().in("id", movimientoIds)
+      if (error) throw error
+
+      const idSet = new Set(movimientoIds)
+      setMovimientos((prev) => prev.filter((mov) => !idSet.has(mov.id)))
+    } catch (err) {
+      throw err
+    }
+  }
+
   const refetch = () => {
     setMovimientos([])
     setPage(0)
@@ -412,6 +481,9 @@ export function useMovimientos(
     refetch,
     updateCategoria,
     updateMovimiento,
+    updateManyMovimientos,
+    updateManyCategorias,
+    deleteMovimientos,
     createMovimiento,
     loadMore,
     hasMore,


### PR DESCRIPTION
## Summary
- add reusable checkbox primitives to drive the selection UI
- enable multi-select mode with a bulk action bar to edit category, concept, description, or delete transactions at once
- expose bulk movement helpers and update the category selector to support multi-selection messaging

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68c9cf46a4d48326a6bc867924c053eb