### PR TITLE
Evita bloqueos al cargar delegaciones tras perder el foco

### DIFF
--- a/hooks/use-categorias.ts
+++ b/hooks/use-categorias.ts
@@ -37,6 +37,7 @@ export function useCategorias(
         label: 'fetch-categorias',
         table: 'categoria',
         timeoutMs: TIMEOUT_MS,
+        abortController: ac,
         build: async (signal) => {
           let query = supabase
             .from("categoria")

--- a/hooks/use-cuentas.ts
+++ b/hooks/use-cuentas.ts
@@ -72,6 +72,7 @@ export function useCuentas(
         label: 'fetch-cuentas',
         table: 'cuenta',
         timeoutMs: timeout,
+        abortController,
         build: async (signal) =>
           await supabase
             .from("cuenta")

--- a/hooks/use-delegations.ts
+++ b/hooks/use-delegations.ts
@@ -5,7 +5,7 @@ import { supabase } from "@/lib/supabase/client"
 import { useAuth } from "@/contexts/auth-context"
 import type { Delegacion } from "@/lib/types/database"
 import { useRevalidateOnFocusJitter } from "@/hooks/use-app-status"
-import { runQuery } from "@/lib/db/query"
+import { QUERY_TIMEOUT_ERROR_NAME, runQuery } from "@/lib/db/query"
 
 // Robust delegations hook with timeout, cancelation, and focus revalidation
 export function useDelegations({ timeout = 10000 }: { timeout?: number } = {}) {
@@ -39,6 +39,7 @@ export function useDelegations({ timeout = 10000 }: { timeout?: number } = {}) {
         label: 'fetch-delegaciones',
         table: 'membresia',
         timeoutMs: timeout,
+        abortController,
         build: async (signal) =>
           await supabase
             .from("membresia")
@@ -66,7 +67,10 @@ export function useDelegations({ timeout = 10000 }: { timeout?: number } = {}) {
       await attempt()
     } catch (err) {
       if (abortController.signal.aborted) {
-        // Mark as not loading to avoid spinners stuck on abort/timeout
+        // Distinguish between an intentional abort and a timeout that bubbled up.
+        if ((err as Error)?.name === QUERY_TIMEOUT_ERROR_NAME) {
+          setError('La carga de delegaciones tardó demasiado. Intenta recargar.')
+        }
         setLoading(false)
         return
       }

--- a/hooks/use-movimiento-archivos.ts
+++ b/hooks/use-movimiento-archivos.ts
@@ -39,6 +39,7 @@ export function useMovimientoArchivos(movimientoId: string | null, delegacionCod
         label: 'fetch-movimiento-archivos',
         table: 'movimiento_archivo',
         timeoutMs: TIMEOUT_MS,
+        abortController: ac,
         build: async (signal) =>
           await supabase
             .from("movimiento_archivo")

--- a/lib/db/query.ts
+++ b/lib/db/query.ts
@@ -7,31 +7,93 @@ export interface RunQueryOptions<T> {
   timeoutMs?: number
   build: (signal: AbortSignal) => Promise<{ data: T | null; error: any }>
   retryOnAuth?: boolean
+  abortController?: AbortController
 }
 
-export async function runQuery<T>({ label, table, timeoutMs = 15000, build, retryOnAuth = true }: RunQueryOptions<T>) {
-  const started = Date.now()
-  const ac = new AbortController()
+export const QUERY_TIMEOUT_ERROR_NAME = 'QueryTimeoutError' as const
 
-  const timeout = setTimeout(() => ac.abort(), timeoutMs)
+function createTimeoutError(label: string, timeoutMs: number) {
+  const error = new Error(`Query "${label}" timed out after ${timeoutMs}ms`)
+  error.name = QUERY_TIMEOUT_ERROR_NAME
+  return error
+}
+
+export async function runQuery<T>({
+  label,
+  table,
+  timeoutMs = 15000,
+  build,
+  retryOnAuth = true,
+  abortController,
+}: RunQueryOptions<T>) {
+  const started = Date.now()
+  const internalController = new AbortController()
+
+  const handleExternalAbort = () => {
+    internalController.abort()
+  }
+
+  if (abortController) {
+    if (abortController.signal.aborted) {
+      internalController.abort()
+    } else {
+      abortController.signal.addEventListener('abort', handleExternalAbort, { once: true })
+    }
+  }
+
+  const runWithTimeout = async () => {
+    if (!timeoutMs || timeoutMs <= 0) {
+      return await build(internalController.signal)
+    }
+
+    let timeoutId: NodeJS.Timeout | undefined
+    try {
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => {
+          if (abortController) {
+            abortController.abort()
+          }
+          internalController.abort()
+          reject(createTimeoutError(label, timeoutMs))
+        }, timeoutMs)
+      })
+
+      return (await Promise.race([
+        build(internalController.signal),
+        timeoutPromise,
+      ])) as { data: T | null; error: any }
+    } finally {
+      if (timeoutId) {
+        clearTimeout(timeoutId)
+      }
+    }
+  }
+
   try {
-    let { data, error } = await build(ac.signal)
+    let { data, error } = await runWithTimeout()
     if (error && retryOnAuth && shouldRetryAuth(error)) {
       try {
         await supabase.auth.refreshSession()
       } catch {}
-      ;({ data, error } = await build(ac.signal))
+      ;({ data, error } = await runWithTimeout())
     }
     const ms = Date.now() - started
     addMetric({ at: Date.now(), label, table, ms, status: error ? 'error' : 'ok', error: error?.message })
     return { data, error }
   } catch (err: any) {
     const ms = Date.now() - started
-    const status: 'timeout' | 'aborted' | 'error' = ac.signal.aborted ? 'timeout' : 'error'
+    const status: 'timeout' | 'aborted' | 'error' =
+      err?.name === QUERY_TIMEOUT_ERROR_NAME
+        ? 'timeout'
+        : internalController.signal.aborted || abortController?.signal.aborted
+          ? 'aborted'
+          : 'error'
     addMetric({ at: Date.now(), label, table, ms, status, error: err?.message || String(err) })
     return { data: null as T | null, error: err }
   } finally {
-    clearTimeout(timeout)
+    if (abortController) {
+      abortController.signal.removeEventListener('abort', handleExternalAbort)
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Add external abort handling and explicit timeout rejection to `runQuery` so hung requests stop the spinner
- Use the improved behaviour in the delegations hook to cancel properly and show a timeout hint when needed
- Pass the abort controllers from the category, account and archivo hooks into `runQuery` for consistent cancellation

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68c9d5c338dc8326a56d35850ad21b2f