### PR TITLE
Fix delegations paging and admin ordering

### DIFF
--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -12,11 +12,18 @@ export async function GET() {
       .from("membresia")
       .select("usuario_id, rol, delegacion:delegacion_id (id, nombre)")
     if (mErr) return NextResponse.json({ error: mErr.message }, { status: 500 })
-    const users = (data?.users || []).map((u) => ({
-      id: u.id,
-      email: u.email,
-      membresias: memberships?.filter((m) => m.usuario_id === u.id) || [],
-    }))
+    const users = (data?.users || [])
+      .map((u) => ({
+        id: u.id,
+        email: u.email,
+        createdAt: u.created_at,
+        membresias: memberships?.filter((m) => m.usuario_id === u.id) || [],
+      }))
+      .sort((a, b) => {
+        const aTime = new Date(a.createdAt ?? 0).getTime()
+        const bTime = new Date(b.createdAt ?? 0).getTime()
+        return bTime - aTime
+      })
     return NextResponse.json({ users })
   } catch (err: any) {
     return NextResponse.json({ error: err?.message || 'Internal error' }, { status: 500 })

--- a/components/configuracion/config-page.tsx
+++ b/components/configuracion/config-page.tsx
@@ -23,6 +23,7 @@ interface UserMembresia {
 interface UserData {
   id: string
   email: string | undefined
+  createdAt?: string
   membresias: UserMembresia[]
 }
 
@@ -56,7 +57,10 @@ export function ConfigPage() {
         return { ...(d as Delegacion), movimientos: count || 0 }
       })
     )
-    setDelegaciones(withCounts)
+    const sorted = [...withCounts].sort((a, b) =>
+      (a?.nombre || "").localeCompare(b?.nombre || "", "es", { sensitivity: "base" }),
+    )
+    setDelegaciones(sorted)
   }
 
   const loadUsers = async () => {
@@ -70,7 +74,19 @@ export function ConfigPage() {
         setUsers([])
         return
       }
-      setUsers(json.users || [])
+      const users = Array.isArray(json.users) ? json.users : []
+      const normalizedUsers: UserData[] = users.map((user: any) => ({
+        id: user.id,
+        email: user.email,
+        createdAt: user.createdAt ?? user.created_at,
+        membresias: Array.isArray(user.membresias) ? user.membresias : [],
+      }))
+      const sortedUsers = [...normalizedUsers].sort((a, b) => {
+        const aDate = new Date(a.createdAt ?? 0).getTime()
+        const bDate = new Date(b.createdAt ?? 0).getTime()
+        return bDate - aDate
+      })
+      setUsers(sortedUsers)
     } catch (err) {
       console.error("Error cargando usuarios:", err)
       setUsers([])
@@ -84,11 +100,14 @@ export function ConfigPage() {
     }
   }, [isAdmin])
 
