### PR TITLE
Añade votos y comentarios a propuestas de mejora

### DIFF
--- a/components/improvement-proposals/proposal-card.tsx
+++ b/components/improvement-proposals/proposal-card.tsx
@@ -1,8 +1,11 @@
 "use client"
 
+import { useMemo, useState } from "react"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Separator } from "@/components/ui/separator"
 import { cn } from "@/lib/utils"
 import {
   type ImprovementProposalStatus,
@@ -11,91 +14,51 @@ import {
   IMPROVEMENT_PROPOSAL_STATUSES,
 } from "@/lib/types/improvement-proposals"
 import type { ImprovementProposalStatusVisualConfig } from "./status-config"
-import { Clock, Sparkles } from "lucide-react"
-import { useMemo } from "react"
+import { Clock, MessageCircle, ThumbsUp } from "lucide-react"
+import { ProposalCommentsDialog } from "./proposal-comments-dialog"
+import { formatRelativeDate, getInitials } from "./utils"
 
 interface ProposalCardProps {
   proposal: ImprovementProposalWithAuthor
   statusConfig: ImprovementProposalStatusVisualConfig
   onStatusChange?: (status: ImprovementProposalStatus) => void
+  onToggleVote?: (proposalId: string) => Promise<void>
+  onCommentAdded?: (proposalId: string) => void
   isAdmin?: boolean
   disabled?: boolean
-}
-
-function getInitials(name?: string | null, email?: string | null) {
-  if (name && name.trim()) {
-    const parts = name.trim().split(/\s+/)
-    if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase()
-    return (parts[0].charAt(0) + parts[parts.length - 1].charAt(0)).toUpperCase()
-  }
-  if (email) {
-    const username = email.split("@")[0]
-    const sanitized = username.replace(/\./g, " ")
-    const segments = sanitized.split(/\s+/)
-    if (segments.length === 1) return segments[0].slice(0, 2).toUpperCase()
-    return (segments[0].charAt(0) + segments[segments.length - 1].charAt(0)).toUpperCase()
-  }
-  return "?"
-}
-
-function formatRelativeDate(value?: string | null) {
-  if (!value) return null
-  const date = new Date(value)
-  if (Number.isNaN(date.getTime())) return null
-
-  const now = new Date()
-  const diffMs = date.getTime() - now.getTime()
-  const diffSeconds = Math.round(diffMs / 1000)
-
-  const thresholds = [
-    { limit: 60, unit: "segundo", seconds: 1 },
-    { limit: 3600, unit: "minuto", seconds: 60 },
-    { limit: 86400, unit: "hora", seconds: 3600 },
-    { limit: 604800, unit: "día", seconds: 86400 },
-    { limit: 2629800, unit: "semana", seconds: 604800 },
-    { limit: 31557600, unit: "mes", seconds: 2629800 },
-  ] as const
-
-  const absoluteSeconds = Math.abs(diffSeconds)
-
-  for (const threshold of thresholds) {
-    if (absoluteSeconds < threshold.limit) {
-      const value = Math.floor(absoluteSeconds / threshold.seconds) || 1
-      const suffix = value === 1 ? threshold.unit : `${threshold.unit}s`
-      return diffSeconds >= 0 ? `en ${value} ${suffix}` : `hace ${value} ${suffix}`
-    }
-  }
-
-  const years = Math.floor(absoluteSeconds / 31557600)
-  return diffSeconds >= 0 ? `en ${years} ${years === 1 ? "año" : "años"}` : `hace ${years} ${years === 1 ? "año" : "años"}`
+  voting?: boolean
 }
 
 export function ProposalCard({
   proposal,
   statusConfig,
   onStatusChange,
+  onToggleVote,
+  onCommentAdded,
   isAdmin = false,
   disabled = false,
+  voting = false,
 }: ProposalCardProps) {
   const createdAgo = useMemo(() => formatRelativeDate(proposal.creado_en), [proposal.creado_en])
   const updatedAgo = useMemo(() => formatRelativeDate(proposal.actualizado_en), [proposal.actualizado_en])
   const statusOptions = useMemo(() => IMPROVEMENT_PROPOSAL_STATUSES, [])
+  const [commentsOpen, setCommentsOpen] = useState(false)
 
   return (
     <div
-      className="group relative overflow-hidden rounded-2xl border border-border/60 bg-card/80 shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg"
+      className="group relative overflow-hidden rounded-2xl border border-border/60 bg-card/80 shadow-sm transition hover:-translate-y-1 hover:shadow-lg"
     >
       <div
         className={cn(
-          "pointer-events-none absolute inset-x-5 top-4 h-1 rounded-full opacity-90",
+          "pointer-events-none absolute inset-x-6 top-5 h-1 rounded-full opacity-90",
           "bg-gradient-to-r",
           statusConfig.accentGradient,
         )}
       />
 
-      <div className="space-y-5 p-5">
-        <div className="flex items-start justify-between gap-3">
-          <div className="space-y-2">
+      <div className="space-y-6 p-6">
+        <div className="flex flex-col gap-4">
+          <div className="flex items-start justify-between gap-3">
             <Badge
               className={cn(
                 "border px-3 py-1 text-xs font-semibold uppercase tracking-wide",
@@ -104,17 +67,19 @@ export function ProposalCard({
             >
               {statusConfig.label}
             </Badge>
-            <h3 className="text-lg font-semibold text-foreground">{proposal.titulo}</h3>
+            {createdAgo && (
+              <span className="inline-flex items-center gap-1 rounded-full bg-muted/60 px-3 py-1 text-[11px] font-medium text-muted-foreground">
+                <Clock className="h-3 w-3" /> {createdAgo}
+              </span>
+            )}
           </div>
-          {createdAgo && (
-            <span className="flex items-center gap-1 text-xs text-muted-foreground">
-              <Clock className="h-3.5 w-3.5" /> {createdAgo}
-            </span>
-          )}
+          <h3 className="text-lg font-semibold leading-tight text-foreground md:text-xl">
+            {proposal.titulo}
+          </h3>
         </div>
 
         <p
-          className="text-sm leading-relaxed text-muted-foreground"
+          className="rounded-2xl border border-transparent bg-muted/30 px-4 py-3 text-sm leading-relaxed text-muted-foreground transition group-hover:border-border/60"
           style={{
             display: "-webkit-box",
             WebkitLineClamp: 4,
@@ -125,45 +90,90 @@ export function ProposalCard({
           {proposal.descripcion}
         </p>
 
-        <div className="flex flex-col gap-4 border-t border-dashed border-border/60 pt-4 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex items-center gap-3">
-            <Avatar className="h-10 w-10">
-              <AvatarFallback className="bg-muted text-sm font-semibold uppercase">
-                {getInitials(proposal.authorName, proposal.creado_por_email)}
-              </AvatarFallback>
-            </Avatar>
-            <div className="space-y-0.5 text-sm">
-              <p className="font-medium leading-tight text-foreground">{proposal.authorName}</p>
-              <p className="text-xs text-muted-foreground">
-                {updatedAgo ? `Actualizada ${updatedAgo}` : "Aún sin actualizar"}
-              </p>
-            </div>
+        <div className="space-y-5 border-t border-dashed border-border/60 pt-5">
+          <div className="flex flex-wrap items-center gap-3">
+            <Button
+              type="button"
+              variant={proposal.userHasVoted ? "default" : "secondary"}
+              size="sm"
+              disabled={disabled || voting || !onToggleVote}
+              onClick={() => void onToggleVote?.(proposal.id)}
+              className={cn(
+                "rounded-full px-3 text-xs font-semibold uppercase tracking-wide",
+                proposal.userHasVoted
+                  ? "bg-indigo-600 text-white hover:bg-indigo-500"
+                  : "bg-background/80 text-foreground hover:bg-background",
+              )}
+            >
+              <ThumbsUp
+                className={cn(
+                  "mr-1.5 h-3.5 w-3.5",
+                  proposal.userHasVoted ? "text-white" : "text-indigo-500",
+                )}
+              />
+              {proposal.userHasVoted ? "Apoyada" : "Apoyar idea"} · {proposal.votesCount}
+            </Button>
+
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => setCommentsOpen(true)}
+              className="rounded-full border border-border/50 bg-background/60 px-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground shadow-sm transition hover:bg-background"
+            >
+              <MessageCircle className="mr-1.5 h-3.5 w-3.5" /> Comentarios · {proposal.commentsCount}
+            </Button>
           </div>
 
-          {isAdmin && onStatusChange ? (
-            <Select
-              value={proposal.estado}
-              onValueChange={(value) => onStatusChange(value as ImprovementProposalStatus)}
-              disabled={disabled}
-            >
-              <SelectTrigger className="h-10 w-full rounded-xl border-border/60 bg-background/80 text-xs font-medium uppercase tracking-wide sm:w-[180px]">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {statusOptions.map((status) => (
-                  <SelectItem key={status} value={status} className="text-sm">
-                    {IMPROVEMENT_PROPOSAL_STATUS_LABELS[status]}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          ) : (
-            <div className="rounded-xl border border-border/60 px-3 py-2 text-xs text-muted-foreground">
-              {statusConfig.description}
+          <Separator className="border-dashed" />
+
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-center gap-3">
+              <Avatar className="h-10 w-10">
+                <AvatarFallback className="bg-muted text-sm font-semibold uppercase">
+                  {getInitials(proposal.authorName, proposal.creado_por_email)}
+                </AvatarFallback>
+              </Avatar>
+              <div className="space-y-0.5 text-sm">
+                <p className="font-medium leading-tight text-foreground">{proposal.authorName}</p>
+                <p className="text-xs text-muted-foreground">
+                  {updatedAgo ? `Actualizada ${updatedAgo}` : "Aún sin actualizar"}
+                </p>
+              </div>
             </div>
-          )}
+
+            {isAdmin && onStatusChange ? (
+              <Select
+                value={proposal.estado}
+                onValueChange={(value) => onStatusChange(value as ImprovementProposalStatus)}
+                disabled={disabled}
+              >
+                <SelectTrigger className="h-10 w-full rounded-xl border-border/60 bg-background/80 text-xs font-medium uppercase tracking-wide sm:w-[180px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {statusOptions.map((status) => (
+                    <SelectItem key={status} value={status} className="text-sm">
+                      {IMPROVEMENT_PROPOSAL_STATUS_LABELS[status]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            ) : (
+              <div className="rounded-xl border border-border/60 px-3 py-2 text-xs text-muted-foreground">
+                {statusConfig.description}
+              </div>
+            )}
+          </div>
         </div>
       </div>
+
+      <ProposalCommentsDialog
+        open={commentsOpen}
+        onOpenChange={setCommentsOpen}
+        proposal={proposal}
+        onCommentAdded={() => onCommentAdded?.(proposal.id)}
+      />
     </div>
   )
 }

--- a/components/improvement-proposals/proposal-comments-dialog.tsx
+++ b/components/improvement-proposals/proposal-comments-dialog.tsx
@@ -1,0 +1,229 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useState } from "react"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
+import { Avatar, AvatarFallback } from "@/components/ui/avatar"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Separator } from "@/components/ui/separator"
+import { LoadingSpinner } from "@/components/ui/loading-spinner"
+import { supabase } from "@/lib/supabase/client"
+import type { ImprovementProposalWithAuthor, ImprovementProposalComment } from "@/lib/types/improvement-proposals"
+import { formatRelativeDate, getInitials } from "./utils"
+import { toast } from "sonner"
+
+interface ProposalCommentsDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  proposal: ImprovementProposalWithAuthor
+  onCommentAdded?: () => void
+}
+
+export function ProposalCommentsDialog({
+  open,
+  onOpenChange,
+  proposal,
+  onCommentAdded,
+}: ProposalCommentsDialogProps) {
+  const [loading, setLoading] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+  const [comments, setComments] = useState<ImprovementProposalComment[]>([])
+  const [commentDraft, setCommentDraft] = useState("")
+
+  const hasComments = comments.length > 0
+
+  const loadComments = useCallback(async () => {
+    if (!open) return
+    setLoading(true)
+
+    const { data, error } = await supabase
+      .from("propuesta_mejora_comentario")
+      .select("*")
+      .eq("propuesta_id", proposal.id)
+      .order("creado_en", { ascending: false })
+
+    if (error) {
+      console.error("Error fetching proposal comments", error)
+      toast.error("No pudimos cargar los comentarios ahora mismo")
+    } else if (data) {
+      setComments(data)
+    }
+
+    setLoading(false)
+  }, [open, proposal.id])
+
+  useEffect(() => {
+    if (open) {
+      void loadComments()
+    } else {
+      setCommentDraft("")
+    }
+  }, [open, loadComments])
+
+  const handleSubmit = useCallback(async () => {
+    const content = commentDraft.trim()
+    if (!content) return
+
+    setSubmitting(true)
+
+    try {
+      const {
+        data: { user },
+        error: authError,
+      } = await supabase.auth.getUser()
+
+      if (authError) throw authError
+      if (!user) throw new Error("Necesitas iniciar sesión para comentar")
+
+      let authorName =
+        user.user_metadata?.full_name?.trim() ||
+        user.email?.split("@")[0]?.replace(/\./g, " ") ||
+        "Usuario"
+
+      try {
+        const { data: perfil } = await supabase
+          .from("perfil")
+          .select("nombre_completo")
+          .eq("usuario_id", user.id)
+          .maybeSingle()
+
+        if (perfil?.nombre_completo && perfil.nombre_completo.trim()) {
+          authorName = perfil.nombre_completo
+        }
+      } catch (profileError) {
+        console.warn("No pudimos obtener el perfil del usuario para el comentario", profileError)
+      }
+
+      const { data, error } = await supabase
+        .from("propuesta_mejora_comentario")
+        .insert({
+          propuesta_id: proposal.id,
+          contenido: content,
+          creado_por: user.id,
+          creado_por_nombre: authorName,
+          creado_por_email: user.email ?? null,
+        })
+        .select("*")
+        .single()
+
+      if (error) throw error
+
+      setComments((prev) => (data ? [data, ...prev] : prev))
+      setCommentDraft("")
+      onCommentAdded?.()
+      toast.success("¡Gracias por sumarte a la conversación!")
+    } catch (err) {
+      console.error("Error creando comentario", err)
+      const message =
+        err instanceof Error
+          ? err.message
+          : "No pudimos guardar tu comentario. Inténtalo otra vez."
+      toast.error(message)
+    } finally {
+      setSubmitting(false)
+    }
+  }, [commentDraft, onCommentAdded, proposal.id])
+
+  const disableButton = submitting || commentDraft.trim().length === 0
+
+  const commentCountLabel = useMemo(() => {
+    if (loading) return "Leyendo ideas..."
+    if (!hasComments) return "Todavía no hay comentarios"
+    return `${comments.length} comentario${comments.length === 1 ? "" : "s"}`
+  }, [comments.length, hasComments, loading])
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-xl gap-6">
+        <DialogHeader className="space-y-2">
+          <DialogTitle className="text-lg font-semibold">Conversación sobre “{proposal.titulo}”</DialogTitle>
+          <DialogDescription className="text-sm text-muted-foreground">
+            Comparte qué te inspira o cómo mejorarías esta idea.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="rounded-2xl border border-dashed border-border/60 bg-muted/20 p-4 text-sm text-muted-foreground">
+          {commentCountLabel}
+        </div>
+
+        <div className="space-y-3">
+          <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Añadir comentario
+          </label>
+          <Textarea
+            rows={4}
+            value={commentDraft}
+            onChange={(event) => setCommentDraft(event.target.value)}
+            placeholder="¿Qué te parece esta propuesta?"
+            className="min-h-[120px] resize-none rounded-xl border-border/60 bg-background/80"
+          />
+          <div className="flex justify-end">
+            <Button
+              type="button"
+              disabled={disableButton}
+              onClick={() => void handleSubmit()}
+            >
+              {submitting ? <LoadingSpinner className="mr-2 h-4 w-4" /> : null}
+              Comentar
+            </Button>
+          </div>
+        </div>
+
+        <Separator className="border-dashed" />
+
+        <ScrollArea className="max-h-[320px] pr-2">
+          {loading ? (
+            <div className="flex items-center justify-center gap-2 py-10 text-sm text-muted-foreground">
+              <LoadingSpinner className="h-4 w-4" /> Cargando comentarios...
+            </div>
+          ) : hasComments ? (
+            <div className="space-y-4">
+              {comments.map((comment) => {
+                const timestamp = formatRelativeDate(comment.creado_en) ?? "Hace un ratito"
+                const displayName =
+                  comment.creado_por_nombre?.trim() ||
+                  comment.creado_por_email?.split("@")[0]?.replace(/\./g, " ") ||
+                  "Persona entusiasta"
+
+                return (
+                  <div
+                    key={comment.id}
+                    className="flex gap-3 rounded-2xl border border-border/60 bg-card/70 p-4 text-sm shadow-sm"
+                  >
+                    <Avatar className="mt-0.5 h-9 w-9">
+                      <AvatarFallback className="bg-muted text-[11px] font-semibold uppercase">
+                        {getInitials(displayName, comment.creado_por_email)}
+                      </AvatarFallback>
+                    </Avatar>
+                    <div className="space-y-2">
+                      <div className="flex flex-wrap items-baseline gap-2">
+                        <span className="text-sm font-semibold text-foreground">{displayName}</span>
+                        <span className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                          {timestamp}
+                        </span>
+                      </div>
+                      <p className="whitespace-pre-line text-sm leading-relaxed text-muted-foreground">
+                        {comment.contenido}
+                      </p>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          ) : (
+            <div className="rounded-2xl border border-dashed border-border/60 bg-muted/20 p-8 text-center text-sm text-muted-foreground">
+              Sé la primera persona en dejar un comentario.
+            </div>
+          )}
+        </ScrollArea>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/improvement-proposals/proposals-board.tsx
+++ b/components/improvement-proposals/proposals-board.tsx
@@ -21,6 +21,9 @@ interface ProposalsBoardProps {
   isAdmin?: boolean
   onStatusChange?: (proposalId: string, status: ImprovementProposalStatus) => Promise<void>
   updatingId?: string | null
+  onToggleVote?: (proposalId: string) => Promise<void>
+  votingId?: string | null
+  onCommentAdded?: (proposalId: string) => void
 }
 
 export function ProposalsBoard({
@@ -31,6 +34,9 @@ export function ProposalsBoard({
   isAdmin = false,
   onStatusChange,
   updatingId,
+  onToggleVote,
+  votingId,
+  onCommentAdded,
 }: ProposalsBoardProps) {
   const statusOrder = useMemo(() => {
     return showCompleted
@@ -121,6 +127,9 @@ export function ProposalsBoard({
                         statusConfig={config}
                         isAdmin={isAdmin}
                         disabled={updatingId === proposal.id}
+                        voting={votingId === proposal.id}
+                        onToggleVote={onToggleVote}
+                        onCommentAdded={onCommentAdded}
                         onStatusChange={
                           onStatusChange
                             ? async (nextStatus) => {

--- a/components/improvement-proposals/proposals-panel.tsx
+++ b/components/improvement-proposals/proposals-panel.tsx
@@ -21,6 +21,9 @@ export function ImprovementProposalsPanel() {
     error,
     createProposal,
     updateProposalStatus,
+    toggleVote,
+    votingId,
+    registerComment,
     refetch,
     statusLabels,
   } = useImprovementProposals()
@@ -170,6 +173,9 @@ export function ImprovementProposalsPanel() {
         isAdmin={isAdmin}
         updatingId={updatingId}
         onStatusChange={isAdmin ? handleStatusChange : undefined}
+        onToggleVote={toggleVote}
+        votingId={votingId}
+        onCommentAdded={registerComment}
       />
 
       <CreateProposalDialog

--- a/components/improvement-proposals/utils.ts
+++ b/components/improvement-proposals/utils.ts
@@ -1,0 +1,49 @@
+export function getInitials(name?: string | null, email?: string | null) {
+  if (name && name.trim()) {
+    const parts = name.trim().split(/\s+/)
+    if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase()
+    return (parts[0].charAt(0) + parts[parts.length - 1].charAt(0)).toUpperCase()
+  }
+  if (email) {
+    const username = email.split("@")[0]
+    const sanitized = username.replace(/\./g, " ")
+    const segments = sanitized.split(/\s+/)
+    if (segments.length === 1) return segments[0].slice(0, 2).toUpperCase()
+    return (segments[0].charAt(0) + segments[segments.length - 1].charAt(0)).toUpperCase()
+  }
+  return "?"
+}
+
+export function formatRelativeDate(value?: string | null) {
+  if (!value) return null
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return null
+
+  const now = new Date()
+  const diffMs = date.getTime() - now.getTime()
+  const diffSeconds = Math.round(diffMs / 1000)
+
+  const thresholds = [
+    { limit: 60, unit: "segundo", seconds: 1 },
+    { limit: 3600, unit: "minuto", seconds: 60 },
+    { limit: 86400, unit: "hora", seconds: 3600 },
+    { limit: 604800, unit: "día", seconds: 86400 },
+    { limit: 2629800, unit: "semana", seconds: 604800 },
+    { limit: 31557600, unit: "mes", seconds: 2629800 },
+  ] as const
+
+  const absoluteSeconds = Math.abs(diffSeconds)
+
+  for (const threshold of thresholds) {
+    if (absoluteSeconds < threshold.limit) {
+      const amount = Math.floor(absoluteSeconds / threshold.seconds) || 1
+      const suffix = amount === 1 ? threshold.unit : `${threshold.unit}s`
+      return diffSeconds >= 0 ? `en ${amount} ${suffix}` : `hace ${amount} ${suffix}`
+    }
+  }
+
+  const years = Math.floor(absoluteSeconds / 31557600)
+  return diffSeconds >= 0
+    ? `en ${years} ${years === 1 ? "año" : "años"}`
+    : `hace ${years} ${years === 1 ? "año" : "años"}`
+}

--- a/hooks/use-improvement-proposals.ts
+++ b/hooks/use-improvement-proposals.ts
@@ -10,6 +10,7 @@ import type {
   ImprovementProposalWithAuthor,
 } from "@/lib/types/improvement-proposals"
 import { IMPROVEMENT_PROPOSAL_STATUS_LABELS } from "@/lib/types/improvement-proposals"
+import { toast } from "sonner"
 
 interface CreateImprovementProposalInput {
   title: string
@@ -17,12 +18,20 @@ interface CreateImprovementProposalInput {
   impact?: string | null
 }
 
+type ProposalQueryRow = ImprovementProposal & {
+  votos?: { count: number | null }[]
+  comentarios?: { count: number | null }[]
+}
+
 export function useImprovementProposals() {
   const [proposals, setProposals] = useState<ImprovementProposalWithAuthor[]>([])
   const [loading, setLoading] = useState(true)
   const [refreshing, setRefreshing] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [currentUserId, setCurrentUserId] = useState<string | null>(null)
+  const [votingId, setVotingId] = useState<string | null>(null)
   const hasFetchedRef = useRef(false)
+  const proposalsRef = useRef<ImprovementProposalWithAuthor[]>([])
 
   const enrichWithAuthor = useCallback(async (rows: ImprovementProposal[]) => {
     if (rows.length === 0) return [] as ImprovementProposalWithAuthor[]
@@ -65,6 +74,43 @@ export function useImprovementProposals() {
     }))
   }, [])
 
+  useEffect(() => {
+    proposalsRef.current = proposals
+  }, [proposals])
+
+  useEffect(() => {
+    let mounted = true
+
+    const resolveSession = async () => {
+      try {
+        const {
+          data: { session },
+        } = await supabase.auth.getSession()
+        if (mounted) {
+          setCurrentUserId(session?.user?.id ?? null)
+        }
+      } catch (sessionError) {
+        console.error("Error resolving current session for proposals", sessionError)
+        if (mounted) setCurrentUserId(null)
+      }
+    }
+
+    void resolveSession()
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_, session) => {
+      if (mounted) {
+        setCurrentUserId(session?.user?.id ?? null)
+      }
+    })
+
+    return () => {
+      mounted = false
+      subscription.unsubscribe()
+    }
+  }, [])
+
   const fetchProposals = useCallback(async () => {
     if (!hasFetchedRef.current) {
       setLoading(true)
@@ -74,13 +120,15 @@ export function useImprovementProposals() {
 
     try {
       setError(null)
-      const { data, error: fetchError } = await runQuery<ImprovementProposal[]>({
+      const { data, error: fetchError } = await runQuery<ProposalQueryRow[]>({
         label: "fetch-improvement-proposals",
         table: "propuesta_mejora",
         build: async (signal) =>
           await supabase
             .from("propuesta_mejora")
-            .select("*")
+            .select(
+              "*, votos:propuesta_mejora_voto(count), comentarios:propuesta_mejora_comentario(count)",
+            )
             .order("estado", { ascending: true })
             .order("creado_en", { ascending: false })
             .abortSignal(signal),
@@ -95,8 +143,41 @@ export function useImprovementProposals() {
         return
       }
 
-      const enriched = await enrichWithAuthor(data ?? [])
-      setProposals(enriched)
+      const rows = data ?? []
+
+      let votedIds = new Set<string>()
+
+      if (currentUserId) {
+        try {
+          const { data: userVotes, error: votesError } = await supabase
+            .from("propuesta_mejora_voto")
+            .select("propuesta_id")
+            .eq("usuario_id", currentUserId)
+
+          if (votesError) {
+            console.error("Error fetching user votes for proposals", votesError)
+          } else if (userVotes) {
+            votedIds = new Set(userVotes.map((vote) => vote.propuesta_id))
+          }
+        } catch (votesErr) {
+          console.error("Unexpected error loading user votes", votesErr)
+        }
+      }
+
+      const enriched = await enrichWithAuthor(rows as ImprovementProposal[])
+      const normalized = enriched.map((proposal) => {
+        const raw = rows.find((row) => row.id === proposal.id)
+        const votesCount = raw?.votos?.[0]?.count ?? 0
+        const commentsCount = raw?.comentarios?.[0]?.count ?? 0
+        return {
+          ...proposal,
+          votesCount,
+          commentsCount,
+          userHasVoted: votedIds.has(proposal.id),
+        }
+      })
+
+      setProposals(normalized)
     } catch (err) {
       console.error("Unexpected error loading improvement proposals", err)
       setError(
@@ -109,7 +190,7 @@ export function useImprovementProposals() {
       setLoading(false)
       setRefreshing(false)
     }
-  }, [enrichWithAuthor])
+  }, [currentUserId, enrichWithAuthor])
 
   const createProposal = useCallback(
     async ({ title, description, impact }: CreateImprovementProposalInput) => {
@@ -169,6 +250,9 @@ export function useImprovementProposals() {
       const newProposal: ImprovementProposalWithAuthor = {
         ...(data as ImprovementProposal),
         authorName,
+        votesCount: 0,
+        commentsCount: 0,
+        userHasVoted: false,
       }
 
       setProposals((prev) => [newProposal, ...prev])
@@ -202,6 +286,9 @@ export function useImprovementProposals() {
             ? {
                 ...(data as ImprovementProposal),
                 authorName: proposal.authorName,
+                votesCount: proposal.votesCount,
+                commentsCount: proposal.commentsCount,
+                userHasVoted: proposal.userHasVoted,
               }
             : proposal,
         ),
@@ -209,6 +296,89 @@ export function useImprovementProposals() {
     },
     [],
   )
+
+  const toggleVote = useCallback(
+    async (proposalId: string) => {
+      if (!proposalId) return
+      if (!currentUserId) {
+        toast.error("Necesitas iniciar sesión para apoyar ideas")
+        return
+      }
+
+      const target = proposalsRef.current.find((proposal) => proposal.id === proposalId)
+      if (!target) return
+
+      setVotingId(proposalId)
+
+      try {
+        if (target.userHasVoted) {
+          const { error } = await supabase
+            .from("propuesta_mejora_voto")
+            .delete()
+            .eq("propuesta_id", proposalId)
+            .eq("usuario_id", currentUserId)
+
+          if (error) throw error
+
+          setProposals((prev) =>
+            prev.map((proposal) =>
+              proposal.id === proposalId
+                ? {
+                    ...proposal,
+                    votesCount: Math.max(0, proposal.votesCount - 1),
+                    userHasVoted: false,
+                  }
+                : proposal,
+            ),
+          )
+          toast.success("Has retirado tu apoyo")
+        } else {
+          const { error } = await supabase
+            .from("propuesta_mejora_voto")
+            .insert({ propuesta_id: proposalId, usuario_id: currentUserId })
+
+          if (error) throw error
+
+          setProposals((prev) =>
+            prev.map((proposal) =>
+              proposal.id === proposalId
+                ? {
+                    ...proposal,
+                    votesCount: proposal.votesCount + 1,
+                    userHasVoted: true,
+                  }
+                : proposal,
+            ),
+          )
+          toast.success("¡Gracias por apoyar la idea!")
+        }
+      } catch (voteError) {
+        console.error("Error toggling proposal vote", voteError)
+        toast.error(
+          voteError instanceof Error
+            ? voteError.message
+            : "No pudimos actualizar tu voto. Inténtalo de nuevo.",
+        )
+      } finally {
+        setVotingId(null)
+      }
+    },
+    [currentUserId],
+  )
+
+  const registerComment = useCallback((proposalId: string) => {
+    if (!proposalId) return
+    setProposals((prev) =>
+      prev.map((proposal) =>
+        proposal.id === proposalId
+          ? {
+              ...proposal,
+              commentsCount: proposal.commentsCount + 1,
+            }
+          : proposal,
+      ),
+    )
+  }, [])
 
   useEffect(() => {
     fetchProposals()
@@ -238,6 +408,9 @@ export function useImprovementProposals() {
     error,
     createProposal,
     updateProposalStatus,
+    toggleVote,
+    votingId,
+    registerComment,
     refetch: fetchProposals,
     statusLabels: IMPROVEMENT_PROPOSAL_STATUS_LABELS,
   }

--- a/lib/types/database.ts
+++ b/lib/types/database.ts
@@ -305,6 +305,55 @@ export type Database = {
           actualizado_en?: string | null
         }
       }
+      propuesta_mejora_comentario: {
+        Row: {
+          id: string
+          propuesta_id: string
+          contenido: string
+          creado_por: string
+          creado_por_nombre: string | null
+          creado_por_email: string | null
+          creado_en: string
+        }
+        Insert: {
+          id?: string
+          propuesta_id: string
+          contenido: string
+          creado_por: string
+          creado_por_nombre?: string | null
+          creado_por_email?: string | null
+          creado_en?: string
+        }
+        Update: {
+          id?: string
+          propuesta_id?: string
+          contenido?: string
+          creado_por?: string
+          creado_por_nombre?: string | null
+          creado_por_email?: string | null
+          creado_en?: string
+        }
+      }
+      propuesta_mejora_voto: {
+        Row: {
+          id: string
+          propuesta_id: string
+          usuario_id: string
+          creado_en: string
+        }
+        Insert: {
+          id?: string
+          propuesta_id: string
+          usuario_id: string
+          creado_en?: string
+        }
+        Update: {
+          id?: string
+          propuesta_id?: string
+          usuario_id?: string
+          creado_en?: string
+        }
+      }
     }
   }
 }
@@ -318,6 +367,8 @@ export type Membresia = Database["public"]["Tables"]["membresia"]["Row"]
 export type Perfil = Database["public"]["Tables"]["perfil"]["Row"]
 export type MovimientoArchivo = Database["public"]["Tables"]["movimiento_archivo"]["Row"]
 export type PropuestaMejora = Database["public"]["Tables"]["propuesta_mejora"]["Row"]
+export type PropuestaMejoraComentario = Database["public"]["Tables"]["propuesta_mejora_comentario"]["Row"]
+export type PropuestaMejoraVoto = Database["public"]["Tables"]["propuesta_mejora_voto"]["Row"]
 
 // Extended types with relations
 export type MovimientoConRelaciones = Movimiento & {

--- a/lib/types/improvement-proposals.ts
+++ b/lib/types/improvement-proposals.ts
@@ -7,6 +7,19 @@ export type ImprovementProposalStatus = ImprovementProposal["estado"]
 
 export interface ImprovementProposalWithAuthor extends ImprovementProposal {
   authorName: string
+  votesCount: number
+  commentsCount: number
+  userHasVoted: boolean
+}
+
+export interface ImprovementProposalComment {
+  id: string
+  propuesta_id: string
+  contenido: string
+  creado_por: string
+  creado_por_nombre: string | null
+  creado_por_email: string | null
+  creado_en: string
 }
 
 export const IMPROVEMENT_PROPOSAL_STATUSES: ImprovementProposalStatus[] = [

--- a/scripts/021_propuesta_mejora_interacciones.sql
+++ b/scripts/021_propuesta_mejora_interacciones.sql
@@ -1,0 +1,82 @@
+-- Tablas de interacción para propuestas de mejora
+
+-- Votos
+CREATE TABLE IF NOT EXISTS public.propuesta_mejora_voto (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  propuesta_id UUID NOT NULL REFERENCES public.propuesta_mejora(id) ON DELETE CASCADE,
+  usuario_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  creado_en TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now()),
+  CONSTRAINT propuesta_mejora_voto_unique UNIQUE (propuesta_id, usuario_id)
+);
+
+ALTER TABLE public.propuesta_mejora_voto ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY IF NOT EXISTS "Propuestas - votos visibles" ON public.propuesta_mejora_voto
+  FOR SELECT
+  USING (auth.role() = 'authenticated');
+
+CREATE POLICY IF NOT EXISTS "Propuestas - votar" ON public.propuesta_mejora_voto
+  FOR INSERT
+  WITH CHECK (auth.uid() = usuario_id);
+
+CREATE POLICY IF NOT EXISTS "Propuestas - retirar voto" ON public.propuesta_mejora_voto
+  FOR DELETE
+  USING (auth.uid() = usuario_id);
+
+CREATE POLICY IF NOT EXISTS "Gestor central limpia votos" ON public.propuesta_mejora_voto
+  FOR DELETE
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.membresia m
+      WHERE m.usuario_id = auth.uid()
+        AND m.rol = 'gestor_central'
+    )
+  );
+
+CREATE INDEX IF NOT EXISTS propuesta_mejora_voto_propuesta_idx ON public.propuesta_mejora_voto (propuesta_id);
+CREATE INDEX IF NOT EXISTS propuesta_mejora_voto_usuario_idx ON public.propuesta_mejora_voto (usuario_id);
+
+-- Comentarios
+CREATE TABLE IF NOT EXISTS public.propuesta_mejora_comentario (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  propuesta_id UUID NOT NULL REFERENCES public.propuesta_mejora(id) ON DELETE CASCADE,
+  contenido TEXT NOT NULL,
+  creado_por UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  creado_por_nombre TEXT,
+  creado_por_email TEXT,
+  creado_en TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now())
+);
+
+ALTER TABLE public.propuesta_mejora_comentario ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY IF NOT EXISTS "Propuestas - comentarios visibles" ON public.propuesta_mejora_comentario
+  FOR SELECT
+  USING (auth.role() = 'authenticated');
+
+CREATE POLICY IF NOT EXISTS "Propuestas - comentar" ON public.propuesta_mejora_comentario
+  FOR INSERT
+  WITH CHECK (auth.uid() = creado_por);
+
+CREATE POLICY IF NOT EXISTS "Propuestas - autor edita comentario" ON public.propuesta_mejora_comentario
+  FOR UPDATE
+  USING (auth.uid() = creado_por)
+  WITH CHECK (auth.uid() = creado_por);
+
+CREATE POLICY IF NOT EXISTS "Propuestas - autor elimina comentario" ON public.propuesta_mejora_comentario
+  FOR DELETE
+  USING (auth.uid() = creado_por);
+
+CREATE POLICY IF NOT EXISTS "Gestor central modera comentarios" ON public.propuesta_mejora_comentario
+  FOR DELETE
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.membresia m
+      WHERE m.usuario_id = auth.uid()
+        AND m.rol = 'gestor_central'
+    )
+  );
+
+CREATE INDEX IF NOT EXISTS propuesta_mejora_comentario_propuesta_idx ON public.propuesta_mejora_comentario (propuesta_id);
+CREATE INDEX IF NOT EXISTS propuesta_mejora_comentario_creado_en_idx ON public.propuesta_mejora_comentario (creado_en DESC);


### PR DESCRIPTION
## Summary
- refreshed the improvement proposals cards with clearer layout, voting CTA and comment entry points
- added a comment dialog with Supabase-backed CRUD plumbing and exposed voting/comment counts through the proposals hook
- documented the required Supabase tables/policies for proposal votes and comments

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cc1df3d43c83269cdd82ce01590ea7