### PR TITLE
Soporta orden de categorías por delegación

### DIFF
--- a/components/categories/category-list.tsx
+++ b/components/categories/category-list.tsx
@@ -378,7 +378,9 @@ export function CategoryList() {
 
     map.forEach((list) => {
       list.sort((a, b) => {
-        if (a.orden !== b.orden) return a.orden - b.orden
+        const ordenA = "orden_efectivo" in a ? a.orden_efectivo ?? a.orden : a.orden
+        const ordenB = "orden_efectivo" in b ? b.orden_efectivo ?? b.orden : b.orden
+        if (ordenA !== ordenB) return ordenA - ordenB
         return a.nombre.localeCompare(b.nombre)
       })
     })

--- a/components/categories/category-search.tsx
+++ b/components/categories/category-search.tsx
@@ -28,7 +28,12 @@ export function CategorySearch({
   const [searchValue, setSearchValue] = useState("")
 
   const orderedCategories = useMemo(() => {
-    return [...categories].sort((a, b) => a.orden - b.orden)
+    return [...categories].sort((a, b) => {
+      const ordenA = "orden_efectivo" in a ? a.orden_efectivo ?? a.orden : a.orden
+      const ordenB = "orden_efectivo" in b ? b.orden_efectivo ?? b.orden : b.orden
+      if (ordenA !== ordenB) return ordenA - ordenB
+      return a.nombre.localeCompare(b.nombre)
+    })
   }, [categories])
 
   const groupedCategories = useMemo(() => {
@@ -46,7 +51,12 @@ export function CategorySearch({
     const result: (Categoria & { depth: number })[] = []
     for (const cat of top) {
       result.push(cat)
-      const subs = (children[cat.id] || []).sort((a, b) => a.orden - b.orden)
+      const subs = (children[cat.id] || []).sort((a, b) => {
+        const ordenA = "orden_efectivo" in a ? a.orden_efectivo ?? a.orden : a.orden
+        const ordenB = "orden_efectivo" in b ? b.orden_efectivo ?? b.orden : b.orden
+        if (ordenA !== ordenB) return ordenA - ordenB
+        return a.nombre.localeCompare(b.nombre)
+      })
       for (const sub of subs) result.push({ ...sub, depth: 1 })
     }
     return result

--- a/components/transactions/category-mega-selector.tsx
+++ b/components/transactions/category-mega-selector.tsx
@@ -58,9 +58,19 @@ export function CategoryMegaSelector({
       }
     })
 
-    const sortedParents = [...parentCategories].sort((a, b) => a.orden - b.orden)
+    const sortedParents = [...parentCategories].sort((a, b) => {
+      const ordenA = "orden_efectivo" in a ? a.orden_efectivo ?? a.orden : a.orden
+      const ordenB = "orden_efectivo" in b ? b.orden_efectivo ?? b.orden : b.orden
+      if (ordenA !== ordenB) return ordenA - ordenB
+      return a.nombre.localeCompare(b.nombre)
+    })
     const groups: CategoryGroup[] = sortedParents.map((parent) => {
-      const children = (childMap.get(parent.id) || []).sort((a, b) => a.orden - b.orden)
+      const children = (childMap.get(parent.id) || []).sort((a, b) => {
+        const ordenA = "orden_efectivo" in a ? a.orden_efectivo ?? a.orden : a.orden
+        const ordenB = "orden_efectivo" in b ? b.orden_efectivo ?? b.orden : b.orden
+        if (ordenA !== ordenB) return ordenA - ordenB
+        return a.nombre.localeCompare(b.nombre)
+      })
       children.forEach((child) => parentLookupMap.set(child.id, parent))
       parentLookupMap.set(parent.id, undefined)
       return {
@@ -72,7 +82,12 @@ export function CategoryMegaSelector({
     const parentIds = new Set(parentCategories.map((cat) => cat.id))
     const orphans = categories
       .filter((cat) => cat.categoria_padre_id && !parentIds.has(cat.categoria_padre_id))
-      .sort((a, b) => a.orden - b.orden)
+      .sort((a, b) => {
+        const ordenA = "orden_efectivo" in a ? a.orden_efectivo ?? a.orden : a.orden
+        const ordenB = "orden_efectivo" in b ? b.orden_efectivo ?? b.orden : b.orden
+        if (ordenA !== ordenB) return ordenA - ordenB
+        return a.nombre.localeCompare(b.nombre)
+      })
 
     orphans.forEach((orphan) => {
       if (orphan.categoria_padre_id) {
@@ -98,7 +113,12 @@ export function CategoryMegaSelector({
         category.nombre.toLowerCase().includes(normalizedSearch) ||
         (category.emoji && category.emoji.includes(searchValue.trim())),
       )
-      .sort((a, b) => a.orden - b.orden)
+      .sort((a, b) => {
+        const ordenA = "orden_efectivo" in a ? a.orden_efectivo ?? a.orden : a.orden
+        const ordenB = "orden_efectivo" in b ? b.orden_efectivo ?? b.orden : b.orden
+        if (ordenA !== ordenB) return ordenA - ordenB
+        return a.nombre.localeCompare(b.nombre)
+      })
   }, [categories, normalizedSearch, searchValue])
 
   const handleSelect = (categoryId: string) => {

--- a/hooks/use-categorias.ts
+++ b/hooks/use-categorias.ts
@@ -1,26 +1,35 @@
 "use client"
 
 import { useState, useEffect, useCallback, useRef } from "react"
-import { supabase } from "@/lib/supabase/client"
-import type { Categoria } from "@/lib/types/database"
+import type { CategoriaConOrdenEfectivo } from "@/lib/types/database"
 import { useRevalidateOnFocusJitter } from "./use-app-status"
-import { runQuery } from "@/lib/db/query"
+import { DatabaseService } from "@/lib/services/database"
+
+type CategoriaOrdenChange = {
+  categoriaId: string
+  orden: number | null
+}
+
+const sortCategorias = (categorias: CategoriaConOrdenEfectivo[]) =>
+  [...categorias].sort((a, b) => {
+    if (a.orden_efectivo !== b.orden_efectivo) {
+      return a.orden_efectivo - b.orden_efectivo
+    }
+    return a.nombre.localeCompare(b.nombre)
+  })
 
 export function useCategorias(
   delegacionId?: string | null,
   options?: { includeGlobal?: boolean },
 ) {
-  const [categorias, setCategorias] = useState<Categoria[]>([])
+  const [categorias, setCategorias] = useState<CategoriaConOrdenEfectivo[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const abortRef = useRef<AbortController | null>(null)
-  const timeoutRef = useRef<NodeJS.Timeout | null>(null)
-  const TIMEOUT_MS = 12000
   const includeGlobal = options?.includeGlobal ?? true
 
   const fetchCategorias = useCallback(async () => {
     if (abortRef.current) abortRef.current.abort()
-    if (timeoutRef.current) clearTimeout(timeoutRef.current)
 
     const ac = new AbortController()
     abortRef.current = ac
@@ -33,50 +42,19 @@ export function useCategorias(
 
       setLoading(true)
 
-      const { data, error } = await runQuery<Categoria[]>({
-        label: 'fetch-categorias',
-        table: 'categoria',
-        timeoutMs: TIMEOUT_MS,
-        build: async (signal) => {
-          let query = supabase
-            .from("categoria")
-            .select("*")
-            .order("orden", { ascending: true })
-            .order("nombre", { ascending: true })
-          if (delegacionId) {
-            query = includeGlobal
-              ? query.or(`delegacion_id.eq.${delegacionId},es_global.is.true`)
-              : query.eq("delegacion_id", delegacionId)
-          } else if (includeGlobal) {
-            query = query.eq("es_global", true)
-          }
-          return await query.abortSignal(signal)
-        }
+      const data = await DatabaseService.getCategoriasByDelegacion(delegacionId, {
+        includeGlobal,
+        signal: ac.signal,
       })
 
-      if (error) {
-        setError(error.message)
-        return
-      }
-
-      setCategorias(
-        (data || []).sort((a, b) => {
-          if (a.es_global !== b.es_global) {
-            return a.es_global ? -1 : 1
-          }
-          return a.orden - b.orden
-        }),
-      )
+      setCategorias(data)
+      setError(null)
     } catch (err) {
       if (!ac.signal.aborted) {
         setError(err instanceof Error ? err.message : "Error desconocido")
       }
     } finally {
       setLoading(false)
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current)
-        timeoutRef.current = null
-      }
     }
   }, [delegacionId, includeGlobal])
 
@@ -84,24 +62,75 @@ export function useCategorias(
     fetchCategorias()
     return () => {
       if (abortRef.current) abortRef.current.abort()
-      if (timeoutRef.current) clearTimeout(timeoutRef.current)
     }
   }, [fetchCategorias])
 
   // Revalidate on focus
   useRevalidateOnFocusJitter(fetchCategorias, { minMs: 60, maxMs: 160 })
 
-  const updateCategoria = async (id: string, updates: Partial<Categoria>) => {
+  const updateCategoria = async (id: string, updates: Partial<CategoriaConOrdenEfectivo>) => {
     try {
-      const { error } = await supabase.from("categoria").update(updates).eq("id", id)
+      await DatabaseService.updateCategoria(id, updates)
 
-      if (error) throw error
-
-      setCategorias((prev) => prev.map((cat) => (cat.id === id ? { ...cat, ...updates } : cat)))
+      setCategorias((prev) => {
+        const next = prev.map((cat) => {
+          if (cat.id !== id) return cat
+          const orden_base = updates.orden ?? cat.orden_base ?? cat.orden
+          const orden_override = cat.orden_override
+          const orden_efectivo = orden_override ?? orden_base
+          return {
+            ...cat,
+            ...updates,
+            orden: orden_base,
+            orden_base,
+            orden_efectivo,
+          }
+        })
+        return sortCategorias(next)
+      })
+      setError(null)
     } catch (err) {
       setError(err instanceof Error ? err.message : "Error al actualizar categoría")
+      throw err
     }
   }
 
-  return { categorias, loading, error, updateCategoria, fetchCategorias }
+  const saveCategoriaOrdenes = async (changes: CategoriaOrdenChange[]) => {
+    if (!delegacionId) {
+      throw new Error("Se requiere una delegación para guardar el orden")
+    }
+
+    try {
+      await Promise.all(
+        changes.map((change) =>
+          change.orden === null
+            ? DatabaseService.clearDelegacionCategoryOrder(delegacionId, change.categoriaId)
+            : DatabaseService.setDelegacionCategoryOrder(delegacionId, change.categoriaId, change.orden),
+        ),
+      )
+
+      setCategorias((prev) => {
+        const changeMap = new Map(changes.map((change) => [change.categoriaId, change]))
+        const next = prev.map((cat) => {
+          const change = changeMap.get(cat.id)
+          if (!change) return cat
+          const orden_override = change.orden
+          const orden_base = cat.orden_base ?? cat.orden
+          const orden_efectivo = orden_override ?? orden_base
+          return {
+            ...cat,
+            orden_override,
+            orden_efectivo,
+          }
+        })
+        return sortCategorias(next)
+      })
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "No se pudo guardar el orden de categorías")
+      throw err
+    }
+  }
+
+  return { categorias, loading, error, updateCategoria, fetchCategorias, saveCategoriaOrdenes }
 }

--- a/lib/services/database.ts
+++ b/lib/services/database.ts
@@ -1,5 +1,55 @@
 import { supabase } from "@/lib/supabase/client"
-import type { Categoria } from "@/lib/types/database"
+import type {
+  Categoria,
+  CategoriaConOrdenEfectivo,
+  CategoriaOrdenDelegacion,
+} from "@/lib/types/database"
+
+type CategoriaWithOverrides = Categoria & {
+  overrides?: CategoriaOrdenDelegacion[] | null
+}
+
+const selectCategoriasWithOverrides = `
+  *,
+  overrides:categoria_orden_delegacion!left (
+    delegacion_id,
+    categoria_id,
+    orden
+  )
+`
+
+function mapCategorias(
+  data: CategoriaWithOverrides[] | null,
+  delegacionId?: string | null,
+): CategoriaConOrdenEfectivo[] {
+  if (!data) return []
+
+  const mapped = data.map((item) => {
+    const { overrides, orden, ...categoria } = item
+    const override = delegacionId
+      ? overrides?.find((entry) => entry.delegacion_id === delegacionId)
+      : null
+
+    const orden_base = orden
+    const orden_override = override?.orden ?? null
+    const orden_efectivo = orden_override ?? orden_base
+
+    return {
+      ...categoria,
+      orden,
+      orden_base,
+      orden_override,
+      orden_efectivo,
+    }
+  })
+
+  return mapped.sort((a, b) => {
+    if (a.orden_efectivo !== b.orden_efectivo) {
+      return a.orden_efectivo - b.orden_efectivo
+    }
+    return a.nombre.localeCompare(b.nombre)
+  })
+}
 
 export class DatabaseService {
   private static getClient() {
@@ -16,22 +66,37 @@ export class DatabaseService {
 
   // Categoria operations (client-side only)
   static async getCategoriasByDelegacion(
-    delegacionId: string,
-    options: { includeGlobal?: boolean } = {},
-  ): Promise<Categoria[]> {
+    delegacionId?: string | null,
+    options: { includeGlobal?: boolean; signal?: AbortSignal } = {},
+  ): Promise<CategoriaConOrdenEfectivo[]> {
     const supabase = this.getClient()
-    const { data, error } = await supabase
+    const includeGlobal = options.includeGlobal ?? true
+
+    if (!delegacionId && includeGlobal === false) {
+      return []
+    }
+
+    let query = supabase
       .from("categoria")
-      .select("*")
-      .or(
-        options.includeGlobal !== false
-          ? `delegacion_id.eq.${delegacionId},es_global.is.true`
-          : `delegacion_id.eq.${delegacionId}`,
-      )
+      .select(selectCategoriasWithOverrides)
       .order("orden", { ascending: true })
 
+    if (delegacionId) {
+      query = includeGlobal
+        ? query.or(`delegacion_id.eq.${delegacionId},es_global.is.true`)
+        : query.eq("delegacion_id", delegacionId)
+    } else if (includeGlobal) {
+      query = query.eq("es_global", true)
+    }
+
+    if (options.signal) {
+      query = query.abortSignal(options.signal)
+    }
+
+    const { data, error } = await query
+
     if (error) throw error
-    return data || []
+    return mapCategorias(data as CategoriaWithOverrides[] | null, delegacionId)
   }
 
   static async createCategoria(
@@ -54,6 +119,40 @@ export class DatabaseService {
   static async deleteCategoria(id: string): Promise<void> {
     const supabase = this.getClient()
     const { error } = await supabase.from("categoria").delete().eq("id", id)
+
+    if (error) throw error
+  }
+
+  static async setDelegacionCategoryOrder(
+    delegacionId: string,
+    categoriaId: string,
+    orden: number,
+  ): Promise<void> {
+    const supabase = this.getClient()
+    const { error } = await supabase
+      .from("categoria_orden_delegacion")
+      .upsert(
+        {
+          delegacion_id: delegacionId,
+          categoria_id: categoriaId,
+          orden,
+          actualizado_en: new Date().toISOString(),
+        },
+        { onConflict: "delegacion_id,categoria_id" },
+      )
+
+    if (error) throw error
+  }
+
+  static async clearDelegacionCategoryOrder(
+    delegacionId: string,
+    categoriaId: string,
+  ): Promise<void> {
+    const supabase = this.getClient()
+    const { error } = await supabase
+      .from("categoria_orden_delegacion")
+      .delete()
+      .match({ delegacion_id: delegacionId, categoria_id: categoriaId })
 
     if (error) throw error
   }

--- a/lib/services/server-database.ts
+++ b/lib/services/server-database.ts
@@ -2,10 +2,58 @@ import { createClient } from "@/lib/supabase/server"
 import type {
   Delegacion,
   Categoria,
+  CategoriaConOrdenEfectivo,
+  CategoriaOrdenDelegacion,
   Membresia,
   MovimientoConRelaciones,
   CuentaConDelegacion,
 } from "@/lib/types/database"
+
+type CategoriaWithOverrides = Categoria & {
+  overrides?: CategoriaOrdenDelegacion[] | null
+}
+
+const selectCategoriasWithOverrides = `
+  *,
+  overrides:categoria_orden_delegacion!left (
+    delegacion_id,
+    categoria_id,
+    orden
+  )
+`
+
+function mapCategorias(
+  data: CategoriaWithOverrides[] | null,
+  delegacionId?: string | null,
+): CategoriaConOrdenEfectivo[] {
+  if (!data) return []
+
+  const mapped = data.map((item) => {
+    const { overrides, orden, ...categoria } = item
+    const override = delegacionId
+      ? overrides?.find((entry) => entry.delegacion_id === delegacionId)
+      : null
+
+    const orden_base = orden
+    const orden_override = override?.orden ?? null
+    const orden_efectivo = orden_override ?? orden_base
+
+    return {
+      ...categoria,
+      orden,
+      orden_base,
+      orden_override,
+      orden_efectivo,
+    }
+  })
+
+  return mapped.sort((a, b) => {
+    if (a.orden_efectivo !== b.orden_efectivo) {
+      return a.orden_efectivo - b.orden_efectivo
+    }
+    return a.nombre.localeCompare(b.nombre)
+  })
+}
 
 export class ServerDatabaseService {
   private static getServerClient() {
@@ -139,21 +187,66 @@ export class ServerDatabaseService {
 
   // Categoria operations (server-side)
   static async getCategoriasByDelegacion(
-    delegacionId: string,
+    delegacionId?: string | null,
     options: { includeGlobal?: boolean } = {},
-  ): Promise<Categoria[]> {
+  ): Promise<CategoriaConOrdenEfectivo[]> {
     const supabase = this.getServerClient()
-    const { data, error } = await supabase
+    const includeGlobal = options.includeGlobal ?? true
+
+    if (!delegacionId && includeGlobal === false) {
+      return []
+    }
+
+    let query = supabase
       .from("categoria")
-      .select("*")
-      .or(
-        options.includeGlobal !== false
-          ? `delegacion_id.eq.${delegacionId},es_global.is.true`
-          : `delegacion_id.eq.${delegacionId}`,
-      )
+      .select(selectCategoriasWithOverrides)
       .order("orden", { ascending: true })
 
+    if (delegacionId) {
+      query = includeGlobal
+        ? query.or(`delegacion_id.eq.${delegacionId},es_global.is.true`)
+        : query.eq("delegacion_id", delegacionId)
+    } else if (includeGlobal) {
+      query = query.eq("es_global", true)
+    }
+
+    const { data, error } = await query
+
     if (error) throw error
-    return data || []
+    return mapCategorias(data as CategoriaWithOverrides[] | null, delegacionId)
+  }
+
+  static async setDelegacionCategoryOrder(
+    delegacionId: string,
+    categoriaId: string,
+    orden: number,
+  ): Promise<void> {
+    const supabase = this.getServerClient()
+    const { error } = await supabase
+      .from("categoria_orden_delegacion")
+      .upsert(
+        {
+          delegacion_id: delegacionId,
+          categoria_id: categoriaId,
+          orden,
+          actualizado_en: new Date().toISOString(),
+        },
+        { onConflict: "delegacion_id,categoria_id" },
+      )
+
+    if (error) throw error
+  }
+
+  static async clearDelegacionCategoryOrder(
+    delegacionId: string,
+    categoriaId: string,
+  ): Promise<void> {
+    const supabase = this.getServerClient()
+    const { error } = await supabase
+      .from("categoria_orden_delegacion")
+      .delete()
+      .match({ delegacion_id: delegacionId, categoria_id: categoriaId })
+
+    if (error) throw error
   }
 }

--- a/lib/types/database.ts
+++ b/lib/types/database.ts
@@ -186,6 +186,29 @@ export type Database = {
           es_global?: boolean
         }
       }
+      categoria_orden_delegacion: {
+        Row: {
+          delegacion_id: string
+          categoria_id: string
+          orden: number
+          creado_en: string
+          actualizado_en: string
+        }
+        Insert: {
+          delegacion_id: string
+          categoria_id: string
+          orden: number
+          creado_en?: string
+          actualizado_en?: string
+        }
+        Update: {
+          delegacion_id?: string
+          categoria_id?: string
+          orden?: number
+          creado_en?: string
+          actualizado_en?: string
+        }
+      }
       membresia: {
         Row: {
           usuario_id: string
@@ -363,6 +386,12 @@ export type Delegacion = Database["public"]["Tables"]["delegacion"]["Row"]
 export type Cuenta = Database["public"]["Tables"]["cuenta"]["Row"]
 export type Movimiento = Database["public"]["Tables"]["movimiento"]["Row"]
 export type Categoria = Database["public"]["Tables"]["categoria"]["Row"]
+export type CategoriaOrdenDelegacion = Database["public"]["Tables"]["categoria_orden_delegacion"]["Row"]
+export type CategoriaConOrdenEfectivo = Categoria & {
+  orden_base: number
+  orden_override: number | null
+  orden_efectivo: number
+}
 export type Membresia = Database["public"]["Tables"]["membresia"]["Row"]
 export type Perfil = Database["public"]["Tables"]["perfil"]["Row"]
 export type MovimientoArchivo = Database["public"]["Tables"]["movimiento_archivo"]["Row"]

--- a/scripts/009_create_categoria_orden_delegacion.sql
+++ b/scripts/009_create_categoria_orden_delegacion.sql
@@ -1,0 +1,9 @@
+-- Tabla de orden de categorías por delegación
+CREATE TABLE IF NOT EXISTS public.categoria_orden_delegacion (
+  delegacion_id UUID NOT NULL REFERENCES public.delegacion (id) ON DELETE CASCADE,
+  categoria_id UUID NOT NULL REFERENCES public.categoria (id) ON DELETE CASCADE,
+  orden INTEGER NOT NULL,
+  creado_en TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now()),
+  actualizado_en TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now()),
+  PRIMARY KEY (delegacion_id, categoria_id)
+);


### PR DESCRIPTION
## Summary
- añade la migración `categoria_orden_delegacion` para almacenar overrides de orden por delegación
- extiende los tipos y servicios de base de datos para mezclar el orden base con overrides y exponer helpers de upsert/delete
- actualiza el hook y los componentes que consumen categorías para ordenar con el valor efectivo por delegación

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cc3d2b09908326aca6bf70b34dc2af