### PR TITLE
Diseño - liquid glass concept 1

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,31 +16,51 @@ export default function HomePage() {
 
   return (
     <AppLayout>
-      <Tabs defaultValue="inicio" className="space-y-6">
-        <TabsList>
-          <TabsTrigger value="inicio">Inicio</TabsTrigger>
-          <TabsTrigger value="actividad">Balance de actividad</TabsTrigger>
-          <TabsTrigger value="categorias">Analizar una categoría</TabsTrigger>
+      <Tabs defaultValue="inicio" className="space-y-8">
+        <TabsList className="relative inline-flex h-auto items-center justify-start gap-2 rounded-full border border-white/10 bg-slate-900/60 p-2 text-slate-300 shadow-[0_15px_40px_-30px_rgba(24,90,182,0.9)]">
+          <TabsTrigger value="inicio" className="rounded-full px-5 py-2 text-sm font-semibold data-[state=active]:bg-primary/20 data-[state=active]:text-white">
+            Inicio
+          </TabsTrigger>
+          <TabsTrigger value="actividad" className="rounded-full px-5 py-2 text-sm font-semibold data-[state=active]:bg-primary/20 data-[state=active]:text-white">
+            Balance de actividad
+          </TabsTrigger>
+          <TabsTrigger value="categorias" className="rounded-full px-5 py-2 text-sm font-semibold data-[state=active]:bg-primary/20 data-[state=active]:text-white">
+            Analizar una categoría
+          </TabsTrigger>
         </TabsList>
 
-        <TabsContent value="inicio" className="space-y-8">
-          <div className="flex items-center justify-between">
-            <div>
-              <h1 className="text-3xl font-bold tracking-tight">Dashboard</h1>
-              <p className="text-muted-foreground">Panel de control y revisión de la tesorería</p>
+        <TabsContent value="inicio" className="space-y-10">
+          <div className="relative overflow-hidden rounded-3xl border border-white/10 bg-slate-900/60 p-6 shadow-[0_30px_60px_-40px_rgba(16,76,140,0.9)] sm:p-10">
+            <div className="pointer-events-none absolute -right-20 top-0 h-56 w-56 rounded-full bg-primary/20 blur-3xl" />
+            <div className="pointer-events-none absolute -left-16 bottom-0 h-40 w-40 rounded-full bg-sky-500/10 blur-3xl" />
+            <div className="relative flex flex-col gap-8 lg:flex-row lg:items-center lg:justify-between">
+              <div className="max-w-2xl space-y-4">
+                <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-slate-200">
+                  Bienvenido de nuevo
+                </span>
+                <h1 className="text-4xl font-semibold tracking-tight text-white sm:text-5xl">
+                  Todo listo para gestionar la tesorería con calma
+                </h1>
+                <p className="text-base text-slate-300 sm:text-lg">
+                  Visualiza el pulso financiero de tu delegación, detecta oportunidades y actúa en segundos con un entorno que te acompaña en cada decisión.
+                </p>
+              </div>
+              <div className="flex flex-col items-end gap-4 rounded-2xl border border-white/10 bg-slate-900/70 p-4 shadow-inner">
+                <span className="text-xs uppercase tracking-[0.3em] text-slate-400">Periodo de análisis</span>
+                <TimeframeFilter value={timeframe} onChange={setTimeframe} />
+              </div>
             </div>
-            <TimeframeFilter value={timeframe} onChange={setTimeframe} />
           </div>
 
           <FinancialSummary from={from} to={to} />
 
           <div className="space-y-4">
-            <h2 className="text-xl font-semibold">Acciones Rápidas</h2>
+            <h2 className="text-xl font-semibold text-white">Acciones Rápidas</h2>
             <QuickActions />
           </div>
 
           <div className="space-y-4">
-            <h2 className="text-xl font-semibold">Últimas transacciones</h2>
+            <h2 className="text-xl font-semibold text-white">Últimas transacciones</h2>
             <RecentTransactions />
           </div>
         </TabsContent>

--- a/components/app-layout.tsx
+++ b/components/app-layout.tsx
@@ -51,10 +51,16 @@ export function AppLayout({ children }: AppLayoutProps) {
   // Show loading state while auth is loading or redirecting
   if (loading || (isRedirecting && !user)) {
     return (
-      <div className="min-h-screen bg-background flex items-center justify-center">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto mb-4"></div>
-          <p className="text-muted-foreground">{isRedirecting ? "Redirigiendo..." : "Cargando..."}</p>
+      <div className="relative flex min-h-screen items-center justify-center overflow-hidden">
+        <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(56,110,255,0.18),_transparent_55%)]" />
+        <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_bottom_right,_rgba(19,49,111,0.35),_transparent_60%)]" />
+        <div className="rounded-2xl border border-white/10 bg-background/80 px-10 py-12 text-center backdrop-blur-lg shadow-2xl">
+          <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
+            <div className="h-6 w-6 animate-spin rounded-full border-b-2 border-primary" />
+          </div>
+          <p className="text-sm text-muted-foreground">
+            {isRedirecting ? "Redirigiendo a la zona segura..." : "Preparando tu área de trabajo..."}
+          </p>
         </div>
       </div>
     )