-  const roles = useMemo(() => [
-    { value: "gestor_central", label: "Gestor Central" },
-    { value: "tesorero", label: "Tesorero" },
-    { value: "solo_lectura", label: "Solo Lectura" },
-  ], [])
+  const roles = useMemo(
+    () => [
+      { value: "gestor_central", label: "Gestor Central" },
+      { value: "tesorero", label: "Tesorería" },
+      { value: "solo_lectura", label: "Solo Lectura" },
+    ],
+    [],
+  )
 
   if (!isAdmin) {
     return <p className="text-center text-muted-foreground">Acceso restringido</p>
@@ -153,12 +172,16 @@ export function ConfigPage() {
           <TableBody>
             {users.map((u) => {
               const uniqueRoles = new Set(u.membresias.map((m) => m.rol))
-              const role = uniqueRoles.size === 1 ? (u.membresias[0]?.rol || "-") : "múltiples"
+              const baseRole = uniqueRoles.size === 1 ? (u.membresias[0]?.rol || "-") : "múltiples"
+              const roleLabel =
+                uniqueRoles.size === 1
+                  ? roles.find((r) => r.value === baseRole)?.label || baseRole
+                  : "múltiples"
               const delegs = u.membresias.map((m) => m.delegacion?.nombre).filter(Boolean).join(", ")
               return (
                 <TableRow key={u.id}>
                   <TableCell>{u.email}</TableCell>
-                  <TableCell>{role}</TableCell>
+                  <TableCell>{roleLabel}</TableCell>
                   <TableCell>{delegs}</TableCell>
                   <TableCell className="text-right space-x-2">
                     <Button
@@ -172,7 +195,10 @@ export function ConfigPage() {
                           password: "",
                           memberships: u.membresias
                             .filter((m) => !!m.delegacion?.id)
-                            .map((m) => ({ delegacion_id: m.delegacion!.id, rol: m.rol })),
+                            .map((m) => ({
+                              delegacion_id: m.delegacion!.id,
+                              rol: m.rol || "tesorero",
+                            })),
                         })
                       }}
                     >
@@ -356,10 +382,20 @@ export function ConfigPage() {
                               setUserForm((f) => {
                                 const exists = f.memberships.find((m) => m.delegacion_id === d.id)
                                 if (e.target.checked) {
-                                  if (!exists) return { ...f, memberships: [...f.memberships, { delegacion_id: d.id, rol: "solo_lectura" }] }
+                                  if (!exists) {
+                                    return {
+                                      ...f,
+                                      memberships: [
+                                        ...f.memberships,
+                                        { delegacion_id: d.id, rol: "tesorero" },
+                                      ],
+                                    }
+                                  }
                                   return f
-                                } else {
-                                  return { ...f, memberships: f.memberships.filter((m) => m.delegacion_id !== d.id) }
+                                }
+                                return {
+                                  ...f,
+                                  memberships: f.memberships.filter((m) => m.delegacion_id !== d.id),
                                 }
                               })
                             }}
@@ -369,7 +405,7 @@ export function ConfigPage() {
                         {checked && (
                           <select
                             className="border rounded px-2 py-1 text-sm"
-                            value={current?.rol || "solo_lectura"}
+                            value={current?.rol || "tesorero"}
                             onChange={(e) => {
                               const value = e.target.value
                               setUserForm((f) => ({
@@ -473,12 +509,22 @@ export function ConfigPage() {
                           onChange={(e) => {
                             setUserForm((f) => {
                               const exists = f.memberships.find((m) => m.delegacion_id === d.id)
-                              if (e.target.checked) {
-                                if (!exists) return { ...f, memberships: [...f.memberships, { delegacion_id: d.id, rol: "solo_lectura" }] }
-                                return f
-                              } else {
-                                return { ...f, memberships: f.memberships.filter((m) => m.delegacion_id !== d.id) }
-                              }
+                                if (e.target.checked) {
+                                  if (!exists) {
+                                    return {
+                                      ...f,
+                                      memberships: [
+                                        ...f.memberships,
+                                        { delegacion_id: d.id, rol: "tesorero" },
+                                      ],
+                                    }
+                                  }
+                                  return f
+                                }
+                                return {
+                                  ...f,
+                                  memberships: f.memberships.filter((m) => m.delegacion_id !== d.id),
+                                }
                             })
                           }}
                         />
@@ -487,7 +533,7 @@ export function ConfigPage() {
                       {checked && (
                         <select
                           className="border rounded px-2 py-1 text-sm"
-                          value={current?.rol || "solo_lectura"}
+                          value={current?.rol || "tesorero"}
                           onChange={(e) => {
                             const value = e.target.value
                             setUserForm((f) => ({

--- a/hooks/use-delegations.ts
+++ b/hooks/use-delegations.ts
@@ -59,7 +59,10 @@ export function useDelegations({ timeout = 10000 }: { timeout?: number } = {}) {
       if (error) throw error
 
       const userDelegations = (data?.map((item: any) => item.delegacion).filter(Boolean) || []) as Delegacion[]
-      setDelegations(userDelegations)
+      const sortedDelegations = [...userDelegations].sort((a, b) =>
+        (a?.nombre || "").localeCompare(b?.nombre || "", "es", { sensitivity: "base" }),
+      )
+      setDelegations(sortedDelegations)
     }
 
     try {

--- a/hooks/use-movimientos.ts
+++ b/hooks/use-movimientos.ts
@@ -299,7 +299,7 @@ export function useMovimientos(
   useRevalidateOnFocusJitter(() => fetchMovimientos(0, false), { minMs: 90, maxMs: 220 })
 
   const loadMore = useCallback(() => {
-    if (loading || !hasMore) return
+    if (loading || !hasMore || isFetchingRef.current) return
     const nextPage = page + 1
     setPage(nextPage)
     fetchMovimientos(nextPage, true)


### PR DESCRIPTION
## Summary
- prevent duplicate pagination calls in the transaction list by guarding load-more requests
- sort delegations alphabetically across the selector and admin views and default delegation roles to Tesorería when toggled
- return creation timestamps for admin users and sort them so the newest accounts appear first

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cb4491e09c8326a9ab67b7f5e407c9