### PR TITLE
Fix movimientos pagination and admin ordering

### DIFF
--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -12,9 +12,15 @@ export async function GET() {
       .from("membresia")
       .select("usuario_id, rol, delegacion:delegacion_id (id, nombre)")
     if (mErr) return NextResponse.json({ error: mErr.message }, { status: 500 })
-    const users = (data?.users || []).map((u) => ({
+    const sortedUsers = [...(data?.users || [])].sort((a, b) => {
+      const aTime = a.created_at ? new Date(a.created_at).getTime() : 0
+      const bTime = b.created_at ? new Date(b.created_at).getTime() : 0
+      return bTime - aTime
+    })
+    const users = sortedUsers.map((u) => ({
       id: u.id,
       email: u.email,
+      createdAt: u.created_at,
       membresias: memberships?.filter((m) => m.usuario_id === u.id) || [],
     }))
     return NextResponse.json({ users })

--- a/components/configuracion/config-page.tsx
+++ b/components/configuracion/config-page.tsx
@@ -24,6 +24,7 @@ interface UserData {
   id: string
   email: string | undefined
   membresias: UserMembresia[]
+  createdAt?: string
 }
 
 export function ConfigPage() {
@@ -56,6 +57,7 @@ export function ConfigPage() {
         return { ...(d as Delegacion), movimientos: count || 0 }
       })
     )
+    withCounts.sort((a, b) => a.nombre.localeCompare(b.nombre, "es", { sensitivity: "accent" }))
     setDelegaciones(withCounts)
   }
 
@@ -70,7 +72,16 @@ export function ConfigPage() {
         setUsers([])
         return
       }
-      setUsers(json.users || [])
+      const users = [...((json.users || []) as UserData[])].map((user) => ({
+        ...user,
+        createdAt: user.createdAt ?? (user as any).created_at,
+      }))
+      users.sort((a, b) => {
+        const aTime = a.createdAt ? new Date(a.createdAt).getTime() : 0
+        const bTime = b.createdAt ? new Date(b.createdAt).getTime() : 0
+        return bTime - aTime
+      })
+      setUsers(users)
     } catch (err) {
       console.error("Error cargando usuarios:", err)
       setUsers([])
@@ -86,7 +97,7 @@ export function ConfigPage() {
 
   const roles = useMemo(() => [
     { value: "gestor_central", label: "Gestor Central" },
-    { value: "tesorero", label: "Tesorero" },
+    { value: "tesorero", label: "Tesorería" },
     { value: "solo_lectura", label: "Solo Lectura" },
   ], [])
 
@@ -356,7 +367,7 @@ export function ConfigPage() {
                               setUserForm((f) => {
                                 const exists = f.memberships.find((m) => m.delegacion_id === d.id)
                                 if (e.target.checked) {
-                                  if (!exists) return { ...f, memberships: [...f.memberships, { delegacion_id: d.id, rol: "solo_lectura" }] }
+                                  if (!exists) return { ...f, memberships: [...f.memberships, { delegacion_id: d.id, rol: "tesorero" }] }
                                   return f
                                 } else {
                                   return { ...f, memberships: f.memberships.filter((m) => m.delegacion_id !== d.id) }
@@ -369,7 +380,7 @@ export function ConfigPage() {
                         {checked && (
                           <select
                             className="border rounded px-2 py-1 text-sm"
-                            value={current?.rol || "solo_lectura"}
+                            value={current?.rol || "tesorero"}
                             onChange={(e) => {
                               const value = e.target.value
                               setUserForm((f) => ({
@@ -474,7 +485,7 @@ export function ConfigPage() {
                             setUserForm((f) => {
                               const exists = f.memberships.find((m) => m.delegacion_id === d.id)
                               if (e.target.checked) {
-                                if (!exists) return { ...f, memberships: [...f.memberships, { delegacion_id: d.id, rol: "solo_lectura" }] }
+                                if (!exists) return { ...f, memberships: [...f.memberships, { delegacion_id: d.id, rol: "tesorero" }] }
                                 return f
                               } else {
                                 return { ...f, memberships: f.memberships.filter((m) => m.delegacion_id !== d.id) }
@@ -487,7 +498,7 @@ export function ConfigPage() {
                       {checked && (
                         <select
                           className="border rounded px-2 py-1 text-sm"
-                          value={current?.rol || "solo_lectura"}
+                          value={current?.rol || "tesorero"}
                           onChange={(e) => {
                             const value = e.target.value
                             setUserForm((f) => ({

--- a/components/configuration/configuration-manager.tsx
+++ b/components/configuration/configuration-manager.tsx
@@ -29,6 +29,7 @@ interface DelegacionWithCount extends Delegacion {
 interface UserInfo {
   id: string
   email: string
+  createdAt: string | null
   delegaciones: { id: string; nombre: string }[]
   rol: string | null
 }
@@ -56,6 +57,7 @@ export function ConfigurationManager() {
         results.push({ ...d, movimientos: count ?? 0 })
       }
     }
+    results.sort((a, b) => a.nombre.localeCompare(b.nombre, "es", { sensitivity: "accent" }))
     setDelegaciones(results)
   }
 
@@ -66,6 +68,7 @@ export function ConfigurationManager() {
     const baseUsers: UserInfo[] = json.users.map((u: any) => ({
       id: u.id,
       email: u.email,
+      createdAt: u.createdAt || u.created_at || null,
       delegaciones: [],
       rol: null,
     }))
@@ -76,6 +79,11 @@ export function ConfigurationManager() {
       const memberships = (data || []).filter((m: any) => m.usuario_id === u.id)
       u.delegaciones = memberships.map((m: any) => m.delegacion).filter(Boolean)
       u.rol = memberships[0]?.rol || null
+    })
+    baseUsers.sort((a, b) => {
+      const aTime = a.createdAt ? new Date(a.createdAt).getTime() : 0
+      const bTime = b.createdAt ? new Date(b.createdAt).getTime() : 0
+      return bTime - aTime
     })
     setUsers(baseUsers)
   }
@@ -109,11 +117,11 @@ export function ConfigurationManager() {
     for (const id of toAdd) {
       await supabase
         .from("membresia")
-        .insert({ usuario_id: updated.id, delegacion_id: id, rol: updated.rol || "solo_lectura" })
+        .insert({ usuario_id: updated.id, delegacion_id: id, rol: updated.rol || "tesorero" })
     }
     await supabase
       .from("membresia")
-      .update({ rol: updated.rol || "solo_lectura" })
+      .update({ rol: updated.rol || "tesorero" })
       .in("delegacion_id", selectedIds)
       .eq("usuario_id", updated.id)
     await fetchUsers()
@@ -234,13 +242,13 @@ export function ConfigurationManager() {
               }}
             >
               <p className="text-sm">{editingUser.email}</p>
-              <Select name="rol" defaultValue={editingUser.rol || "solo_lectura"}>
+              <Select name="rol" defaultValue={editingUser.rol || "tesorero"}>
                 <SelectTrigger>
                   <SelectValue placeholder="Rol" />
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="gestor_central">Gestor Central</SelectItem>
-                  <SelectItem value="tesorero">Tesorero</SelectItem>
+                  <SelectItem value="tesorero">Tesorería</SelectItem>
                   <SelectItem value="solo_lectura">Solo Lectura</SelectItem>
                 </SelectContent>
               </Select>

--- a/hooks/use-delegations.ts
+++ b/hooks/use-delegations.ts
@@ -59,7 +59,10 @@ export function useDelegations({ timeout = 10000 }: { timeout?: number } = {}) {
       if (error) throw error
 
       const userDelegations = (data?.map((item: any) => item.delegacion).filter(Boolean) || []) as Delegacion[]
-      setDelegations(userDelegations)
+      const sortedDelegations = [...userDelegations].sort((a, b) =>
+        a.nombre.localeCompare(b.nombre, "es", { sensitivity: "accent" }),
+      )
+      setDelegations(sortedDelegations)
     }
 
     try {

--- a/hooks/use-movimientos.ts
+++ b/hooks/use-movimientos.ts
@@ -300,6 +300,7 @@ export function useMovimientos(
 
   const loadMore = useCallback(() => {
     if (loading || !hasMore) return
+    if (isFetchingRef.current) return
     const nextPage = page + 1
     setPage(nextPage)
     fetchMovimientos(nextPage, true)


### PR DESCRIPTION
## Summary
- guard movimientos lazy loading to avoid duplicate requests when reaching later pages
- sort delegations alphabetically across selectors and admin screens and default delegation roles to Tesorería
- return user creation timestamps from the admin API and sort user tables by newest first

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cb4491e09c8326a9ab67b7f5e407c9