@@ -66,21 +72,30 @@ export function AppLayout({ children }: AppLayoutProps) {
   }
 
   return (
-    <div className="min-h-screen bg-background">
-      {/* Desktop Sidebar */}
+    <div className="relative flex min-h-screen text-foreground">
+      <div className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
+        <div className="absolute -left-40 top-10 h-80 w-80 rounded-full bg-sky-500/20 blur-3xl" />
+        <div className="absolute -right-32 top-40 h-96 w-96 rounded-full bg-indigo-500/20 blur-3xl" />
+        <div className="absolute inset-x-0 bottom-0 h-72 bg-gradient-to-t from-slate-950/80 via-transparent" />
+      </div>
+
       <Sidebar
         collapsed={sidebarCollapsed}
         onToggleCollapse={() => setSidebarCollapsed(!sidebarCollapsed)}
         showMobileTrigger={false}
       />
 
-      {/* Main Content */}
-      <div className={cn("transition-all duration-300", sidebarCollapsed ? "lg:pl-16" : "lg:pl-72")}>
-        {/* Topbar */}
+      <div
+        className={cn(
+          "relative z-10 flex min-h-screen flex-1 flex-col transition-[padding] duration-300",
+          sidebarCollapsed ? "lg:pl-20" : "lg:pl-72",
+        )}
+      >
         <Topbar selectedDelegation={selectedDelegation} onDelegationChange={(id) => setSelectedDelegation(id)} />
 
-        {/* Page Content */}
-        <main className="flex-1 p-4 lg:p-6">{children}</main>
+        <main className="flex-1 px-4 pb-12 pt-6 sm:px-6 lg:px-10">
+          <div className="mx-auto flex w-full max-w-7xl flex-col gap-8 pb-6">{children}</div>
+        </main>
       </div>
     </div>
   )

--- a/components/dashboard/activity-balance.tsx
+++ b/components/dashboard/activity-balance.tsx
@@ -22,7 +22,7 @@ import { format } from "date-fns"
 import { es } from "date-fns/locale"
 
 export function ActivityBalanceDashboard() {
-  const { selectedDelegation, getCurrentDelegation } = useDelegationContext()
+  const { selectedDelegation } = useDelegationContext()
   const [timeframe, setTimeframe] = useState<Timeframe>("month")
   const [categoryIds, setCategoryIds] = useState<string[]>([])
 
@@ -67,51 +67,71 @@ export function ActivityBalanceDashboard() {
   }
 
   return (
-    <div className="space-y-6">
-      <div className="flex flex-col gap-4 md:flex-row">
-        <TimeframeFilter value={timeframe} onChange={setTimeframe} />
-        <div className="md:flex-1">
-          <CategorySelector
-            categories={categorias}
-            selectedCategories={categoryIds}
-            onSelectionChange={setCategoryIds}
-            allowMultiple
-            placeholder="Filtrar categorías..."
-          />
+    <div className="space-y-10">
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,2fr)_auto]">
+        <div className="rounded-3xl border border-white/10 bg-slate-900/60 p-5 shadow-inner">
+          <div className="flex flex-col gap-3">
+            <span className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">
+              Periodo
+            </span>
+            <TimeframeFilter value={timeframe} onChange={setTimeframe} className="w-full" />
+          </div>
         </div>
-        <Button variant="outline" onClick={clearFilters} className="md:self-start">
+        <div className="rounded-3xl border border-white/10 bg-slate-900/60 p-5 shadow-inner">
+          <span className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">Categorías</span>
+          <div className="mt-3">
+            <CategorySelector
+              categories={categorias}
+              selectedCategories={categoryIds}
+              onSelectionChange={setCategoryIds}
+              allowMultiple
+              placeholder="Filtrar categorías..."
+            />
+          </div>
+        </div>
+        <Button
+          variant="outline"
+          onClick={clearFilters}
+          className="h-full min-h-[60px] rounded-3xl border-white/20 bg-white/5 px-5 font-semibold uppercase tracking-[0.3em] text-slate-200 transition hover:bg-white/10"
+        >
           Borrar filtros
         </Button>
       </div>
 
       <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Ingresos</CardTitle>
-            <TrendingUp className="h-4 w-4 text-green-600" />
+        <Card className="border border-white/10 bg-slate-900/70 text-slate-200 shadow-[0_20px_45px_-35px_rgba(16,76,140,0.9)]">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
+            <CardTitle className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-400">
+              Ingresos
+            </CardTitle>
+            <TrendingUp className="h-5 w-5 text-emerald-200" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">€{summary.ingresos.toFixed(2)}</div>
+            <div className="text-3xl font-semibold text-white">€{summary.ingresos.toFixed(2)}</div>
           </CardContent>
         </Card>
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Gastos</CardTitle>
-            <TrendingDown className="h-4 w-4 text-red-600" />
+        <Card className="border border-white/10 bg-slate-900/70 text-slate-200 shadow-[0_20px_45px_-35px_rgba(16,76,140,0.9)]">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
+            <CardTitle className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-400">
+              Gastos
+            </CardTitle>
+            <TrendingDown className="h-5 w-5 text-rose-200" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">€{summary.gastos.toFixed(2)}</div>
+            <div className="text-3xl font-semibold text-white">€{summary.gastos.toFixed(2)}</div>
           </CardContent>
         </Card>
-        <Card className="md:col-span-3">
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Balance</CardTitle>
+        <Card className="border border-white/10 bg-slate-900/70 text-slate-200 shadow-[0_20px_45px_-35px_rgba(16,76,140,0.9)]">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
+            <CardTitle className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-400">
+              Balance
+            </CardTitle>
             <Wallet
-              className={`h-4 w-4 ${summary.balance >= 0 ? "text-green-600" : "text-red-600"}`}
+              className={`h-5 w-5 ${summary.balance >= 0 ? "text-sky-200" : "text-amber-200"}`}
             />
           </CardHeader>
           <CardContent>
-            <div className="text-3xl font-bold">€{summary.balance.toFixed(2)}</div>
+            <div className="text-3xl font-semibold text-white">€{summary.balance.toFixed(2)}</div>
           </CardContent>
         </Card>
       </div>
