### PR TITLE
refactor: mejora gestion de categorias

### DIFF
--- a/components/categories/category-edit-form.tsx
+++ b/components/categories/category-edit-form.tsx
@@ -27,11 +27,33 @@ export function CategoryEditForm({ category, parentCategory, onSave, onCancel, c
     emoji: category.emoji || "📁",
     tipo: category.tipo,
     color: parentCategory?.color || category.color || "#4ECDC4",
-    scope: (category.es_global ? "global" : "delegacion") as ScopeOption,
+    scope: (parentCategory
+      ? parentCategory.es_global
+        ? "global"
+        : "delegacion"
+      : category.es_global
+        ? "global"
+        : "delegacion") as ScopeOption,
   })
   const [loading, setLoading] = useState(false)
 
   const canToggleGlobal = canManageGlobal && (!parentCategory || parentCategory.es_global)
+
+  useEffect(() => {
+    setFormData({
+      nombre: category.nombre,
+      emoji: category.emoji || "📁",
+      tipo: category.tipo,
+      color: parentCategory?.color || category.color || "#4ECDC4",
+      scope: (parentCategory
+        ? parentCategory.es_global
+          ? "global"
+          : "delegacion"
+        : category.es_global
+          ? "global"
+          : "delegacion") as ScopeOption,
+    })
+  }, [category, parentCategory])
 
   useEffect(() => {
     if (!canToggleGlobal) {
@@ -50,12 +72,20 @@ export function CategoryEditForm({ category, parentCategory, onSave, onCancel, c
     setLoading(true)
 
     try {
+      const resolvedScope = parentCategory
+        ? parentCategory.es_global
+          ? "global"
+          : "delegacion"
+        : formData.scope
+
       await onSave({
         nombre: formData.nombre.trim(),
         emoji: formData.emoji,
         tipo: formData.tipo,
-        ...(parentCategory ? {} : { color: formData.color }),
-        es_global: formData.scope === "global",
+        ...(parentCategory
+          ? { categoria_padre_id: parentCategory.id }
+          : { color: formData.color }),
+        es_global: resolvedScope === "global",
       })
     } catch (error) {
       console.error("Error saving category:", error)

--- a/components/categories/category-list.tsx
+++ b/components/categories/category-list.tsx
@@ -1,14 +1,13 @@
 "use client"
 
 import { cn } from "@/lib/utils"
-import { useState, useEffect } from "react"
+import { useState, useEffect, useMemo } from "react"
 import { useSearchParams } from "next/navigation"
 import { DragDropContext, Droppable, Draggable, type DropResult } from "@hello-pangea/dnd"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Card, CardContent } from "@/components/ui/card"
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet"
-import { Badge } from "@/components/ui/badge"
 import { CategoryEditForm } from "./category-edit-form"
 import { DateRangeFilter } from "@/components/transactions/date-range-filter"
 import { useCategorias } from "@/hooks/use-categorias"
@@ -16,143 +15,170 @@ import { useMovimientos } from "@/hooks/use-movimientos"
 import { useDelegationContext } from "@/contexts/delegation-context"
 import useIsAdmin from "@/hooks/use-is-admin"
 import { DatabaseService } from "@/lib/services/database"
-import { GripVertical, Search, Edit, Trash2, Plus, X, Globe2 } from "lucide-react"
+import { GripVertical, Search, Edit, Trash2, Plus, X, Globe2, PlusCircle } from "lucide-react"
 import { AmountDisplay } from "@/components/amount-display"
 import { DeleteCategoryDialog } from "./delete-category-dialog"
 import { RelatedMovementsSheet } from "@/components/transactions/related-movements-sheet"
 import type { Categoria } from "@/lib/types/database"
 
-
 interface CategoryCardProps {
   category: Categoria
   index: number
+  depth: number
   balance: number
   onEdit: (category: Categoria) => void
   onSearch: (category: Categoria) => void
   onDelete: (category: Categoria) => void
+  onAddSubcategory?: (category: Categoria) => void
   canEdit: boolean
   canDelete: boolean
+  canAddSubcategory: boolean
   isDragDisabled: boolean
+  dragDisabledReason?: string
   isGlobal: boolean
 }
 
 function CategoryCard({
   category,
   index,
+  depth,
   balance,
   onEdit,
   onSearch,
   onDelete,
+  onAddSubcategory,
   canEdit,
   canDelete,
+  canAddSubcategory,
   isDragDisabled,
+  dragDisabledReason,
   isGlobal,
 }: CategoryCardProps) {
-  const isSub = !!category.categoria_padre_id
+  const indentation = depth * 24
+  const addSubcategoryTitle = canAddSubcategory
+    ? "Añadir subcategoría"
+    : category.es_global
+      ? "Solo el gestor central puede añadir subcategorías globales"
+      : "No puedes añadir subcategorías en este momento"
+
   return (
     <Draggable draggableId={category.id} index={index} isDragDisabled={isDragDisabled}>
       {(provided, snapshot) => (
-        <Card
+        <div
           ref={provided.innerRef}
           {...provided.draggableProps}
-          className={cn(
-            "transition-shadow hover:shadow-md",
-            snapshot.isDragging && "shadow-lg rotate-2",
-            isSub && "ml-6",
-            isDragDisabled && "opacity-95",
-          )}
+          style={{
+            ...provided.draggableProps.style,
+          }}
+          className={cn("relative", snapshot.isDragging && "z-40")}
         >
-          <CardContent className="p-3 sm:p-4 lg:p-6">
-            <div className="flex items-center gap-3 sm:gap-4">
-              {/* Drag Handle */}
-              <div
-                {...(provided.dragHandleProps ?? {})}
-                className={cn(
-                  "flex h-8 w-8 items-center justify-center rounded text-muted-foreground hover:bg-muted flex-shrink-0",
-                  isDragDisabled ? "cursor-default opacity-40" : "cursor-grab active:cursor-grabbing",
-                )}
-                title={
-                  isDragDisabled
-                    ? "Solo el gestor central puede reorganizar categorías globales"
-                    : undefined
-                }
-              >
-                <GripVertical className="h-4 w-4" />
-              </div>
+          <div style={{ marginLeft: indentation }}>
+            <Card
+              className={cn(
+                "transition-shadow hover:shadow-md bg-background",
+                snapshot.isDragging && "shadow-lg ring-2 ring-primary/40",
+                depth > 0 && "border-muted-foreground/20",
+              )}
+            >
+              <CardContent className="p-3 sm:p-4 lg:p-5">
+                <div className="flex items-start gap-3 sm:gap-4">
+                  <div
+                    {...(provided.dragHandleProps ?? {})}
+                    className={cn(
+                      "flex h-8 w-8 items-center justify-center rounded-md border border-dashed flex-shrink-0 text-muted-foreground",
+                      isDragDisabled
+                        ? "cursor-not-allowed border-transparent opacity-40"
+                        : "cursor-grab border-transparent bg-muted/40 hover:bg-muted/70 active:cursor-grabbing",
+                    )}
+                    title={isDragDisabled ? dragDisabledReason : "Arrastra para reordenar"}
+                  >
+                    <GripVertical className="h-4 w-4" />
+                  </div>
 
-              {/* Category Icon */}
-              <div
-                className={cn(
-                  "flex h-12 w-12 sm:h-14 sm:w-14 lg:h-16 lg:w-16 items-center justify-center rounded-xl text-xl sm:text-2xl shadow-sm flex-shrink-0",
-                  isSub && "h-10 w-10 sm:h-12 sm:w-12 lg:h-14 lg:w-14 text-lg sm:text-xl",
-                )}
-                style={{ backgroundColor: category.color || "#e5e7eb" }}
-              >
-                {category.emoji || "📁"}
-              </div>
+                  <div
+                    className={cn(
+                      "flex h-12 w-12 sm:h-14 sm:w-14 items-center justify-center rounded-xl text-xl sm:text-2xl shadow-sm flex-shrink-0",
+                      depth > 0 && "h-10 w-10 sm:h-12 sm:w-12 text-lg sm:text-xl",
+                    )}
+                    style={{ backgroundColor: category.color || "#e5e7eb" }}
+                  >
+                    {category.emoji || "📁"}
+                  </div>
 
-              {/* Category Info */}
-              <div className="flex-1 min-w-0">
-                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
-                  <div className="min-w-0">
+                  <div className="flex-1 min-w-0">
                     <div className="flex flex-wrap items-center gap-2">
-                      <h3 className={cn("font-semibold text-base sm:text-lg truncate", isSub && "font-medium")}>{category.nombre}</h3>
+                      <h3
+                        className={cn(
+                          "font-semibold text-base sm:text-lg truncate",
+                          depth > 0 && "font-medium",
+                        )}
+                      >
+                        {category.nombre}
+                      </h3>
                       {isGlobal && (
-                        <Badge
-                          variant="outline"
-                          className="flex items-center gap-1 border-blue-200 bg-blue-50 text-blue-700 dark:bg-blue-950/30 dark:text-blue-200"
-                        >
+                        <span className="flex items-center gap-1 text-xs font-medium uppercase tracking-wide text-blue-500 dark:text-blue-200">
                           <Globe2 className="h-3 w-3" />
-                          <span className="text-[10px] uppercase tracking-wide">Global</span>
-                        </Badge>
+                          <span>Global</span>
+                        </span>
                       )}
                     </div>
                     <div className="mt-1 text-xs text-muted-foreground">
                       <AmountDisplay amount={balance} size="sm" />
                     </div>
                   </div>
-                </div>
-              </div>
 
-              {/* Action Buttons */}
-              <div className="flex items-center gap-1 flex-shrink-0">
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-8 w-8 sm:h-9 sm:w-9 text-blue-600 hover:bg-blue-50"
-                  onClick={() => onSearch(category)}
-                  title="Buscar transacciones"
-                >
-                  <Search className="h-3 w-3 sm:h-4 sm:w-4" />
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-8 w-8 sm:h-9 sm:w-9 text-gray-600 hover:bg-gray-50"
-                  onClick={() => onEdit(category)}
-                  title={canEdit ? "Editar categoría" : "Solo el gestor central puede editar categorías globales"}
-                  disabled={!canEdit}
-                >
-                  <Edit className="h-3 w-3 sm:h-4 sm:w-4" />
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-8 w-8 sm:h-9 sm:w-9 text-red-600 hover:bg-red-50"
-                  onClick={() => onDelete(category)}
-                  title={canDelete ? "Eliminar categoría" : "Solo el gestor central puede eliminar categorías globales"}
-                  disabled={!canDelete}
-                >
-                  <Trash2 className="h-3 w-3 sm:h-4 sm:w-4" />
-                </Button>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
+                  <div className="flex items-center gap-1 flex-shrink-0">
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8 sm:h-9 sm:w-9 text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-950/30"
+                      onClick={() => onSearch(category)}
+                      title="Buscar transacciones"
+                    >
+                      <Search className="h-3 w-3 sm:h-4 sm:w-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8 sm:h-9 sm:w-9 text-emerald-600 hover:bg-emerald-50 dark:hover:bg-emerald-950/30"
+                      onClick={() => onAddSubcategory?.(category)}
+                      title={addSubcategoryTitle}
+                      disabled={!canAddSubcategory}
+                    >
+                      <PlusCircle className="h-3 w-3 sm:h-4 sm:w-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8 sm:h-9 sm:w-9 text-gray-600 hover:bg-gray-50 dark:hover:bg-gray-900/30"
+                      onClick={() => onEdit(category)}
+                      title={canEdit ? "Editar categoría" : "Solo el gestor central puede editar categorías globales"}
+                      disabled={!canEdit}
+                    >
+                      <Edit className="h-3 w-3 sm:h-4 sm:w-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8 sm:h-9 sm:w-9 text-red-600 hover:bg-red-50 dark:hover:bg-red-950/30"
+                      onClick={() => onDelete(category)}
+                      title={canDelete ? "Eliminar categoría" : "Solo el gestor central puede eliminar categorías globales"}
+                      disabled={!canDelete}
+                    >
+                      <Trash2 className="h-3 w-3 sm:h-4 sm:w-4" />
+                    </Button>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
       )}
     </Draggable>
   )
 }
+
+type Scope = "global" | "local"
 
 export function CategoryList() {
   const { selectedDelegation, getCurrentDelegation } = useDelegationContext()
@@ -163,6 +189,7 @@ export function CategoryList() {
   const [deletingCategory, setDeletingCategory] = useState<Categoria | null>(null)
   const [editSheetOpen, setEditSheetOpen] = useState(false)
   const [createSheetOpen, setCreateSheetOpen] = useState(false)
+  const [creatingParent, setCreatingParent] = useState<Categoria | null>(null)
   const [viewingCategory, setViewingCategory] = useState<Categoria | null>(null)
   const [dateFrom, setDateFrom] = useState<string | undefined>()
   const [dateTo, setDateTo] = useState<string | undefined>()
@@ -174,24 +201,24 @@ export function CategoryList() {
   const { movimientos } = useMovimientos(selectedDelegation || null)
   const searchParams = useSearchParams()
 
-  // Todos los useEffect y useCallback van aquí
   useEffect(() => {
     if (searchParams.get("panel") === "create") {
       setEditingCategory(null)
+      setCreatingParent(null)
       setCreateSheetOpen(true)
     }
   }, [searchParams])
 
   const getCategoryBalance = (categoryId: string) => {
     let filteredMovements = movimientos.filter((mov) => mov.categoria_id === categoryId)
-    
+
     if (dateFrom) {
       filteredMovements = filteredMovements.filter((mov) => mov.fecha >= dateFrom)
     }
     if (dateTo) {
       filteredMovements = filteredMovements.filter((mov) => mov.fecha <= dateTo)
     }
-    
+
     return filteredMovements.reduce((sum, mov) => sum + mov.importe, 0)
   }
 
@@ -203,6 +230,7 @@ export function CategoryList() {
   const canEditCategory = (category: Categoria) => !category.es_global || isCentralManager
   const canDeleteCategory = (category: Categoria) => !category.es_global || isCentralManager
   const canReorderCategory = (category: Categoria) => !category.es_global || isCentralManager
+  const canCreateSubcategory = (category: Categoria) => (category.es_global ? isCentralManager : true)
 
   const handleEdit = (category: Categoria) => {
     if (!canEditCategory(category)) return
@@ -211,6 +239,14 @@ export function CategoryList() {
   }
 
   const handleCreate = () => {
+    setEditingCategory(null)
+    setCreatingParent(null)
+    setCreateSheetOpen(true)
+  }
+
+  const handleAddSubcategory = (category: Categoria) => {
+    if (!canCreateSubcategory(category)) return
+    setCreatingParent(category)
     setEditingCategory(null)
     setCreateSheetOpen(true)
   }
@@ -230,8 +266,8 @@ export function CategoryList() {
     try {
       await DatabaseService.deleteCategoria(deletingCategory.id)
       await fetchCategorias()
-    } catch (error) {
-      console.error("Error deleting category:", error)
+    } catch (err) {
+      console.error("Error deleting category:", err)
       alert("Error al eliminar la categoría")
     } finally {
       setDeletingCategory(null)
@@ -247,11 +283,15 @@ export function CategoryList() {
           tipo: patch.tipo,
         }
 
-        if (patch.color && editingCategory.categoria_padre_id === null) {
+        if (patch.categoria_padre_id !== undefined) {
+          updates.categoria_padre_id = patch.categoria_padre_id
+        }
+
+        if (!editingCategory.categoria_padre_id && patch.color) {
           updates.color = patch.color
         }
 
-        if (patch.es_global !== undefined) {
+        if (isCentralManager && patch.es_global !== undefined) {
           updates.es_global = patch.es_global
           updates.delegacion_id = patch.es_global ? null : selectedDelegation || editingCategory.delegacion_id
 
@@ -277,29 +317,37 @@ export function CategoryList() {
           throw new Error("No se ha podido determinar la organización")
         }
 
-        const isGlobal = !!patch.es_global
+        const parentCategory = creatingParent
+        const parentId = parentCategory?.id ?? patch.categoria_padre_id ?? null
+        const targetIsGlobal = parentCategory ? parentCategory.es_global : !!patch.es_global
 
-        if (!isGlobal && !selectedDelegation) {
+        if (targetIsGlobal && !isCentralManager) {
+          alert("Solo el gestor central puede crear categorías globales")
+          return
+        }
+
+        if (!targetIsGlobal && !selectedDelegation) {
           alert("Selecciona una delegación para crear categorías locales")
           return
         }
 
-        const relevantCategories = categories.filter((category) =>
-          isGlobal ? category.es_global : !category.es_global && category.delegacion_id === selectedDelegation,
+        const siblings = categories.filter(
+          (category) =>
+            (category.categoria_padre_id ?? null) === parentId &&
+            (targetIsGlobal ? category.es_global : !category.es_global),
         )
-        const maxOrder =
-          relevantCategories.length > 0 ? Math.max(...relevantCategories.map((c) => c.orden)) : 0
+        const maxOrder = siblings.length > 0 ? Math.max(...siblings.map((c) => c.orden)) : 0
 
         await DatabaseService.createCategoria({
           organizacion_id: organizacionId,
-          delegacion_id: isGlobal ? null : selectedDelegation!,
+          delegacion_id: targetIsGlobal ? null : parentCategory?.delegacion_id ?? selectedDelegation!,
           nombre: patch.nombre!,
           tipo: patch.tipo!,
-          emoji: patch.emoji || "📁",
-          color: patch.color || "#4ECDC4",
+          emoji: patch.emoji || parentCategory?.emoji || "📁",
+          color: parentCategory?.color || patch.color || "#4ECDC4",
           orden: maxOrder + 1,
-          categoria_padre_id: patch.categoria_padre_id ?? null,
-          es_global: isGlobal,
+          categoria_padre_id: parentId,
+          es_global: targetIsGlobal,
         })
       }
 
@@ -307,88 +355,101 @@ export function CategoryList() {
       setEditSheetOpen(false)
       setCreateSheetOpen(false)
       setEditingCategory(null)
-    } catch (error) {
-      console.error("Error saving category:", error)
+      setCreatingParent(null)
+    } catch (err) {
+      console.error("Error saving category:", err)
       alert("Error al guardar la categoría")
     }
   }
 
-  const handleDragEnd = async (result: DropResult) => {
-    if (!result.destination) return
+  const categoryMap = useMemo(() => new Map(categories.map((cat) => [cat.id, cat])), [categories])
 
-    const items = Array.from(sortedCategories)
-    const [moved] = items.splice(result.source.index, 1)
-    items.splice(result.destination.index, 0, moved)
-
-    if (!canReorderCategory(moved)) return
-
-    const prev = items[result.destination.index - 1] ?? null
-    let newParentId: string | null = null
-
-    if (prev) {
-      newParentId = prev.categoria_padre_id === null ? prev.id : prev.categoria_padre_id
+  const childrenMap = useMemo(() => {
+    const map = new Map<string | null, Categoria[]>()
+    for (const category of categories) {
+      const key = category.categoria_padre_id ?? null
+      const collection = map.get(key)
+      if (collection) {
+        collection.push(category)
+      } else {
+        map.set(key, [category])
+      }
     }
 
-    if (newParentId) {
-      const parent = items.find((c) => c.id === newParentId)
-      if (parent) {
-        if (moved.es_global && !parent.es_global) {
-          newParentId = null
-        } else if (!moved.es_global && parent.delegacion_id && parent.delegacion_id !== (moved.delegacion_id || selectedDelegation)) {
-          newParentId = parent.es_global ? parent.id : null
+    map.forEach((list) => {
+      list.sort((a, b) => {
+        if (a.orden !== b.orden) return a.orden - b.orden
+        return a.nombre.localeCompare(b.nombre)
+      })
+    })
+
+    return map
+  }, [categories])
+
+  const isFiltering = searchTerm.trim().length > 0
+
+  const visibleCategoryIds = useMemo(() => {
+    if (!isFiltering) {
+      return new Set(categories.map((cat) => cat.id))
+    }
+
+    const lowerTerm = searchTerm.toLowerCase()
+    const matches = new Set<string>()
+
+    const addAncestors = (categoryId: string) => {
+      let current = categoryMap.get(categoryId)
+      while (current?.categoria_padre_id) {
+        const parentId = current.categoria_padre_id
+        matches.add(parentId)
+        current = categoryMap.get(parentId)
+      }
+    }
+
+    const addDescendants = (categoryId: string) => {
+      const children = childrenMap.get(categoryId) ?? []
+      for (const child of children) {
+        if (!matches.has(child.id)) {
+          matches.add(child.id)
+          addDescendants(child.id)
         }
       }
     }
 
-    const parentColor = newParentId ? items.find((c) => c.id === newParentId)?.color || moved.color : moved.color
-
-    try {
-      const updates = items
-        .map((item, index) => {
-          const original = sortedCategories.find((c) => c.id === item.id)
-          const newOrden = index + 1
-          const isMoved = item.id === moved.id
-          const ordenChanged = original ? original.orden !== newOrden : true
-
-          if (isMoved) {
-            const payload: Partial<Categoria> = {
-              orden: newOrden,
-              categoria_padre_id: newParentId,
-              color: parentColor,
-            }
-
-            return updateCategoria(item.id, payload)
-          } else if (ordenChanged) {
-            return updateCategoria(item.id, { orden: newOrden })
-          }
-
-          return null
-        })
-        .filter(Boolean) as Promise<void>[]
-
-      await Promise.all(updates)
-      await fetchCategorias()
-    } catch (error) {
-      console.error("Error reordering categories:", error)
+    for (const category of categories) {
+      if (category.nombre.toLowerCase().includes(lowerTerm)) {
+        matches.add(category.id)
+        addAncestors(category.id)
+        addDescendants(category.id)
+      }
     }
-  }
 
-  // Logica de filtrado y ordenación (después de todos los hooks)
-  const filteredCategories = categories.filter((category) =>
-    category.nombre.toLowerCase().includes(searchTerm.toLowerCase()),
+    return matches
+  }, [isFiltering, searchTerm, categories, categoryMap, childrenMap])
+
+  const allGlobalRoots = useMemo(
+    () => (childrenMap.get(null) ?? []).filter((cat) => cat.es_global),
+    [childrenMap],
+  )
+  const allLocalRoots = useMemo(
+    () => (childrenMap.get(null) ?? []).filter((cat) => !cat.es_global),
+    [childrenMap],
   )
 
-  const sortedCategories = [...filteredCategories].sort((a, b) => {
-    if (a.es_global !== b.es_global) {
-      return a.es_global ? -1 : 1
-    }
-    return a.orden - b.orden
-  })
+  const visibleGlobalRoots = useMemo(
+    () => allGlobalRoots.filter((cat) => !isFiltering || visibleCategoryIds.has(cat.id)),
+    [allGlobalRoots, isFiltering, visibleCategoryIds],
+  )
+  const visibleLocalRoots = useMemo(
+    () => allLocalRoots.filter((cat) => !isFiltering || visibleCategoryIds.has(cat.id)),
+    [allLocalRoots, isFiltering, visibleCategoryIds],
+  )
+
+  const hasAnyCategory = categories.length > 0
+  const hasVisibleCategories = categories.some((cat) => visibleCategoryIds.has(cat.id))
 
   const globalCount = categories.filter((category) => category.es_global).length
   const localCount = categories.length - globalCount
 
-  // Renders condicionales al final
   if (!selectedDelegation) {
     return (
       <div className="flex items-center justify-center py-12">
@@ -416,37 +477,256 @@ export function CategoryList() {
     )
   }
 
+  const parseDroppableId = (droppableId: string): { parentId: string | null; scope: Scope } | null => {
+    if (droppableId === "root-global") return { parentId: null, scope: "global" }
+    if (droppableId === "root-local") return { parentId: null, scope: "local" }
+    if (droppableId.startsWith("children-")) {
+      const parentId = droppableId.replace("children-", "")
+      const parent = categoryMap.get(parentId)
+      if (!parent) return null
+      return { parentId, scope: parent.es_global ? "global" : "local" }
+    }
+    return null
+  }
+
+  const getDroppableItems = (droppableId: string) => {
+    const info = parseDroppableId(droppableId)
+    if (!info) return []
+    if (info.parentId === null) {
+      const rootItems = childrenMap.get(null) ?? []
+      return rootItems.filter((cat) => (info.scope === "global" ? cat.es_global : !cat.es_global))
+    }
+    return childrenMap.get(info.parentId) ?? []
+  }
+
+  const handleDragEnd = async (result: DropResult) => {
+    const { destination, source, draggableId } = result
+    if (!destination) return
+    if (isFiltering) return
+    if (destination.droppableId === source.droppableId && destination.index === source.index) return
+
+    const moved = categoryMap.get(draggableId)
+    if (!moved) return
+    if (!canReorderCategory(moved)) return
+
+    const sourceInfo = parseDroppableId(source.droppableId)
+    const destInfo = parseDroppableId(destination.droppableId)
+    if (!sourceInfo || !destInfo) return
+
+    const destinationParentId = destInfo.parentId
+    const destinationParent = destinationParentId ? categoryMap.get(destinationParentId) ?? null : null
+
+    if (destInfo.scope === "global" && !moved.es_global) {
+      alert("Solo el gestor central puede convertir una categoría en global.")
+      return
+    }
+
+    if (destinationParent && moved.es_global && !destinationParent.es_global) {
+      alert("No puedes anidar una categoría global dentro de una categoría local.")
+      return
+    }
+
+    if (
+      destinationParent &&
+      destinationParent.delegacion_id &&
+      destinationParent.delegacion_id !== (moved.delegacion_id || selectedDelegation)
+    ) {
+      alert("No puedes mover la categoría a otra delegación.")
+      return
+    }
+
+    if (destinationParent && destinationParent.es_global && !moved.es_global) {
+      alert("Solo el gestor central puede crear subcategorías globales.")
+      return
+    }
+
+    const sourceItems = Array.from(getDroppableItems(source.droppableId))
+    const destItems =
+      source.droppableId === destination.droppableId
+        ? sourceItems
+        : Array.from(getDroppableItems(destination.droppableId))
+
+    const [removed] = sourceItems.splice(source.index, 1)
+    if (!removed || removed.id !== moved.id) {
+      return
+    }
+
+    if (source.droppableId === destination.droppableId) {
+      sourceItems.splice(destination.index, 0, removed)
+    } else {
+      destItems.splice(destination.index, 0, removed)
+    }
+
+    const updates: Promise<void>[] = []
+    const processList = (list: Categoria[], droppableId: string) => {
+      const info = parseDroppableId(droppableId)
+      if (!info) return
+      const expectedParentId = info.parentId
+      list.forEach((item, index) => {
+        const payload: Partial<Categoria> = {}
+        const newOrden = index + 1
+        const currentParentId = item.categoria_padre_id ?? null
+
+        if (currentParentId !== expectedParentId) {
+          payload.categoria_padre_id = expectedParentId
+          if (item.id === moved.id) {
+            if (expectedParentId) {
+              const parent = categoryMap.get(expectedParentId)
+              payload.color = parent?.color ?? item.color
+              payload.es_global = parent?.es_global ?? item.es_global
+              payload.delegacion_id = parent?.delegacion_id ?? null
+            } else {
+              payload.es_global = info.scope === "global"
+              payload.delegacion_id = info.scope === "global" ? null : selectedDelegation || item.delegacion_id
+            }
+          }
+        }
+
+        if (item.orden !== newOrden) {
+          payload.orden = newOrden
+        }
+
+        if (item.id === moved.id && !expectedParentId && info.scope === "local") {
+          payload.delegacion_id = selectedDelegation || item.delegacion_id
+        }
+
+        if (Object.keys(payload).length > 0) {
+          updates.push(updateCategoria(item.id, payload))
+        }
+      })
+    }
+
+    processList(sourceItems, source.droppableId)
+    if (source.droppableId !== destination.droppableId) {
+      processList(destItems, destination.droppableId)
+    }
+
+    if (updates.length === 0) return
+
+    try {
+      await Promise.all(updates)
+      await fetchCategorias()
+    } catch (err) {
+      console.error("Error reordenando categorías:", err)
+      alert("No se pudo reordenar la categoría.")
+    }
+  }
+
+  const renderCategoryTree = (
+    parentId: string | null,
+    depth: number,
+    scope: Scope,
+    items: Categoria[],
+  ) => {
+    const droppableId = parentId ? `children-${parentId}` : scope === "global" ? "root-global" : "root-local"
+    const dropDisabled =
+      isFiltering ||
+      (parentId
+        ? categoryMap.get(parentId)?.es_global && !isCentralManager
+        : scope === "global" && !isCentralManager)
+    const fullItems =
+      parentId === null
+        ? (childrenMap.get(null) ?? []).filter((cat) => (scope === "global" ? cat.es_global : !cat.es_global))
+        : childrenMap.get(parentId) ?? []
+    const noVisibleButExisting = isFiltering && fullItems.length > 0 && items.length === 0
+
+    const placeholderText = parentId
+      ? dropDisabled
+        ? "Sin subcategorías"
+        : "Suelta aquí para crear una subcategoría"
+      : dropDisabled
+        ? scope === "global"
+          ? "Solo el gestor central puede reorganizar globales"
+          : "Sin categorías locales"
+        : "Suelta aquí para ordenar en este nivel"
+
+    return (
+      <Droppable droppableId={droppableId} type="CATEGORY" isDropDisabled={dropDisabled}>
+        {(provided, snapshot) => (
+          <div
+            ref={provided.innerRef}
+            className={cn(
+              "space-y-2",
+              parentId ? "ml-6 border-l border-dashed border-muted-foreground/30 pl-4" : "space-y-4",
+              snapshot.isDraggingOver && "rounded-lg bg-muted/40",
+            )}
+          >
+            {items.map((category, index) => {
+              const childItems = (childrenMap.get(category.id) ?? []).filter(
+                (child) => !isFiltering || visibleCategoryIds.has(child.id),
+              )
+              const dragDisabled = isFiltering || !canReorderCategory(category)
+              const dragDisabledReason = !canReorderCategory(category)
+                ? "Solo el gestor central puede reorganizar categorías globales"
+                : "Desactiva los filtros para reorganizar"
+
+              return (
+                <div key={category.id} className="space-y-2">
+                  <CategoryCard
+                    category={category}
+                    index={index}
+                    depth={depth}
+                    balance={getCategoryBalance(category.id)}
+                    onEdit={handleEdit}
+                    onSearch={handleSearch}
+                    onDelete={handleDeleteRequest}
+                    onAddSubcategory={handleAddSubcategory}
+                    canEdit={canEditCategory(category)}
+                    canDelete={canDeleteCategory(category)}
+                    canAddSubcategory={canCreateSubcategory(category)}
+                    isDragDisabled={dragDisabled}
+                    dragDisabledReason={dragDisabled ? dragDisabledReason : undefined}
+                    isGlobal={category.es_global}
+                  />
+                  {renderCategoryTree(category.id, depth + 1, category.es_global ? "global" : "local", childItems)}
+                </div>
+              )
+            })}
+            {items.length === 0 && !noVisibleButExisting && (
+              <div
+                className={cn(
+                  "rounded-md border border-dashed border-muted-foreground/30 py-3 text-center text-xs text-muted-foreground",
+                  snapshot.isDraggingOver && "border-primary/60 text-primary",
+                )}
+              >
+                {placeholderText}
+              </div>
+            )}
+            {noVisibleButExisting && (
+              <div className="rounded-md bg-muted/30 py-3 text-center text-xs text-muted-foreground">
+                No hay resultados dentro de esta categoría.
+              </div>
+            )}
+            {provided.placeholder}
+          </div>
+        )}
+      </Droppable>
+    )
+  }
+
+  const showEmptyState = !hasAnyCategory && !isFiltering
+  const showNoResults = hasAnyCategory && !hasVisibleCategories
+
   return (
     <div className="space-y-4 sm:space-y-6">
-      {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-      <div>
-        <h2 className="text-2xl sm:text-3xl font-bold">Categorías</h2>
-        <p className="text-muted-foreground mt-1 text-sm sm:text-base">
-          {localCount} locales • {globalCount} globales • Arrastra para reordenar
-        </p>
-      </div>
-      <Button
-        onClick={handleCreate}
-        size="default"
-        className="w-full sm:w-auto"
-        disabled={!organizacionId}
-      >
-        <Plus className="h-4 w-4 mr-2" />
-        Añadir categoría
-      </Button>
+        <div>
+          <h2 className="text-2xl sm:text-3xl font-bold">Categorías</h2>
+          <p className="text-muted-foreground mt-1 text-sm sm:text-base">
+            {localCount} locales • {globalCount} globales • Arrastra para reordenar o anidar categorías
+          </p>
+        </div>
+        <Button onClick={handleCreate} size="default" className="w-full sm:w-auto" disabled={!organizacionId}>
+          <Plus className="h-4 w-4 mr-2" />
+          Añadir categoría
+        </Button>
       </div>
 
-      {/* Filters */}
-      <div className="flex gap-4">
+      <div className="flex gap-4 flex-col sm:flex-row">
         <div className="flex-1 sm:flex-1">
-          <DateRangeFilter
-            dateFrom={dateFrom}
-            dateTo={dateTo}
-            onDateRangeChange={handleDateRangeChange}
-          />
+          <DateRangeFilter dateFrom={dateFrom} dateTo={dateTo} onDateRangeChange={handleDateRangeChange} />
         </div>
-        
+
         <div className="w-auto sm:flex-1">
           <div className="sm:hidden">
             {searchOpen ? (
@@ -474,12 +754,7 @@ export function CategoryList() {
                 </Button>
               </div>
             ) : (
-              <Button
-                variant="outline"
-                size="icon"
-                className="h-12 w-12"
-                onClick={() => setSearchOpen(true)}
-              >
+              <Button variant="outline" size="icon" className="h-12 w-12" onClick={() => setSearchOpen(true)}>
                 <Search className="h-4 w-4" />
               </Button>
             )}
@@ -497,48 +772,59 @@ export function CategoryList() {
         </div>
       </div>
 
-      {sortedCategories.length === 0 ? (
+      {isFiltering && (
+        <p className="text-xs text-muted-foreground">
+          El reordenamiento se desactiva mientras hay filtros activos.
+        </p>
+      )}
+
+      {showEmptyState ? (
         <div className="flex items-center justify-center py-8 sm:py-12">
           <div className="text-center px-4">
-            <p className="text-muted-foreground mb-4 text-sm sm:text-base">
-              {searchTerm ? "No se encontraron categorías que coincidan con tu búsqueda" : "No hay categorías creadas"}
-            </p>
-            {!searchTerm && (
-              <Button onClick={handleCreate} className="w-full sm:w-auto">
-                <Plus className="h-4 w-4 mr-2" />
-                Crear primera categoría
-              </Button>
-            )}
+            <p className="text-muted-foreground mb-4 text-sm sm:text-base">No hay categorías creadas</p>
+            <Button onClick={handleCreate} className="w-full sm:w-auto">
+              <Plus className="h-4 w-4 mr-2" />
+              Crear primera categoría
+            </Button>
           </div>
         </div>
       ) : (
-        <DragDropContext onDragEnd={handleDragEnd}>
-          <Droppable droppableId="categories">
-            {(provided) => (
-              <div {...provided.droppableProps} ref={provided.innerRef} className="space-y-3 sm:space-y-4">
-                {sortedCategories.map((category, index) => (
-                  <CategoryCard
-                    key={category.id}
-                    category={category}
-                    index={index}
-                    balance={getCategoryBalance(category.id)}
-                    onEdit={handleEdit}
-                    onSearch={handleSearch}
-                    onDelete={handleDeleteRequest}
-                    canEdit={canEditCategory(category)}
-                    canDelete={canDeleteCategory(category)}
-                    isDragDisabled={!canReorderCategory(category)}
-                    isGlobal={category.es_global}
-                  />
-                ))}
-                {provided.placeholder}
-              </div>
-            )}
-          </Droppable>
-        </DragDropContext>
+        <>
+          {showNoResults && (
+            <div className="rounded-md border border-dashed border-muted-foreground/30 bg-muted/20 p-4 text-center text-sm text-muted-foreground">
+              No se encontraron categorías que coincidan con tu búsqueda.
+            </div>
+          )}
+
+          <DragDropContext onDragEnd={handleDragEnd}>
+            <div className="space-y-6">
+              {allGlobalRoots.length > 0 && (
+                <section className="space-y-3">
+                  <div className="flex items-center justify-between">
+                    <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      Categorías globales
+                    </h3>
+                    {isCentralManager && (
+                      <span className="text-xs text-muted-foreground">
+                        Arrastra una tarjeta sobre otra para anidar subcategorías.
+                      </span>
+                    )}
+                  </div>
+                  {renderCategoryTree(null, 0, "global", visibleGlobalRoots)}
+                </section>
+              )}
+
+              <section className="space-y-3">
+                <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  Categorías de la delegación
+                </h3>
+                {renderCategoryTree(null, 0, "local", visibleLocalRoots)}
+              </section>
+            </div>
+          </DragDropContext>
+        </>
       )}
 
-      {/* Sheets and Dialogs */}
       {deletingCategory && (
         <DeleteCategoryDialog
           categoria={deletingCategory}
@@ -566,27 +852,41 @@ export function CategoryList() {
         </SheetContent>
       </Sheet>
 
-      <Sheet open={createSheetOpen} onOpenChange={setCreateSheetOpen}>
+      <Sheet
+        open={createSheetOpen}
+        onOpenChange={(open) => {
+          setCreateSheetOpen(open)
+          if (!open) setCreatingParent(null)
+        }}
+      >
         <SheetContent className="w-full sm:w-[400px] sm:max-w-[540px] overflow-y-auto">
           <SheetHeader>
-            <SheetTitle>Crear categoría</SheetTitle>
+            <SheetTitle>
+              {creatingParent ? `Añadir subcategoría a ${creatingParent.nombre}` : "Crear categoría"}
+            </SheetTitle>
           </SheetHeader>
           <CategoryEditForm
             category={{
               id: "",
               organizacion_id: organizacionId || "",
-              delegacion_id: selectedDelegation || null,
+              delegacion_id: creatingParent
+                ? creatingParent.delegacion_id
+                : selectedDelegation || null,
               nombre: "",
-              tipo: "gasto",
-              emoji: "📁",
-              color: "#4ECDC4",
+              tipo: creatingParent?.tipo || "gasto",
+              emoji: creatingParent?.emoji || "📁",
+              color: creatingParent?.color || "#4ECDC4",
               orden: 0,
-              categoria_padre_id: null,
+              categoria_padre_id: creatingParent?.id ?? null,
               creado_en: "",
-              es_global: false,
+              es_global: creatingParent ? creatingParent.es_global : false,
             }}
+            parentCategory={creatingParent ?? undefined}
             onSave={handleSaveCategory}
-            onCancel={() => setCreateSheetOpen(false)}
+            onCancel={() => {
+              setCreateSheetOpen(false)
+              setCreatingParent(null)
+            }}
             canManageGlobal={isCentralManager}
           />
         </SheetContent>


### PR DESCRIPTION
## Summary
- reorganize the categories view into a hierarchical drag & drop tree with dedicated subcategory actions
- restrict global category management to central managers and tone down the global indicator styling
- align the category editor defaults with parent scope so subcategories inherit scope and color

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68c9d4cc17748326b438f64f1191f360