### PR TITLE
Improve cancellation for delegation data fetching

### DIFF
--- a/hooks/use-categorias.ts
+++ b/hooks/use-categorias.ts
@@ -24,6 +24,12 @@ export function useCategorias(
 
     const ac = new AbortController()
     abortRef.current = ac
+    timeoutRef.current = setTimeout(() => {
+      if (!ac.signal.aborted) {
+        ac.abort()
+      }
+    }, TIMEOUT_MS + 1000)
+
     try {
       if (!delegacionId && !includeGlobal) {
         setCategorias([])
@@ -37,6 +43,7 @@ export function useCategorias(
         label: 'fetch-categorias',
         table: 'categoria',
         timeoutMs: TIMEOUT_MS,
+        externalSignal: ac.signal,
         build: async (signal) => {
           let query = supabase
             .from("categoria")
@@ -59,6 +66,10 @@ export function useCategorias(
         return
       }
 
+      if (ac.signal.aborted) {
+        return
+      }
+
       setCategorias(
         (data || []).sort((a, b) => {
           if (a.es_global !== b.es_global) {
@@ -68,7 +79,8 @@ export function useCategorias(
         }),
       )
     } catch (err) {
-      if (!ac.signal.aborted) {
+      const aborted = ac.signal.aborted || (err instanceof DOMException && err.name === "AbortError")
+      if (!aborted) {
         setError(err instanceof Error ? err.message : "Error desconocido")
       }
     } finally {

--- a/hooks/use-cuentas.ts
+++ b/hooks/use-cuentas.ts
@@ -62,6 +62,11 @@ export function useCuentas(
     // Create new abort controller for this request
     const abortController = new AbortController()
     abortControllerRef.current = abortController
+    timeoutRef.current = setTimeout(() => {
+      if (!abortController.signal.aborted) {
+        abortController.abort()
+      }
+    }, timeout + 1000)
 
     try {
       setLoading(true)
@@ -72,6 +77,7 @@ export function useCuentas(
         label: 'fetch-cuentas',
         table: 'cuenta',
         timeoutMs: timeout,
+        externalSignal: abortController.signal,
         build: async (signal) =>
           await supabase
             .from("cuenta")
@@ -122,11 +128,11 @@ export function useCuentas(
       setCuentas(transformedData)
       lastFetchAtRef.current = Date.now()
     } catch (err) {
-      if (abortController.signal.aborted) {
-        console.log("Cuentas query was cancelled")
+      const aborted = abortController.signal.aborted || (err instanceof DOMException && err.name === "AbortError")
+      if (aborted) {
         return
       }
-      
+
       const errorMessage = err instanceof Error ? err.message : "Error desconocido"
       console.error("Error fetching cuentas:", errorMessage)
       setError(errorMessage)

--- a/hooks/use-delegations.ts
+++ b/hooks/use-delegations.ts
@@ -17,6 +17,18 @@ export function useDelegations({ timeout = 10000 }: { timeout?: number } = {}) {
   const abortControllerRef = useRef<AbortController | null>(null)
   const timeoutRef = useRef<NodeJS.Timeout | null>(null)
 
+  const isAbortError = (err: unknown) => {
+    if (!err) return false
+    if (err instanceof DOMException) {
+      return err.name === "AbortError"
+    }
+    if (typeof err === "object" && "name" in err) {
+      return (err as { name?: unknown }).name === "AbortError"
+    }
+    const message = typeof err === "object" && err && "message" in err ? (err as { message?: unknown }).message : null
+    return typeof message === "string" && /abort(ed)?/i.test(message)
+  }
+
   const fetchDelegations = useCallback(async () => {
     if (!user) {
       setDelegations([])
@@ -31,6 +43,13 @@ export function useDelegations({ timeout = 10000 }: { timeout?: number } = {}) {
     const abortController = new AbortController()
     abortControllerRef.current = abortController
 
+    // Fallback timeout in case runQuery doesn't settle (e.g., suspended tab)
+    timeoutRef.current = setTimeout(() => {
+      if (!abortController.signal.aborted) {
+        abortController.abort()
+      }
+    }, timeout + 1000)
+
     const attempt = async () => {
       setLoading(true)
       setError(null)
@@ -39,6 +58,7 @@ export function useDelegations({ timeout = 10000 }: { timeout?: number } = {}) {
         label: 'fetch-delegaciones',
         table: 'membresia',
         timeoutMs: timeout,
+        externalSignal: abortController.signal,
         build: async (signal) =>
           await supabase
             .from("membresia")
@@ -58,6 +78,10 @@ export function useDelegations({ timeout = 10000 }: { timeout?: number } = {}) {
 
       if (error) throw error
 
+      if (abortController.signal.aborted) {
+        return
+      }
+
       const userDelegations = (data?.map((item: any) => item.delegacion).filter(Boolean) || []) as Delegacion[]
       setDelegations(userDelegations)
     }
@@ -65,7 +89,7 @@ export function useDelegations({ timeout = 10000 }: { timeout?: number } = {}) {
     try {
       await attempt()
     } catch (err) {
-      if (abortController.signal.aborted) {
+      if (abortController.signal.aborted || isAbortError(err)) {
         // Mark as not loading to avoid spinners stuck on abort/timeout
         setLoading(false)
         return

--- a/hooks/use-movimiento-archivos.ts
+++ b/hooks/use-movimiento-archivos.ts
@@ -34,11 +34,16 @@ export function useMovimientoArchivos(movimientoId: string | null, delegacionCod
     setError(null)
 
     try {
-      timeoutRef.current = setTimeout(() => ac.abort(), TIMEOUT_MS)
+      timeoutRef.current = setTimeout(() => {
+        if (!ac.signal.aborted) {
+          ac.abort()
+        }
+      }, TIMEOUT_MS + 1000)
       const { data, error } = await runQuery<any[]>({
         label: 'fetch-movimiento-archivos',
         table: 'movimiento_archivo',
         timeoutMs: TIMEOUT_MS,
+        externalSignal: ac.signal,
         build: async (signal) =>
           await supabase
             .from("movimiento_archivo")
@@ -50,9 +55,14 @@ export function useMovimientoArchivos(movimientoId: string | null, delegacionCod
 
       if (error) throw error
 
+      if (ac.signal.aborted) {
+        return
+      }
+
       setArchivos(data || [])
     } catch (err) {
-      if (!ac.signal.aborted) {
+      const aborted = ac.signal.aborted || (err instanceof DOMException && err.name === "AbortError")
+      if (!aborted) {
         setError(err instanceof Error ? err.message : "Error al cargar archivos")
       }
     } finally {

--- a/lib/db/query.ts
+++ b/lib/db/query.ts
@@ -7,11 +7,35 @@ export interface RunQueryOptions<T> {
   timeoutMs?: number
   build: (signal: AbortSignal) => Promise<{ data: T | null; error: any }>
   retryOnAuth?: boolean
+  /** Optional external signal to propagate cancellation/timeouts */
+  externalSignal?: AbortSignal | null
 }
 
-export async function runQuery<T>({ label, table, timeoutMs = 15000, build, retryOnAuth = true }: RunQueryOptions<T>) {
+export async function runQuery<T>({
+  label,
+  table,
+  timeoutMs = 15000,
+  build,
+  retryOnAuth = true,
+  externalSignal,
+}: RunQueryOptions<T>) {
   const started = Date.now()
   const ac = new AbortController()
+  let removeExternalAbortListener: (() => void) | undefined
+
+  if (externalSignal) {
+    const abort = () => {
+      if (!ac.signal.aborted) {
+        ac.abort()
+      }
+    }
+    if (externalSignal.aborted) {
+      abort()
+    } else {
+      externalSignal.addEventListener("abort", abort)
+      removeExternalAbortListener = () => externalSignal.removeEventListener("abort", abort)
+    }
+  }
 
   const timeout = setTimeout(() => ac.abort(), timeoutMs)
   try {
@@ -32,6 +56,9 @@ export async function runQuery<T>({ label, table, timeoutMs = 15000, build, retr
     return { data: null as T | null, error: err }
   } finally {
     clearTimeout(timeout)
+    if (removeExternalAbortListener) {
+      removeExternalAbortListener()
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- allow runQuery to accept an external AbortSignal and tie it to the internal controller
- harden useDelegations so it propagates cancellation, guards against abort errors and adds a fallback timer
- propagate the same cancellation behaviour to category, account and movement-file hooks

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68c9d5c338dc8326a56d35850ad21b2f