@@ -121,28 +141,36 @@ export function ActivityBalanceDashboard() {
           title="No se han encontrado movimientos"
           description="Prueba con otro periodo de tiempo o limpia los filtros de categorías."
           icon={<SearchX className="h-6 w-6" />}
+          className="border-white/10 bg-slate-900/70 text-slate-200"
         >
-          <Button variant="outline" onClick={clearFilters}>Borrar filtros</Button>
+          <Button
+            variant="outline"
+            onClick={clearFilters}
+            className="rounded-xl border-white/20 bg-white/5 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-200 hover:bg-white/10"
+          >
+            Borrar filtros
+          </Button>
         </EmptyState>
       ) : (
-        <Card>
+        <Card className="border border-white/10 bg-slate-900/70 text-slate-200 shadow-[0_30px_60px_-40px_rgba(16,76,140,0.9)]">
           <CardHeader>
-            <CardTitle>Ingresos vs Gastos</CardTitle>
+            <CardTitle className="text-lg font-semibold text-white">Ingresos vs Gastos</CardTitle>
           </CardHeader>
           <CardContent>
-            <ChartContainer config={chartConfig} className="h-[300px]">
+            <ChartContainer config={chartConfig} className="h-[320px]">
               <BarChart data={chartData}>
-                <CartesianGrid strokeDasharray="3 3" />
+                <CartesianGrid strokeDasharray="3 3" stroke="rgba(148, 163, 184, 0.2)" />
                 <XAxis
                   dataKey="date"
+                  tick={{ fill: "rgba(226, 232, 240, 0.7)", fontSize: 12 }}
                   tickFormatter={(value) =>
                     format(new Date(value), "d MMM", { locale: es })
                   }
                 />
-                <YAxis />
-                <ChartTooltip content={<ChartTooltipContent />} />
-                <Bar dataKey="ingresos" fill="var(--color-ingresos)" />
-                <Bar dataKey="gastos" fill="var(--color-gastos)" />
+                <YAxis tick={{ fill: "rgba(226, 232, 240, 0.7)", fontSize: 12 }} axisLine={{ stroke: "rgba(148, 163, 184, 0.2)" }} tickLine={{ stroke: "rgba(148, 163, 184, 0.2)" }} />
+                <ChartTooltip content={<ChartTooltipContent />} cursor={{ fill: "rgba(37, 99, 235, 0.08)" }} />
+                <Bar dataKey="ingresos" fill="var(--color-ingresos)" radius={[8, 8, 8, 8]} />
+                <Bar dataKey="gastos" fill="var(--color-gastos)" radius={[8, 8, 8, 8]} />
               </BarChart>
             </ChartContainer>
           </CardContent>

--- a/components/dashboard/category-analysis.tsx
+++ b/components/dashboard/category-analysis.tsx
@@ -26,7 +26,7 @@ import {
 } from "@/components/ui/table"
 
 export function CategoryAnalysisDashboard() {
-  const { selectedDelegation, getCurrentDelegation } = useDelegationContext()
+  const { selectedDelegation } = useDelegationContext()
   const [timeframe, setTimeframe] = useState<Timeframe>("month")
   const [categoryIds, setCategoryIds] = useState<string[]>([])
 
@@ -111,9 +111,9 @@ export function CategoryAnalysisDashboard() {
     const config = buildConfig(data)
     const total = data.reduce((sum, d) => sum + d.value, 0)
     return (
-      <Card>
+      <Card className="border border-white/10 bg-slate-900/70 text-slate-200 shadow-[0_30px_60px_-40px_rgba(16,76,140,0.9)]">
         <CardHeader>
-          <CardTitle>{title}</CardTitle>
+          <CardTitle className="text-lg font-semibold text-white">{title}</CardTitle>
         </CardHeader>
         <CardContent>
           <ChartContainer config={config} className="h-[300px]">
@@ -132,19 +132,31 @@ export function CategoryAnalysisDashboard() {
   }
 
   return (
-    <div className="space-y-6">
-      <div className="flex flex-col gap-4 md:flex-row">
-        <TimeframeFilter value={timeframe} onChange={setTimeframe} />
-        <div className="md:flex-1">
-          <CategorySelector
-            categories={categorias}
-            selectedCategories={categoryIds}
-            onSelectionChange={setCategoryIds}
-            allowMultiple
-            placeholder="Filtrar categorías..."
-          />
+    <div className="space-y-10">
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,2fr)_auto]">
+        <div className="rounded-3xl border border-white/10 bg-slate-900/60 p-5 shadow-inner">
+          <div className="flex flex-col gap-3">
+            <span className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">Periodo</span>
+            <TimeframeFilter value={timeframe} onChange={setTimeframe} className="w-full" />
+          </div>
         </div>
-        <Button variant="outline" onClick={clearFilters} className="md:self-start">
+        <div className="rounded-3xl border border-white/10 bg-slate-900/60 p-5 shadow-inner">
+          <span className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">Categorías</span>
+          <div className="mt-3">
+            <CategorySelector
+              categories={categorias}
+              selectedCategories={categoryIds}
+              onSelectionChange={setCategoryIds}
+              allowMultiple
+              placeholder="Filtrar categorías..."
+            />
+          </div>
+        </div>
+        <Button
+          variant="outline"
+          onClick={clearFilters}
+          className="h-full min-h-[60px] rounded-3xl border-white/20 bg-white/5 px-5 font-semibold uppercase tracking-[0.3em] text-slate-200 transition hover:bg-white/10"
+        >
           Borrar filtros
         </Button>
       </div>
@@ -154,8 +166,15 @@ export function CategoryAnalysisDashboard() {
           title="No se han encontrado movimientos"
           description="Prueba con otro periodo de tiempo o limpia los filtros de categorías."
           icon={<SearchX className="h-6 w-6" />}
+          className="border-white/10 bg-slate-900/70 text-slate-200"
         >
-          <Button variant="outline" onClick={clearFilters}>Borrar filtros</Button>
+          <Button
+            variant="outline"
+            onClick={clearFilters}
+            className="rounded-xl border-white/20 bg-white/5 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-200 hover:bg-white/10"
+          >
+            Borrar filtros
+          </Button>
         </EmptyState>
       ) : (
         <>
@@ -165,27 +184,27 @@ export function CategoryAnalysisDashboard() {
           </div>
 
           {summary.length > 0 && (
-            <Card>
+            <Card className="border border-white/10 bg-slate-900/70 text-slate-200 shadow-[0_30px_60px_-40px_rgba(16,76,140,0.9)]">
               <CardHeader>
-                <CardTitle>Resumen por categoría</CardTitle>
+                <CardTitle className="text-lg font-semibold text-white">Resumen por categoría</CardTitle>
               </CardHeader>
               <CardContent>
                 <Table>
                   <TableHeader>
                     <TableRow>
-                      <TableHead>Categoría</TableHead>
-                      <TableHead className="text-right">Ingresos</TableHead>
-                      <TableHead className="text-right">Gastos</TableHead>
+                      <TableHead className="text-slate-300">Categoría</TableHead>
+                      <TableHead className="text-right text-slate-300">Ingresos</TableHead>
+                      <TableHead className="text-right text-slate-300">Gastos</TableHead>
                     </TableRow>
                   </TableHeader>
                   <TableBody>
                     {summary.map((s) => (
-                      <TableRow key={s.id}>
-                        <TableCell>{s.name}</TableCell>
-                        <TableCell className="text-right">
+                      <TableRow key={s.id} className="border-white/5 hover:bg-white/5">
+                        <TableCell className="font-medium text-white">{s.name}</TableCell>
+                        <TableCell className="text-right text-emerald-200">
                           {s.income ? formatCurrency(s.income) : "-"}
                         </TableCell>
-                        <TableCell className="text-right">
+                        <TableCell className="text-right text-rose-200">
                           {s.expense ? formatCurrency(s.expense) : "-"}
                         </TableCell>
                       </TableRow>

--- a/components/dashboard/financial-summary.tsx
+++ b/components/dashboard/financial-summary.tsx
@@ -6,6 +6,7 @@ import { useDelegationContext } from "@/contexts/delegation-context"
 import { useMovimientos } from "@/hooks/use-movimientos"
 import { useMemo } from "react"
 import { useRouter } from "next/navigation"
+import { cn } from "@/lib/utils"
 
 interface Props {
   from: string
@@ -52,32 +53,32 @@ export function FinancialSummary({ from, to }: Props) {
       value: `€${summary.ingresos.toFixed(2)}`,
       description: "Total de entradas",
       icon: TrendingUp,
-      color: "text-green-600",
-      bgColor: "bg-green-50",
+      iconTint: "text-emerald-200",
+      glow: "from-emerald-500/30 via-emerald-500/10 to-transparent",
     },
     {
       title: "Gastos",
       value: `€${summary.gastos.toFixed(2)}`,
       description: "Total de salidas",
       icon: TrendingDown,
-      color: "text-red-600",
-      bgColor: "bg-red-50",
+      iconTint: "text-rose-200",
+      glow: "from-rose-500/30 via-rose-500/10 to-transparent",
     },
     {
       title: "Balance",
       value: `€${summary.balance.toFixed(2)}`,
       description: "Ingresos - Gastos",
       icon: Wallet,
-      color: summary.balance >= 0 ? "text-green-600" : "text-red-600",
-      bgColor: summary.balance >= 0 ? "bg-green-50" : "bg-red-50",
+      iconTint: summary.balance >= 0 ? "text-sky-200" : "text-amber-200",
+      glow: summary.balance >= 0 ? "from-sky-500/30 via-sky-500/10 to-transparent" : "from-amber-500/30 via-amber-500/10 to-transparent",
     },
     {
       title: "Transacciones",
       value: summary.count.toString(),
       description: "En el periodo",
       icon: Target,
-      color: "text-blue-600",
-      bgColor: "bg-blue-50",
+      iconTint: "text-indigo-200",
+      glow: "from-indigo-500/30 via-indigo-500/10 to-transparent",
       action: () => router.push("/transacciones"),
     },
     {
@@ -85,29 +86,43 @@ export function FinancialSummary({ from, to }: Props) {
       value: summary.uncategorized.toString(),
       description: "Transacciones",
       icon: Tag,
-      color: "text-orange-600",
-      bgColor: "bg-orange-50",
+      iconTint: "text-amber-200",
+      glow: "from-amber-500/30 via-amber-500/10 to-transparent",
       action: () => router.push("/transacciones?uncategorized=1"),
     },
-  ]
+  ] as const
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-5">
       {metrics.map((metric) => (
         <Card
           key={metric.title}
-          className={metric.action ? "cursor-pointer hover:shadow-md" : undefined}
+          className={cn(
+            "group relative overflow-hidden border border-white/10 bg-slate-900/70 p-6 text-slate-200 shadow-[0_20px_45px_-35px_rgba(24,90,182,0.9)] transition-all hover:border-white/20 hover:shadow-[0_30px_60px_-35px_rgba(24,90,182,1)]",
+            metric.action && "cursor-pointer",
+          )}
           onClick={metric.action}
         >
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">{metric.title}</CardTitle>
-            <div className={`p-2 rounded-lg ${metric.bgColor}`}>
-              <metric.icon className={`h-4 w-4 ${metric.color}`} />
+          <div
+            className={cn(
+              "pointer-events-none absolute inset-0 opacity-40 transition-opacity duration-300 group-hover:opacity-100",
+              `bg-gradient-to-br ${metric.glow}`,
+            )}
+          />
+          <CardHeader className="relative flex flex-row items-center justify-between space-y-0 pb-4">
+            <div className="space-y-1">
+              <CardTitle className="text-sm font-semibold uppercase tracking-[0.25em] text-slate-300">
+                {metric.title}
+              </CardTitle>
+              <p className="text-xs text-slate-400">{metric.description}</p>
+            </div>
+            <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-white/10 bg-white/5 text-lg transition-all group-hover:border-white/30 group-hover:bg-white/10">
+              <metric.icon className={cn("h-5 w-5", metric.iconTint)} />
             </div>
           </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{metric.value}</div>
-            <p className="text-xs text-muted-foreground">{metric.description}</p>
+          <CardContent className="relative pt-0">
+            <div className="text-3xl font-semibold text-white">{metric.value}</div>
+            <p className="text-xs text-slate-400">{metric.description}</p>
           </CardContent>
         </Card>
       ))}

--- a/components/dashboard/quick-actions.tsx
+++ b/components/dashboard/quick-actions.tsx
@@ -36,22 +36,27 @@ export function QuickActions() {
       action: () => router.push("/categorias?panel=create"),
       variant: "outline" as const,
     },
-  ]
+  ] as const
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
       {actions.map((action) => (
-        <Card key={action.title} className="hover:shadow-md transition-shadow cursor-pointer" onClick={action.action}>
-          <CardHeader className="pb-3">
-            <div className="flex items-center gap-2">
-              <div className="p-2 rounded-lg bg-primary/10">
-                <action.icon className="h-5 w-5 text-primary" />
+        <Card
+          key={action.title}
+          className="group relative cursor-pointer overflow-hidden border border-white/10 bg-gradient-to-br from-slate-900/80 via-slate-900/60 to-slate-900/30 p-6 text-slate-200 shadow-[0_20px_45px_-35px_rgba(16,76,140,0.9)] transition-all hover:border-white/20 hover:shadow-[0_35px_70px_-40px_rgba(16,76,140,1)]"
+          onClick={action.action}
+        >
+          <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(120%_120%_at_80%_0%,rgba(46,106,234,0.25),transparent_65%)] opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+          <CardHeader className="relative pb-4">
+            <div className="flex items-center gap-3">
+              <div className="flex h-11 w-11 items-center justify-center rounded-2xl border border-white/10 bg-white/5 text-primary">
+                <action.icon className="h-5 w-5" />
               </div>
-              <CardTitle className="text-lg">{action.title}</CardTitle>
+              <CardTitle className="text-lg font-semibold text-white">{action.title}</CardTitle>
             </div>
           </CardHeader>
-          <CardContent>
-            <CardDescription className="text-sm">{action.description}</CardDescription>
+          <CardContent className="relative pt-0">
+            <CardDescription className="text-sm text-slate-300">{action.description}</CardDescription>
           </CardContent>
         </Card>
       ))}

--- a/components/dashboard/recent-transactions.tsx
+++ b/components/dashboard/recent-transactions.tsx
@@ -19,28 +19,45 @@ export function RecentTransactions({ limit = 5 }: Props) {
   const latest = movimientos.slice(0, limit)
 
   return (
-    <Card>
-      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">Últimas transacciones</CardTitle>
-        <Button variant="ghost" asChild size="sm" className="h-auto p-0">
+    <Card className="overflow-hidden border border-white/10 bg-slate-900/70 text-slate-200 shadow-[0_20px_45px_-35px_rgba(16,76,140,0.9)]">
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
+        <div>
+          <CardTitle className="text-lg font-semibold text-white">Últimas transacciones</CardTitle>
+          <p className="text-xs text-slate-400">Una mirada rápida a tus últimos movimientos registrados.</p>
+        </div>
+        <Button
+          variant="ghost"
+          asChild
+          size="sm"
+          className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-slate-200 transition hover:bg-white/10"
+        >
           <Link href="/transacciones">Ver todas</Link>
         </Button>
       </CardHeader>
-      <CardContent>
+      <CardContent className="space-y-4">
         {latest.length === 0 ? (
-          <p className="text-sm text-muted-foreground">Sin movimientos recientes</p>
+          <p className="text-sm text-slate-400">Sin movimientos recientes</p>
         ) : (
-          <ul className="space-y-2">
+          <ul className="space-y-3">
             {latest.map((mov) => (
-              <li key={mov.id} className="flex items-center justify-between text-sm">
+              <li
+                key={mov.id}
+                className="flex items-center justify-between rounded-2xl border border-white/5 bg-white/5 px-4 py-3 text-sm transition hover:border-white/15 hover:bg-white/10"
+              >
                 <div className="flex flex-col">
-                  <span>{mov.concepto || "Sin concepto"}</span>
-                  <span className="text-muted-foreground">
+                  <span className="font-medium text-white">{mov.concepto || "Sin concepto"}</span>
+                  <span className="text-xs text-slate-300">
                     {format(new Date(mov.fecha), "d MMM", { locale: es })}
                     {mov.categoria ? ` • ${mov.categoria.nombre}` : ""}
                   </span>
                 </div>
-                <span className={mov.importe >= 0 ? "text-green-600" : "text-red-600"}>
+                <span
+                  className={
+                    mov.importe >= 0
+                      ? "font-semibold text-emerald-300"
+                      : "font-semibold text-rose-300"
+                  }
+                >
                   {mov.importe >= 0 ? "+" : "-"}€{Math.abs(mov.importe).toFixed(2)}
                 </span>
               </li>

--- a/components/dashboard/timeframe-filter.tsx
+++ b/components/dashboard/timeframe-filter.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { cn } from "@/lib/utils"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 
 export type Timeframe = "today" | "week" | "month" | "school-year"
@@ -14,17 +15,27 @@ const OPTIONS = [
 interface Props {
   value: Timeframe
   onChange: (value: Timeframe) => void
+  className?: string
 }
 
-export function TimeframeFilter({ value, onChange }: Props) {
+export function TimeframeFilter({ value, onChange, className }: Props) {
   return (
     <Select value={value} onValueChange={onChange}>
-      <SelectTrigger className="w-auto min-w-[200px]">
-        <SelectValue />
+      <SelectTrigger
+        className={cn(
+          "min-w-[200px] rounded-xl border border-white/10 bg-slate-900/70 px-4 py-3 text-left text-sm font-medium text-slate-100 shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] transition hover:border-white/20",
+          className,
+        )}
+      >
+        <SelectValue placeholder="Seleccionar periodo" />
       </SelectTrigger>
-      <SelectContent>
+      <SelectContent className="rounded-2xl border border-white/10 bg-slate-950/95 text-slate-100 shadow-xl">
         {OPTIONS.map((o) => (
-          <SelectItem key={o.value} value={o.value}>
+          <SelectItem
+            key={o.value}
+            value={o.value}
+            className="rounded-lg px-3 py-2 text-sm font-medium data-[state=checked]:bg-primary/20 data-[state=checked]:text-white"
+          >
             {o.label}
           </SelectItem>
         ))}

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -20,8 +20,6 @@ import {
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
-import { DialogTitle } from "@/components/ui/dialog"
-import { VisuallyHidden } from "@/components/ui/visually-hidden"
 import useIsAdmin from "@/hooks/use-is-admin"
 import { useDelegationCounts } from "@/hooks/use-delegation-counts"
 import type { DelegationCounts } from "@/hooks/use-delegation-counts"
@@ -122,9 +120,16 @@ function SidebarContent({ className, collapsed = false, counts, countsLoading }:
   ]
 
   return (
-    <div className={cn("flex h-full flex-col bg-sidebar", className)}>
-      {/* Logo */}
-      <div className="flex h-16 items-center border-b border-sidebar-border px-6">
+    <div
+      className={cn(
+        "relative flex h-full flex-col overflow-hidden border-r border-white/10 bg-sidebar text-sidebar-foreground shadow-[0_20px_45px_-25px_rgba(8,19,40,0.8)]",
+        className,
+      )}
+    >
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(120%_100%_at_0%_0%,rgba(62,114,255,0.25),transparent_60%)]" />
+      <div className="pointer-events-none absolute inset-y-0 right-0 w-24 bg-[radial-gradient(80%_120%_at_100%_20%,rgba(12,33,71,0.65),transparent_70%)]" />
+
+      <div className="relative flex h-20 items-center justify-between border-b border-white/10 px-5">
         <button
           type="button"
           onClick={() => {
@@ -134,16 +139,22 @@ function SidebarContent({ className, collapsed = false, counts, countsLoading }:
               // no-op
             }
           }}
-          className="flex items-center gap-2 hover:opacity-90 transition-opacity"
+          className="flex items-center gap-3 rounded-xl px-3 py-2 transition-all hover:bg-white/10 hover:text-white"
           title="Ir al inicio"
         >
-          <Building2 className="h-8 w-8 text-sidebar-primary" />
-          {!collapsed && <span className="text-xl font-bold text-sidebar-foreground">MCM Bank</span>}
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-sidebar-primary/15 text-sidebar-primary">
+            <Building2 className="h-5 w-5" />
+          </div>
+          {!collapsed && (
+            <div className="flex flex-col">
+              <span className="text-lg font-semibold tracking-tight">MCM Bank</span>
+              <span className="text-xs uppercase tracking-[0.3em] text-sidebar-foreground/70">Tesorería viva</span>
+            </div>
+          )}
         </button>
       </div>
 
-      {/* Navigation */}
-      <nav className="flex-1 space-y-1 p-4">
+      <nav className="relative flex-1 space-y-1.5 px-3 py-5">
         {navigation.map((item) => {
           const isActive = pathname === item.href
           const isDisabled = !item.enabled
@@ -151,25 +162,31 @@ function SidebarContent({ className, collapsed = false, counts, countsLoading }:
           const linkContent = (
             <div
               className={cn(
-                "flex items-center justify-between rounded-lg px-3 py-2 text-sm font-medium transition-colors",
+                "group flex items-center justify-between rounded-xl px-3 py-2 text-sm font-medium transition-all",
                 isDisabled
-                  ? "text-muted-foreground cursor-not-allowed opacity-50"
+                  ? "cursor-not-allowed text-sidebar-foreground/40"
                   : isActive
-                    ? "bg-sidebar-accent text-sidebar-accent-foreground"
-                    : "text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+                    ? "bg-white/10 text-white shadow-[0_10px_30px_-15px_rgba(15,72,169,0.8)] backdrop-blur"
+                    : "text-sidebar-foreground/80 hover:bg-white/5 hover:text-white",
               )}
             >
               <div className="flex items-center gap-3">
-                <item.icon className="h-5 w-5" />
+                <item.icon
+                  className={cn(
+                    "h-5 w-5 transition-transform duration-200",
+                    !isDisabled && "group-hover:scale-110",
+                    isActive ? "text-sidebar-primary" : "text-sidebar-foreground/70",
+                  )}
+                />
                 {!collapsed && <span>{item.name}</span>}
               </div>
               {!collapsed && item.count !== null && (
                 <span
                   className={cn(
-                    "rounded-full px-2 py-0.5 text-xs",
+                    "rounded-full border px-2 py-0.5 text-xs",
                     isDisabled
-                      ? "bg-muted text-muted-foreground"
-                      : "bg-sidebar-primary text-sidebar-primary-foreground",
+                      ? "border-white/10 bg-white/5 text-sidebar-foreground/50"
+                      : "border-sidebar-primary/40 bg-sidebar-primary/15 text-sidebar-primary-foreground",
                   )}
                 >
                   {item.count}
@@ -179,11 +196,15 @@ function SidebarContent({ className, collapsed = false, counts, countsLoading }:
           )
 
           if (isDisabled) {
-            return <div key={item.name}>{linkContent}</div>
+            return (
+              <div key={item.name} className="relative">
+                {linkContent}
+              </div>
+            )
           }
 
           return (
-            <Link key={item.name} href={item.href}>
+            <Link key={item.name} href={item.href} className="block">
               {linkContent}
             </Link>
           )
@@ -215,7 +236,7 @@ export function Sidebar({
         <div
           className={cn(
             "hidden lg:fixed lg:inset-y-0 lg:z-50 lg:flex lg:flex-col transition-all duration-300",
-            collapsed ? "lg:w-16" : "lg:w-72",
+            collapsed ? "lg:w-20" : "lg:w-72",
           )}
         >
           <SidebarContent collapsed={collapsed} counts={counts} countsLoading={countsLoading} />
@@ -225,7 +246,7 @@ export function Sidebar({
             <Button
               variant="outline"
               size="icon"
-              className="h-6 w-6 rounded-full bg-background border-2 shadow-md"
+              className="h-7 w-7 rounded-full border-white/20 bg-slate-900/70 text-white shadow-lg backdrop-blur"
               onClick={onToggleCollapse}
             >
               {collapsed ? <ChevronRight className="h-3 w-3" /> : <ChevronLeft className="h-3 w-3" />}
@@ -243,7 +264,7 @@ export function Sidebar({
               <span className="sr-only">Abrir menú</span>
             </Button>
           </SheetTrigger>
-          <SheetContent side="left" className="w-72 p-0">
+          <SheetContent side="left" className="w-72 border-white/10 bg-sidebar p-0 text-sidebar-foreground">
             <SidebarContent counts={counts} countsLoading={countsLoading} />
           </SheetContent>
         </Sheet>

--- a/components/topbar.tsx
+++ b/components/topbar.tsx
@@ -111,26 +111,29 @@ export function Topbar({ selectedDelegation, onDelegationChange }: TopbarProps) 
   }
 
   return (
-    <header className="sticky top-0 z-40 flex h-16 items-center gap-4 border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 px-4 lg:px-6">
+    <header className="relative sticky top-0 z-40 flex h-20 items-center gap-4 border-b border-white/10 bg-slate-950/50 px-4 shadow-[0_10px_30px_-20px_rgba(16,76,140,0.9)] backdrop-blur-xl transition-colors lg:px-8">
+      <div className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(120%_120%_at_0%_0%,rgba(40,83,195,0.22),transparent_60%)]" />
       {/* Mobile menu button */}
       <Sidebar showDesktop={false} />
 
       {/* Delegation selector */}
       <div className="flex items-center gap-4">
-        <DelegationSelector value={selectedDelegation} onValueChange={onDelegationChange} />
+        <div className="rounded-2xl border border-white/10 bg-slate-900/60 p-2 shadow-inner">
+          <DelegationSelector value={selectedDelegation} onValueChange={onDelegationChange} />
+        </div>
       </div>
 
       {/* Spacer */}
       <div className="flex-1" />
 
       {/* Right side actions */}
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-3">
         {/* Manual/Documentation button */}
-        <Button 
-          variant="ghost" 
-          size="sm" 
+        <Button
+          variant="ghost"
+          size="sm"
           onClick={handleManualClick}
-          className="hidden sm:inline-flex"
+          className="hidden rounded-full border border-white/10 bg-white/5 px-4 text-xs font-medium uppercase tracking-[0.2em] text-slate-200 transition hover:bg-white/10 sm:inline-flex"
         >
           <BookOpen className="h-4 w-4 mr-2" />
           Manual
@@ -141,7 +144,7 @@ export function Topbar({ selectedDelegation, onDelegationChange }: TopbarProps) 
           <Button
             variant="ghost"
             size="sm"
-            className="w-9 h-9 p-0"
+            className="h-10 w-10 rounded-full border border-white/10 bg-white/5 p-0 text-slate-200 transition hover:bg-white/10"
             onClick={handleThemeCycle}
             title={`Cambiar tema (actual: ${currentThemeLabel})`}
           >
@@ -151,20 +154,20 @@ export function Topbar({ selectedDelegation, onDelegationChange }: TopbarProps) 
         )}
 
         {/* User info and logout */}
-        <div className="flex items-center gap-3 pl-2 border-l border-border">
+        <div className="flex items-center gap-3 rounded-full border border-white/10 bg-white/5 px-3 py-1.5">
           <div className="flex items-center gap-2">
-            <Avatar className="h-8 w-8">
+            <Avatar className="h-10 w-10 border border-white/10 bg-slate-900/80 text-slate-100">
               <AvatarImage src="" alt={getUserDisplayName()} />
-              <AvatarFallback className="text-xs font-medium">
+              <AvatarFallback className="text-xs font-medium text-white">
                 {getUserInitials(perfil?.nombre_completo, user?.email)}
               </AvatarFallback>
             </Avatar>
             <div className="hidden sm:flex flex-col items-start text-sm">
-              <span className="font-medium text-foreground leading-none">
+              <span className="font-medium leading-none text-white">
                 {getUserDisplayName()}
               </span>
               {user?.email && (
-                <span className="text-xs text-muted-foreground mt-0.5">
+                <span className="mt-0.5 text-xs text-slate-300/80">
                   {user.email}
                 </span>
               )}
@@ -176,7 +179,7 @@ export function Topbar({ selectedDelegation, onDelegationChange }: TopbarProps) 
             variant="ghost"
             size="sm"
             onClick={handleSignOut}
-            className="text-muted-foreground hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-950/20 w-9 h-9 p-0"
+            className="h-9 w-9 rounded-full border border-white/10 bg-white/5 p-0 text-slate-200 transition hover:bg-red-500/10 hover:text-red-200"
             title="Cerrar sesión"
           >
             <LogOut className="h-4 w-4" />

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -10,72 +10,72 @@
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 0 0% 3.9%;
-    --card: 0 0% 100%;
-    --card-foreground: 0 0% 3.9%;
-    --popover: 0 0% 100%;
-    --popover-foreground: 0 0% 3.9%;
-    --primary: 0 0% 9%;
-    --primary-foreground: 0 0% 98%;
-    --secondary: 0 0% 96.1%;
-    --secondary-foreground: 0 0% 9%;
-    --muted: 0 0% 96.1%;
-    --muted-foreground: 0 0% 45.1%;
-    --accent: 0 0% 96.1%;
-    --accent-foreground: 0 0% 9%;
+    --background: 225 40% 9%;
+    --foreground: 210 40% 96%;
+    --card: 224 35% 14%;
+    --card-foreground: 210 40% 96%;
+    --popover: 224 45% 12%;
+    --popover-foreground: 210 40% 98%;
+    --primary: 216 86% 62%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 222 32% 18%;
+    --secondary-foreground: 210 40% 92%;
+    --muted: 222 32% 18%;
+    --muted-foreground: 215 16% 76%;
+    --accent: 217 65% 38%;
+    --accent-foreground: 210 40% 96%;
     --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 0 0% 98%;
-    --border: 0 0% 89.8%;
-    --input: 0 0% 89.8%;
-    --ring: 0 0% 3.9%;
-    --chart-1: 12 76% 61%;
-    --chart-2: 173 58% 39%;
-    --chart-3: 197 37% 24%;
-    --chart-4: 43 74% 66%;
-    --chart-5: 27 87% 67%;
-    --radius: 0.5rem;
-    --sidebar-background: 0 0% 98%;
-    --sidebar-foreground: 240 5.3% 26.1%;
-    --sidebar-primary: 240 5.9% 10%;
-    --sidebar-primary-foreground: 0 0% 98%;
-    --sidebar-accent: 240 4.8% 95.9%;
-    --sidebar-accent-foreground: 240 5.9% 10%;
-    --sidebar-border: 220 13% 91%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 223 36% 22%;
+    --input: 223 36% 22%;
+    --ring: 218 82% 60%;
+    --chart-1: 217 90% 62%;
+    --chart-2: 200 80% 60%;
+    --chart-3: 188 68% 55%;
+    --chart-4: 266 70% 65%;
+    --chart-5: 14 85% 64%;
+    --radius: 0.75rem;
+    --sidebar-background: 225 45% 6%;
+    --sidebar-foreground: 213 32% 88%;
+    --sidebar-primary: 215 86% 62%;
+    --sidebar-primary-foreground: 210 40% 98%;
+    --sidebar-accent: 219 55% 18%;
+    --sidebar-accent-foreground: 210 40% 98%;
+    --sidebar-border: 220 40% 20%;
     --sidebar-ring: 217.2 91.2% 59.8%;
   }
   .dark {
-    --background: 0 0% 3.9%;
-    --foreground: 0 0% 98%;
-    --card: 0 0% 3.9%;
-    --card-foreground: 0 0% 98%;
-    --popover: 0 0% 3.9%;
-    --popover-foreground: 0 0% 98%;
-    --primary: 0 0% 98%;
-    --primary-foreground: 0 0% 9%;
-    --secondary: 0 0% 14.9%;
-    --secondary-foreground: 0 0% 98%;
-    --muted: 0 0% 14.9%;
-    --muted-foreground: 0 0% 63.9%;
-    --accent: 0 0% 14.9%;
-    --accent-foreground: 0 0% 98%;
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 0 0% 98%;
-    --border: 0 0% 14.9%;
-    --input: 0 0% 14.9%;
-    --ring: 0 0% 83.1%;
-    --chart-1: 220 70% 50%;
-    --chart-2: 160 60% 45%;
-    --chart-3: 30 80% 55%;
-    --chart-4: 280 65% 60%;
-    --chart-5: 340 75% 55%;
-    --sidebar-background: 240 5.9% 10%;
-    --sidebar-foreground: 240 4.8% 95.9%;
-    --sidebar-primary: 224.3 76.3% 48%;
-    --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 240 3.7% 15.9%;
-    --sidebar-accent-foreground: 240 4.8% 95.9%;
-    --sidebar-border: 240 3.7% 15.9%;
+    --background: 223 45% 5%;
+    --foreground: 214 32% 92%;
+    --card: 222 40% 10%;
+    --card-foreground: 214 32% 92%;
+    --popover: 222 45% 9%;
+    --popover-foreground: 214 32% 98%;
+    --primary: 215 90% 64%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 220 35% 14%;
+    --secondary-foreground: 214 32% 92%;
+    --muted: 220 35% 14%;
+    --muted-foreground: 215 16% 70%;
+    --accent: 219 66% 32%;
+    --accent-foreground: 210 40% 96%;
+    --destructive: 0 72% 51%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 225 40% 16%;
+    --input: 225 40% 16%;
+    --ring: 217.2 91.2% 59.8%;
+    --chart-1: 217 90% 62%;
+    --chart-2: 200 80% 60%;
+    --chart-3: 188 68% 55%;
+    --chart-4: 266 70% 65%;
+    --chart-5: 14 85% 64%;
+    --sidebar-background: 223 60% 4%;
+    --sidebar-foreground: 213 32% 88%;
+    --sidebar-primary: 215 90% 64%;
+    --sidebar-primary-foreground: 210 40% 98%;
+    --sidebar-accent: 223 50% 10%;
+    --sidebar-accent-foreground: 210 40% 96%;
+    --sidebar-border: 225 40% 16%;
     --sidebar-ring: 217.2 91.2% 59.8%;
   }
 }
@@ -85,6 +85,14 @@
     @apply border-border;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply text-foreground;
+    background-color: hsl(var(--background));
+    background-image:
+      radial-gradient(120% 120% at 0% 0%, rgba(58, 112, 252, 0.24), transparent 55%),
+      radial-gradient(80% 120% at 100% 10%, rgba(11, 41, 87, 0.4), transparent 60%),
+      linear-gradient(180deg, rgba(8, 18, 38, 0.9), rgba(8, 11, 20, 0.9));
+    background-attachment: fixed;
+    position: relative;
+    min-height: 100vh;
   }
 }


### PR DESCRIPTION
## Summary
- actualicé la paleta global y el fondo para un modo oscuro con acentos azules y degradados envolventes
- renové el layout principal, la sidebar y la topbar con glas effects, transiciones y badges más vivos
- rehice los módulos del dashboard (tabs, hero, métricas, acciones, transacciones y analíticas) con tarjetas y filtros temáticos

## Testing
- `pnpm lint` *(emite advertencias en archivos preexistentes sin cambios relacionados)*

------
https://chatgpt.com/codex/tasks/task_e_68cb30f680ac83268b10a5f85d3a49bb