### PR TITLE
feat(propuestas): soportar ideas y errores

### DIFF
--- a/components/improvement-proposals/create-proposal-dialog.tsx
+++ b/components/improvement-proposals/create-proposal-dialog.tsx
@@ -12,19 +12,73 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
-import { Loader2, Sparkles } from "lucide-react"
+import { Loader2, Sparkles, Bug } from "lucide-react"
+import type { ImprovementProposalType } from "@/lib/types/improvement-proposals"
 
 interface CreateProposalDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
-  onSubmit: (values: { title: string; description: string }) => Promise<void>
+  type: ImprovementProposalType
+  onTypeChange?: (type: ImprovementProposalType) => void
+  onSubmit: (values: {
+    title: string
+    description: string
+    type: ImprovementProposalType
+  }) => Promise<void>
 }
 
-export function CreateProposalDialog({ open, onOpenChange, onSubmit }: CreateProposalDialogProps) {
+const TYPE_COPY: Record<
+  ImprovementProposalType,
+  {
+    title: string
+    description: string
+    titlePlaceholder: string
+    descriptionPlaceholder: string
+    submitLabel: string
+    submittingLabel: string
+    helperText: string
+    icon: typeof Sparkles
+  }
+> = {
+  idea: {
+    title: "Comparte una idea brillante",
+    description:
+      "Todavía tenemos margen de mejora y mucha IA por utilizar. ¡Danos ideas para arreglar lo que falla!",
+    titlePlaceholder: "Cambiar este filtro, añadir botón para...",
+    descriptionPlaceholder: "Explica en más detalle tu brillante propuesta",
+    submitLabel: "Publicar propuesta",
+    submittingLabel: "Enviando idea...",
+    helperText:
+      "Las ideas nos ayudan a priorizar mejoras. Cuéntanos qué impacto tendría tu propuesta.",
+    icon: Sparkles,
+  },
+  error: {
+    title: "Reporta un error",
+    description:
+      "Si algo no funciona como debería, déjanos los detalles para poder reproducirlo y arreglarlo pronto.",
+    titlePlaceholder: "Error al descargar extracto...",
+    descriptionPlaceholder:
+      "Describe qué sucede, cómo reproducirlo y qué esperabas que pasara",
+    submitLabel: "Reportar error",
+    submittingLabel: "Enviando reporte...",
+    helperText:
+      "Incluye pasos claros y, si puedes, capturas o mensajes de error. Cuanta más información, mejor.",
+    icon: Bug,
+  },
+}
+
+export function CreateProposalDialog({
+  open,
+  onOpenChange,
+  onSubmit,
+  type,
+  onTypeChange,
+}: CreateProposalDialogProps) {
   const [title, setTitle] = useState("")
   const [description, setDescription] = useState("")
   const [submitting, setSubmitting] = useState(false)
   const [formError, setFormError] = useState<string | null>(null)
+  const [selectedType, setSelectedType] = useState<ImprovementProposalType>(type)
 
   useEffect(() => {
     if (!open) {
@@ -33,13 +87,24 @@ export function CreateProposalDialog({ open, onOpenChange, onSubmit }: CreatePro
     }
   }, [open])
 
+  useEffect(() => {
+    setSelectedType(type)
+  }, [type])
+
+  const copy = TYPE_COPY[selectedType]
+
+  const handleTypeSelection = (value: ImprovementProposalType) => {
+    setSelectedType(value)
+    onTypeChange?.(value)
+  }
+
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
     setFormError(null)
 
     try {
       setSubmitting(true)
-      await onSubmit({ title, description})
+      await onSubmit({ title, description, type: selectedType })
       setTitle("")
       setDescription("")
       onOpenChange(false)
@@ -62,27 +127,48 @@ export function CreateProposalDialog({ open, onOpenChange, onSubmit }: CreatePro
         <DialogHeader className="space-y-4 bg-gradient-to-br from-indigo-600 via-blue-600 to-sky-500 p-6 text-white">
           <div className="flex items-center gap-3">
             <div className="flex h-10 w-10 items-center justify-center rounded-full bg-white/20 backdrop-blur">
-              <Sparkles className="h-5 w-5" />
+              <copy.icon className="h-5 w-5" />
             </div>
             <div className="text-left">
               <DialogTitle className="text-xl font-semibold text-white">
-                Comparte una idea brillante
+                {copy.title}
               </DialogTitle>
               <DialogDescription className="text-white/80">
-                Todavía tenemos margen de mejora y mucha IA por utilizar. ¡Danos ideas para arreglar lo que falla!
+                {copy.description}
               </DialogDescription>
             </div>
           </div>
         </DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-6 bg-background p-6">
+          <div className="flex flex-wrap items-center gap-3">
+            <Button
+              type="button"
+              size="sm"
+              variant={selectedType === "idea" ? "default" : "secondary"}
+              className="rounded-full"
+              onClick={() => handleTypeSelection("idea")}
+            >
+              <Sparkles className="mr-2 h-4 w-4" /> Compartir idea
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant={selectedType === "error" ? "default" : "secondary"}
+              className="rounded-full"
+              onClick={() => handleTypeSelection("error")}
+            >
+              <Bug className="mr-2 h-4 w-4" /> Reportar error
+            </Button>
+          </div>
+
           <div className="space-y-2">
             <label htmlFor="proposal-title" className="text-sm font-medium text-foreground">
               Título
             </label>
             <Input
               id="proposal-title"
-              placeholder="Cambiar este filtro, añadir botón para..."
+              placeholder={copy.titlePlaceholder}
               value={title}
               onChange={(event) => setTitle(event.target.value)}
               maxLength={120}
@@ -95,7 +181,7 @@ export function CreateProposalDialog({ open, onOpenChange, onSubmit }: CreatePro
             </label>
             <Textarea
               id="proposal-description"
-              placeholder="Explica en más detalle tu brillante propuesta"
+              placeholder={copy.descriptionPlaceholder}
               value={description}
               onChange={(event) => setDescription(event.target.value)}
               rows={5}
@@ -110,16 +196,15 @@ export function CreateProposalDialog({ open, onOpenChange, onSubmit }: CreatePro
           )}
 
           <div className="flex flex-col-reverse gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <p className="text-sm text-muted-foreground">
-            </p>
+            <p className="text-sm text-muted-foreground">{copy.helperText}</p>
             <Button type="submit" disabled={disableSubmit} className="sm:w-auto">
               {submitting ? (
                 <>
                   <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  Enviando idea...
+                  {copy.submittingLabel}
                 </>
               ) : (
-                "Publicar propuesta"
+                copy.submitLabel
               )}
             </Button>
           </div>

--- a/components/improvement-proposals/proposal-card.tsx
+++ b/components/improvement-proposals/proposal-card.tsx
@@ -11,7 +11,7 @@ import {
   type ImprovementProposalStatus,
   IMPROVEMENT_PROPOSAL_STATUS_LABELS,
   type ImprovementProposalWithAuthor,
-  IMPROVEMENT_PROPOSAL_STATUSES,
+  IMPROVEMENT_PROPOSAL_STATUS_FLOW,
 } from "@/lib/types/improvement-proposals"
 import type { ImprovementProposalStatusVisualConfig } from "./status-config"
 import { Clock, MessageCircle, ThumbsUp } from "lucide-react"
@@ -41,8 +41,30 @@ export function ProposalCard({
 }: ProposalCardProps) {
   const createdAgo = useMemo(() => formatRelativeDate(proposal.creado_en), [proposal.creado_en])
   const updatedAgo = useMemo(() => formatRelativeDate(proposal.actualizado_en), [proposal.actualizado_en])
-  const statusOptions = useMemo(() => IMPROVEMENT_PROPOSAL_STATUSES, [])
+  const statusOptions = useMemo(
+    () => IMPROVEMENT_PROPOSAL_STATUS_FLOW[proposal.tipo],
+    [proposal.tipo],
+  )
   const [commentsOpen, setCommentsOpen] = useState(false)
+  const isIdea = proposal.tipo === "idea"
+  const typeLabel = isIdea ? "Idea" : "Error"
+  const voteLabel = isIdea
+    ? proposal.userHasVoted
+      ? "Apoyada"
+      : "Apoyar idea"
+    : proposal.userHasVoted
+      ? "Confirmado"
+      : "También me pasa"
+  const voteButtonClasses = proposal.userHasVoted
+    ? isIdea
+      ? "bg-indigo-600 text-white hover:bg-indigo-500"
+      : "bg-rose-600 text-white hover:bg-rose-500"
+    : "bg-background/80 text-foreground hover:bg-background"
+  const voteIconClass = proposal.userHasVoted
+    ? "text-white"
+    : isIdea
+      ? "text-indigo-500"
+      : "text-rose-500"
 
   return (
     <div
@@ -59,14 +81,19 @@ export function ProposalCard({
       <div className="space-y-6 p-6">
         <div className="flex flex-col gap-4">
           <div className="flex items-start justify-between gap-3">
-            <Badge
-              className={cn(
-                "border px-3 py-1 text-xs font-semibold uppercase tracking-wide",
-                statusConfig.badgeClassName,
-              )}
-            >
-              {statusConfig.label}
-            </Badge>
+            <div className="flex flex-wrap items-center gap-2">
+              <Badge
+                className={cn(
+                  "border px-3 py-1 text-xs font-semibold uppercase tracking-wide",
+                  statusConfig.badgeClassName,
+                )}
+              >
+                {statusConfig.label}
+              </Badge>
+              <Badge className="bg-muted/70 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                {typeLabel}
+              </Badge>
+            </div>
             {createdAgo && (
               <span className="inline-flex items-center gap-1 rounded-full bg-muted/60 px-3 py-1 text-[11px] font-medium text-muted-foreground">
                 <Clock className="h-3 w-3" /> {createdAgo}
@@ -100,18 +127,16 @@ export function ProposalCard({
               onClick={() => void onToggleVote?.(proposal.id)}
               className={cn(
                 "rounded-full px-3 text-xs font-semibold uppercase tracking-wide",
-                proposal.userHasVoted
-                  ? "bg-indigo-600 text-white hover:bg-indigo-500"
-                  : "bg-background/80 text-foreground hover:bg-background",
+                voteButtonClasses,
               )}
             >
               <ThumbsUp
                 className={cn(
                   "mr-1.5 h-3.5 w-3.5",
-                  proposal.userHasVoted ? "text-white" : "text-indigo-500",
+                  voteIconClass,
                 )}
               />
-              {proposal.userHasVoted ? "Apoyada" : "Apoyar idea"} · {proposal.votesCount}
+              {voteLabel} · {proposal.votesCount}
             </Button>
 
             <Button

--- a/components/improvement-proposals/proposal-comments-dialog.tsx
+++ b/components/improvement-proposals/proposal-comments-dialog.tsx
@@ -38,6 +38,17 @@ export function ProposalCommentsDialog({
   const [commentDraft, setCommentDraft] = useState("")
 
   const hasComments = comments.length > 0
+  const isIdea = proposal.tipo === "idea"
+  const dialogDescription = isIdea
+    ? "Comparte qué te inspira o cómo mejorarías esta idea."
+    : "Añade pistas que nos ayuden a reproducir y arreglar este error."
+  const commentPlaceholder = isIdea
+    ? "¿Qué te parece esta propuesta?"
+    : "Explica si te ocurre lo mismo o aporta más detalles."
+  const loadingLabel = isIdea ? "Leyendo ideas..." : "Leyendo reportes..."
+  const helperLabel = isIdea
+    ? "Las aportaciones ayudan a priorizar mejoras."
+    : "Cuantos más detalles compartamos, antes lo arreglaremos."
 
   const loadComments = useCallback(async () => {
     if (!open) return
@@ -134,10 +145,10 @@ export function ProposalCommentsDialog({
   const disableButton = submitting || commentDraft.trim().length === 0
 
   const commentCountLabel = useMemo(() => {
-    if (loading) return "Leyendo ideas..."
+    if (loading) return loadingLabel
     if (!hasComments) return "Todavía no hay comentarios"
     return `${comments.length} comentario${comments.length === 1 ? "" : "s"}`
-  }, [comments.length, hasComments, loading])
+  }, [comments.length, hasComments, loading, loadingLabel])
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -145,7 +156,7 @@ export function ProposalCommentsDialog({
         <DialogHeader className="space-y-2">
           <DialogTitle className="text-lg font-semibold">Conversación sobre “{proposal.titulo}”</DialogTitle>
           <DialogDescription className="text-sm text-muted-foreground">
-            Comparte qué te inspira o cómo mejorarías esta idea.
+            {dialogDescription}
           </DialogDescription>
         </DialogHeader>
 
@@ -157,11 +168,12 @@ export function ProposalCommentsDialog({
           <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
             Añadir comentario
           </label>
+          <p className="text-xs text-muted-foreground">{helperLabel}</p>
           <Textarea
             rows={4}
             value={commentDraft}
             onChange={(event) => setCommentDraft(event.target.value)}
-            placeholder="¿Qué te parece esta propuesta?"
+            placeholder={commentPlaceholder}
             className="min-h-[120px] resize-none rounded-xl border-border/60 bg-background/80"
           />
           <div className="flex justify-end">

--- a/components/improvement-proposals/proposals-board.tsx
+++ b/components/improvement-proposals/proposals-board.tsx
@@ -2,18 +2,23 @@
 
 import { useMemo } from "react"
 import { ProposalCard } from "./proposal-card"
-import { IMPROVEMENT_PROPOSAL_STATUS_CONFIG } from "./status-config"
+import {
+  IMPROVEMENT_PROPOSAL_STATUS_CONFIG,
+  IMPROVEMENT_PROPOSAL_BOARD_COPY,
+} from "./status-config"
 import {
   type ImprovementProposalWithAuthor,
   type ImprovementProposalStatus,
-  IMPROVEMENT_PROPOSAL_STATUSES,
+  type ImprovementProposalType,
+  IMPROVEMENT_PROPOSAL_STATUS_FLOW,
 } from "@/lib/types/improvement-proposals"
 import { cn } from "@/lib/utils"
 import { LoadingSpinner } from "@/components/ui/loading-spinner"
 import { EmptyState } from "@/components/ui/empty-state"
-import { Lightbulb } from "lucide-react"
+import { Lightbulb, Bug } from "lucide-react"
 
 interface ProposalsBoardProps {
+  type: ImprovementProposalType
   proposals: ImprovementProposalWithAuthor[]
   loading?: boolean
   refreshing?: boolean
@@ -27,6 +32,7 @@ interface ProposalsBoardProps {
 }
 
 export function ProposalsBoard({
+  type,
   proposals,
   loading = false,
   refreshing = false,
@@ -39,10 +45,12 @@ export function ProposalsBoard({
   onCommentAdded,
 }: ProposalsBoardProps) {
   const statusOrder = useMemo(() => {
-    return showCompleted
-      ? IMPROVEMENT_PROPOSAL_STATUSES
-      : IMPROVEMENT_PROPOSAL_STATUSES.filter((status) => status !== "hechisimo")
-  }, [showCompleted])
+    const flow = IMPROVEMENT_PROPOSAL_STATUS_FLOW[type]
+    if (type === "idea") {
+      return showCompleted ? flow : flow.filter((status) => status !== "hechisimo")
+    }
+    return flow
+  }, [showCompleted, type])
 
   const grouped = useMemo(() => {
     return statusOrder.map((status) => ({
@@ -51,15 +59,19 @@ export function ProposalsBoard({
     }))
   }, [proposals, statusOrder])
 
-  const hiddenCompleted = !showCompleted
-    ? proposals.filter((proposal) => proposal.estado === "hechisimo").length
-    : 0
+  const hiddenCompleted =
+    type === "idea" && !showCompleted
+      ? proposals.filter((proposal) => proposal.estado === "hechisimo").length
+      : 0
+
+  const copy = IMPROVEMENT_PROPOSAL_BOARD_COPY[type]
+  const emptyIcon = type === "idea" ? <Lightbulb className="h-6 w-6" /> : <Bug className="h-6 w-6" />
 
   if (loading && proposals.length === 0) {
     return (
       <div className="flex min-h-[280px] flex-col items-center justify-center gap-4 rounded-3xl border border-dashed border-border/60 bg-muted/10 p-10 text-muted-foreground">
         <LoadingSpinner />
-        <p>Cargando propuestas de mejora...</p>
+        <p>{copy.loading}</p>
       </div>
     )
   }
@@ -67,9 +79,9 @@ export function ProposalsBoard({
   if (proposals.length === 0) {
     return (
       <EmptyState
-        title="Aún no hay propuestas de mejora"
-        description="¡Danos ideas porfi!"
-        icon={<Lightbulb className="h-6 w-6" />}
+        title={copy.emptyTitle}
+        description={copy.emptyDescription}
+        icon={emptyIcon}
       />
     )
   }
@@ -78,7 +90,7 @@ export function ProposalsBoard({
     <div className="space-y-6">
       {refreshing && (
         <div className="flex items-center gap-2 text-sm text-muted-foreground">
-          <LoadingSpinner className="h-3.5 w-3.5" size="sm" /> Sincronizando ideas...
+          <LoadingSpinner className="h-3.5 w-3.5" size="sm" /> {copy.refreshing}
         </div>
       )}
 
@@ -117,7 +129,7 @@ export function ProposalsBoard({
                 <div className="space-y-4">
                   {columnProposals.length === 0 ? (
                     <div className="rounded-2xl border border-dashed border-border/60 bg-muted/10 p-5 text-center text-xs text-muted-foreground">
-                      Aún no hay ideas en esta fase.
+                      {copy.emptyColumn}
                     </div>
                   ) : (
                     columnProposals.map((proposal) => (

--- a/components/improvement-proposals/proposals-panel.tsx
+++ b/components/improvement-proposals/proposals-panel.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useMemo, useState } from "react"
-import { Sparkles, PartyPopper, EyeOff, Eye, RefreshCw } from "lucide-react"
+import { Sparkles, PartyPopper, EyeOff, Eye, RefreshCw, Bug } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
@@ -11,7 +11,10 @@ import { useImprovementProposals } from "@/hooks/use-improvement-proposals"
 import useIsAdmin from "@/hooks/use-is-admin"
 import { toast } from "sonner"
 import { cn } from "@/lib/utils"
-import type { ImprovementProposalStatus } from "@/lib/types/improvement-proposals"
+import type {
+  ImprovementProposalStatus,
+  ImprovementProposalType,
+} from "@/lib/types/improvement-proposals"
 
 export function ImprovementProposalsPanel() {
   const {
@@ -30,26 +33,42 @@ export function ImprovementProposalsPanel() {
   const isAdmin = useIsAdmin()
 
   const [dialogOpen, setDialogOpen] = useState(false)
+  const [dialogType, setDialogType] = useState<ImprovementProposalType>("idea")
   const [showCompleted, setShowCompleted] = useState(false)
   const [updatingId, setUpdatingId] = useState<string | null>(null)
   const [manualRefresh, setManualRefresh] = useState(false)
+  const ideaProposals = useMemo(
+    () => proposals.filter((proposal) => proposal.tipo === "idea"),
+    [proposals],
+  )
+  const errorProposals = useMemo(
+    () => proposals.filter((proposal) => proposal.tipo === "error"),
+    [proposals],
+  )
 
-  const stats = useMemo(() => {
-    const total = proposals.length
-    const celebrating = proposals.filter((proposal) => proposal.estado === "hechisimo").length
-    const active = proposals.filter((proposal) => proposal.estado !== "hechisimo").length
-    const fresh = proposals.filter((proposal) => proposal.estado === "nueva_idea").length
-
-    return { total, celebrating, active, fresh }
-  }, [proposals])
-
-  const handleCreateProposal = async (values: { title: string; description: string}) => {
+  const handleCreateProposal = async ({
+    title,
+    description,
+    type,
+  }: {
+    title: string
+    description: string
+    type: ImprovementProposalType
+  }) => {
     try {
-      await createProposal(values)
-      toast.success("¡Gracias por compartir tu idea! ✨")
+      await createProposal({ title, description, type })
+      toast.success(
+        type === "idea"
+          ? "¡Gracias por compartir tu idea! ✨"
+          : "Gracias por reportar el error 🛠️",
+      )
     } catch (err) {
       const message =
-        err instanceof Error ? err.message : "No pudimos guardar tu propuesta. Quizá es una buena propuesta que este sitema funcione, pero mira, no se puede tener todo."
+        err instanceof Error
+          ? err.message
+          : type === "idea"
+            ? "No pudimos guardar tu propuesta. Quizá es una buena propuesta que este sistema funcione, pero mira, no se puede tener todo."
+            : "No pudimos guardar el reporte del error. Seguiremos investigando igualmente."
       toast.error(message)
       throw err
     }
@@ -61,8 +80,13 @@ export function ImprovementProposalsPanel() {
       await updateProposalStatus(proposalId, status)
       toast.success(`Estado actualizado a ${statusLabels[status]}`)
     } catch (err) {
+      const target = proposals.find((proposal) => proposal.id === proposalId)
       const message =
-        err instanceof Error ? err.message : "No pudimos actualizar el estado de la idea. ¿Nos proponemos mejorarlo?"
+        err instanceof Error
+          ? err.message
+          : target?.tipo === "error"
+            ? "No pudimos actualizar el estado del error. Lo revisamos en un rato."
+            : "No pudimos actualizar el estado de la idea. ¿Nos proponemos mejorarlo?"
       toast.error(message)
       throw err
     } finally {
@@ -74,17 +98,24 @@ export function ImprovementProposalsPanel() {
     try {
       setManualRefresh(true)
       await refetch()
-      toast.success("Ideas actualizadas")
+      toast.success("Panel actualizado")
     } catch (err) {
       const message =
-        err instanceof Error ? err.message : "No pudimos actualizar la lista de ideas. Un fallito tontorrón..."
+        err instanceof Error
+          ? err.message
+          : "No pudimos actualizar la lista ahora mismo. Un fallito tontorrón..."
       toast.error(message)
     } finally {
       setManualRefresh(false)
     }
   }
 
-  const showCelebratedToggle = proposals.some((proposal) => proposal.estado === "hechisimo")
+  const showCelebratedToggle = ideaProposals.some((proposal) => proposal.estado === "hechisimo")
+
+  const handleOpenDialog = (type: ImprovementProposalType) => {
+    setDialogType(type)
+    setDialogOpen(true)
+  }
 
   return (
     <div className="space-y-8">
@@ -107,10 +138,20 @@ export function ImprovementProposalsPanel() {
               <Button
                 type="button"
                 size="lg"
-                onClick={() => setDialogOpen(true)}
+                onClick={() => handleOpenDialog("idea")}
                 className="rounded-full bg-white text-indigo-700 shadow-lg shadow-indigo-900/20 transition hover:bg-white/90"
               >
                 <PartyPopper className="mr-2 h-5 w-5" /> Compartir idea
+              </Button>
+
+              <Button
+                type="button"
+                size="lg"
+                variant="secondary"
+                onClick={() => handleOpenDialog("error")}
+                className="rounded-full border-white/30 bg-white/20 text-white hover:bg-white/30"
+              >
+                <Bug className="mr-2 h-5 w-5" /> Reportar error
               </Button>
 
               {showCelebratedToggle && (
@@ -151,6 +192,8 @@ export function ImprovementProposalsPanel() {
 
             <div className="flex flex-wrap items-center gap-3 text-sm text-white/80">
               {isAdmin && <Badge className="bg-white text-indigo-700 hover:bg-white">Control gestor central</Badge>}
+              <Badge className="bg-white/20 text-white">{ideaProposals.length} ideas</Badge>
+              <Badge className="bg-white/20 text-white">{errorProposals.length} errores</Badge>
             </div>
           </div>
 
@@ -166,7 +209,8 @@ export function ImprovementProposalsPanel() {
       )}
 
       <ProposalsBoard
-        proposals={proposals}
+        type="idea"
+        proposals={ideaProposals}
         loading={loading}
         refreshing={refreshing || manualRefresh}
         showCompleted={showCompleted}
@@ -178,9 +222,35 @@ export function ImprovementProposalsPanel() {
         onCommentAdded={registerComment}
       />
 
+      <section className="space-y-4">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-1">
+            <h2 className="text-xl font-semibold text-foreground">Errores reportados por la comunidad</h2>
+            <p className="text-sm text-muted-foreground">
+              Usa este tablero para seguir el avance de los fallos que ya estamos revisando.
+            </p>
+          </div>
+        </div>
+
+        <ProposalsBoard
+          type="error"
+          proposals={errorProposals}
+          loading={loading}
+          refreshing={refreshing || manualRefresh}
+          isAdmin={isAdmin}
+          updatingId={updatingId}
+          onStatusChange={isAdmin ? handleStatusChange : undefined}
+          onToggleVote={toggleVote}
+          votingId={votingId}
+          onCommentAdded={registerComment}
+        />
+      </section>
+
       <CreateProposalDialog
         open={dialogOpen}
         onOpenChange={setDialogOpen}
+        type={dialogType}
+        onTypeChange={setDialogType}
         onSubmit={handleCreateProposal}
       />
     </div>

--- a/components/improvement-proposals/status-config.ts
+++ b/components/improvement-proposals/status-config.ts
@@ -5,8 +5,14 @@ import {
   CalendarCheck,
   Hammer,
   Trophy,
+  Bug,
+  Wrench,
+  ShieldCheck,
 } from "lucide-react"
-import type { ImprovementProposalStatus } from "@/lib/types/improvement-proposals"
+import type {
+  ImprovementProposalStatus,
+  ImprovementProposalType,
+} from "@/lib/types/improvement-proposals"
 
 export interface ImprovementProposalStatusVisualConfig {
   label: string
@@ -70,5 +76,61 @@ export const IMPROVEMENT_PROPOSAL_STATUS_CONFIG: Record<
     headerBackground:
       "bg-gradient-to-br from-emerald-500/10 via-lime-500/10 to-transparent",
     icon: Trophy,
+  },
+  error_detectado: {
+    label: "Error detectado",
+    description: "Lo tenemos localizado y necesitamos más detalles",
+    accentGradient: "from-red-500 via-rose-500 to-orange-500",
+    badgeClassName:
+      "bg-red-100 text-red-700 border-red-200 dark:bg-red-500/20 dark:text-red-100 dark:border-red-500/40",
+    headerBackground:
+      "bg-gradient-to-br from-red-500/10 via-rose-500/10 to-transparent",
+    icon: Bug,
+  },
+  resolviendo: {
+    label: "Resolviendo",
+    description: "Estamos trabajando para arreglarlo",
+    accentGradient: "from-amber-500 via-orange-500 to-yellow-500",
+    badgeClassName:
+      "bg-amber-100 text-amber-700 border-amber-200 dark:bg-amber-500/20 dark:text-amber-100 dark:border-amber-500/40",
+    headerBackground:
+      "bg-gradient-to-br from-amber-500/10 via-orange-500/10 to-transparent",
+    icon: Wrench,
+  },
+  resuelto: {
+    label: "Resuelto",
+    description: "Arreglado y verificado",
+    accentGradient: "from-emerald-400 via-teal-400 to-green-500",
+    badgeClassName:
+      "bg-emerald-100 text-emerald-700 border-emerald-200 dark:bg-emerald-500/20 dark:text-emerald-100 dark:border-emerald-500/40",
+    headerBackground:
+      "bg-gradient-to-br from-emerald-500/10 via-teal-500/10 to-transparent",
+    icon: ShieldCheck,
+  },
+}
+
+export const IMPROVEMENT_PROPOSAL_BOARD_COPY: Record<
+  ImprovementProposalType,
+  {
+    loading: string
+    emptyTitle: string
+    emptyDescription: string
+    emptyColumn: string
+    refreshing: string
+  }
+> = {
+  idea: {
+    loading: "Cargando propuestas de mejora...",
+    emptyTitle: "Aún no hay propuestas de mejora",
+    emptyDescription: "¡Danos ideas porfi!",
+    emptyColumn: "Aún no hay ideas en esta fase.",
+    refreshing: "Sincronizando ideas...",
+  },
+  error: {
+    loading: "Cargando errores reportados...",
+    emptyTitle: "Sin errores registrados",
+    emptyDescription: "Si encuentras un fallo, avísanos para arreglarlo.",
+    emptyColumn: "Aún no hay errores en esta fase.",
+    refreshing: "Sincronizando reportes...",
   },
 }

--- a/hooks/use-improvement-proposals.ts
+++ b/hooks/use-improvement-proposals.ts
@@ -8,6 +8,7 @@ import type {
   ImprovementProposalInsert,
   ImprovementProposalStatus,
   ImprovementProposalWithAuthor,
+  ImprovementProposalType,
 } from "@/lib/types/improvement-proposals"
 import { IMPROVEMENT_PROPOSAL_STATUS_LABELS } from "@/lib/types/improvement-proposals"
 import { toast } from "sonner"
@@ -16,6 +17,7 @@ interface CreateImprovementProposalInput {
   title: string
   description: string
   impact?: string | null
+  type?: ImprovementProposalType
 }
 
 type ProposalQueryRow = ImprovementProposal & {
@@ -193,13 +195,16 @@ export function useImprovementProposals() {
   }, [currentUserId, enrichWithAuthor])
 
   const createProposal = useCallback(
-    async ({ title, description, impact }: CreateImprovementProposalInput) => {
+    async ({ title, description, impact, type = "idea" }: CreateImprovementProposalInput) => {
       const trimmedTitle = title.trim()
       const trimmedDescription = description.trim()
       const trimmedImpact = impact?.trim()
 
       if (!trimmedTitle) throw new Error("El título es obligatorio")
-      if (!trimmedDescription) throw new Error("Cuéntanos un poco sobre tu idea")
+      if (!trimmedDescription)
+        throw new Error(
+          type === "idea" ? "Cuéntanos un poco sobre tu idea" : "Cuéntanos qué está fallando",
+        )
 
       const {
         data: { user },
@@ -207,7 +212,7 @@ export function useImprovementProposals() {
       } = await supabase.auth.getUser()
 
       if (authError) throw authError
-      if (!user) throw new Error("Necesitas iniciar sesión para proponer una mejora")
+      if (!user) throw new Error("Necesitas iniciar sesión para participar")
 
       let authorName = user.email?.split("@")[0] || "Usuario"
 
@@ -226,11 +231,14 @@ export function useImprovementProposals() {
         console.warn("No pudimos obtener el perfil del usuario", profileError)
       }
 
+      const initialStatus = type === "idea" ? "nueva_idea" : "error_detectado"
+
       const payload: ImprovementProposalInsert = {
         titulo: trimmedTitle,
         descripcion: trimmedDescription,
         impacto: trimmedImpact || null,
-        estado: "nueva_idea",
+        estado: initialStatus,
+        tipo: type,
         creado_por: user.id,
         creado_por_nombre: authorName,
         creado_por_email: user.email ?? null,
@@ -301,13 +309,14 @@ export function useImprovementProposals() {
     async (proposalId: string) => {
       if (!proposalId) return
       if (!currentUserId) {
-        toast.error("Necesitas iniciar sesión para apoyar ideas")
+        toast.error("Necesitas iniciar sesión para participar")
         return
       }
 
       const target = proposalsRef.current.find((proposal) => proposal.id === proposalId)
       if (!target) return
 
+      const isIdea = target.tipo === "idea"
       setVotingId(proposalId)
 
       try {
@@ -331,7 +340,9 @@ export function useImprovementProposals() {
                 : proposal,
             ),
           )
-          toast.success("Has retirado tu apoyo")
+          toast.success(
+            isIdea ? "Has retirado tu apoyo" : "Has retirado tu confirmación",
+          )
         } else {
           const { error } = await supabase
             .from("propuesta_mejora_voto")
@@ -350,14 +361,16 @@ export function useImprovementProposals() {
                 : proposal,
             ),
           )
-          toast.success("¡Gracias por apoyar la idea!")
+          toast.success(
+            isIdea ? "¡Gracias por apoyar la idea!" : "Gracias por confirmar el error",
+          )
         }
       } catch (voteError) {
         console.error("Error toggling proposal vote", voteError)
         toast.error(
           voteError instanceof Error
             ? voteError.message
-            : "No pudimos actualizar tu voto. Inténtalo de nuevo.",
+            : "No pudimos actualizar tu participación. Inténtalo de nuevo.",
         )
       } finally {
         setVotingId(null)

--- a/lib/types/database.ts
+++ b/lib/types/database.ts
@@ -273,7 +273,16 @@ export type Database = {
           titulo: string
           descripcion: string
           impacto: string | null
-          estado: "nueva_idea" | "en_estudio" | "lo_haremos" | "en_desarrollo" | "hechisimo"
+          tipo: "idea" | "error"
+          estado:
+            | "nueva_idea"
+            | "en_estudio"
+            | "lo_haremos"
+            | "en_desarrollo"
+            | "hechisimo"
+            | "error_detectado"
+            | "resolviendo"
+            | "resuelto"
           creado_por: string
           creado_por_nombre: string | null
           creado_por_email: string | null
@@ -285,7 +294,16 @@ export type Database = {
           titulo: string
           descripcion: string
           impacto?: string | null
-          estado?: "nueva_idea" | "en_estudio" | "lo_haremos" | "en_desarrollo" | "hechisimo"
+          tipo?: "idea" | "error"
+          estado?:
+            | "nueva_idea"
+            | "en_estudio"
+            | "lo_haremos"
+            | "en_desarrollo"
+            | "hechisimo"
+            | "error_detectado"
+            | "resolviendo"
+            | "resuelto"
           creado_por: string
           creado_por_nombre?: string | null
           creado_por_email?: string | null
@@ -297,7 +315,16 @@ export type Database = {
           titulo?: string
           descripcion?: string
           impacto?: string | null
-          estado?: "nueva_idea" | "en_estudio" | "lo_haremos" | "en_desarrollo" | "hechisimo"
+          tipo?: "idea" | "error"
+          estado?:
+            | "nueva_idea"
+            | "en_estudio"
+            | "lo_haremos"
+            | "en_desarrollo"
+            | "hechisimo"
+            | "error_detectado"
+            | "resolviendo"
+            | "resuelto"
           creado_por?: string
           creado_por_nombre?: string | null
           creado_por_email?: string | null

--- a/lib/types/improvement-proposals.ts
+++ b/lib/types/improvement-proposals.ts
@@ -4,6 +4,7 @@ export type ImprovementProposal = Database["public"]["Tables"]["propuesta_mejora
 export type ImprovementProposalInsert = Database["public"]["Tables"]["propuesta_mejora"]["Insert"]
 export type ImprovementProposalUpdate = Database["public"]["Tables"]["propuesta_mejora"]["Update"]
 export type ImprovementProposalStatus = ImprovementProposal["estado"]
+export type ImprovementProposalType = ImprovementProposal["tipo"]
 
 export interface ImprovementProposalWithAuthor extends ImprovementProposal {
   authorName: string
@@ -22,18 +23,30 @@ export interface ImprovementProposalComment {
   creado_en: string
 }
 
-export const IMPROVEMENT_PROPOSAL_STATUSES: ImprovementProposalStatus[] = [
-  "nueva_idea",
-  "en_estudio",
-  "lo_haremos",
-  "en_desarrollo",
-  "hechisimo",
-]
-
 export const IMPROVEMENT_PROPOSAL_STATUS_LABELS: Record<ImprovementProposalStatus, string> = {
   nueva_idea: "Nueva idea",
   en_estudio: "En estudio",
   lo_haremos: "Lo haremos",
   en_desarrollo: "En desarrollo",
   hechisimo: "Hechísimo",
+  error_detectado: "Error detectado",
+  resolviendo: "Resolviendo",
+  resuelto: "Resuelto",
+}
+
+export const IMPROVEMENT_PROPOSAL_TYPES: ImprovementProposalType[] = ["idea", "error"]
+
+export const IMPROVEMENT_PROPOSAL_STATUS_FLOW: Record<ImprovementProposalType, ImprovementProposalStatus[]> = {
+  idea: ["nueva_idea", "en_estudio", "lo_haremos", "en_desarrollo", "hechisimo"],
+  error: ["error_detectado", "resolviendo", "resuelto"],
+}
+
+export const IMPROVEMENT_PROPOSAL_STATUSES: ImprovementProposalStatus[] = [
+  ...IMPROVEMENT_PROPOSAL_STATUS_FLOW.idea,
+  ...IMPROVEMENT_PROPOSAL_STATUS_FLOW.error,
+]
+
+export const IMPROVEMENT_PROPOSAL_TYPE_LABELS: Record<ImprovementProposalType, string> = {
+  idea: "Idea de mejora",
+  error: "Error detectado",
 }

--- a/scripts/008_create_propuesta_mejora_table.sql
+++ b/scripts/008_create_propuesta_mejora_table.sql
@@ -4,8 +4,20 @@ CREATE TABLE IF NOT EXISTS public.propuesta_mejora (
   titulo TEXT NOT NULL,
   descripcion TEXT NOT NULL,
   impacto TEXT,
+  tipo TEXT NOT NULL DEFAULT 'idea' CHECK (
+    tipo IN ('idea', 'error')
+  ),
   estado TEXT NOT NULL DEFAULT 'nueva_idea' CHECK (
-    estado IN ('nueva_idea', 'en_estudio', 'lo_haremos', 'en_desarrollo', 'hechisimo')
+    estado IN (
+      'nueva_idea',
+      'en_estudio',
+      'lo_haremos',
+      'en_desarrollo',
+      'hechisimo',
+      'error_detectado',
+      'resolviendo',
+      'resuelto'
+    )
   ),
   creado_por UUID NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
   creado_por_nombre TEXT,
@@ -14,8 +26,9 @@ CREATE TABLE IF NOT EXISTS public.propuesta_mejora (
   actualizado_en TIMESTAMPTZ
 );
 
-COMMENT ON TABLE public.propuesta_mejora IS 'Ideas y propuestas de mejora de la aplicación aportadas por la comunidad';
-COMMENT ON COLUMN public.propuesta_mejora.estado IS 'Workflow: nueva_idea, en_estudio, lo_haremos, en_desarrollo, hechisimo';
+COMMENT ON TABLE public.propuesta_mejora IS 'Ideas de mejora y errores detectados aportados por la comunidad';
+COMMENT ON COLUMN public.propuesta_mejora.tipo IS 'Clasificación de la propuesta: idea o error';
+COMMENT ON COLUMN public.propuesta_mejora.estado IS 'Workflow ideas: nueva_idea → en_estudio → lo_haremos → en_desarrollo → hechisimo; errores: error_detectado → resolviendo → resuelto';
 
 ALTER TABLE public.propuesta_mejora ENABLE ROW LEVEL SECURITY;
 
@@ -63,4 +76,5 @@ CREATE POLICY IF NOT EXISTS "Gestor central puede eliminar propuestas" ON public
   );
 
 CREATE INDEX IF NOT EXISTS propuesta_mejora_estado_idx ON public.propuesta_mejora (estado);
+CREATE INDEX IF NOT EXISTS propuesta_mejora_tipo_idx ON public.propuesta_mejora (tipo);
 CREATE INDEX IF NOT EXISTS propuesta_mejora_creado_en_idx ON public.propuesta_mejora (creado_en DESC);

--- a/scripts/035_update_propuesta_mejora_tipo_y_estados.sql
+++ b/scripts/035_update_propuesta_mejora_tipo_y_estados.sql
@@ -1,0 +1,43 @@
+-- Añade columna tipo y amplía el workflow para gestionar errores reportados
+ALTER TABLE public.propuesta_mejora
+  ADD COLUMN IF NOT EXISTS tipo TEXT;
+
+-- Aseguramos valores por defecto antes de aplicar restricciones nuevas
+UPDATE public.propuesta_mejora
+SET tipo = COALESCE(tipo, 'idea');
+
+ALTER TABLE public.propuesta_mejora
+  ALTER COLUMN tipo SET DEFAULT 'idea';
+
+ALTER TABLE public.propuesta_mejora
+  ALTER COLUMN tipo SET NOT NULL;
+
+ALTER TABLE public.propuesta_mejora
+  DROP CONSTRAINT IF EXISTS propuesta_mejora_tipo_check;
+
+ALTER TABLE public.propuesta_mejora
+  ADD CONSTRAINT propuesta_mejora_tipo_check
+  CHECK (tipo IN ('idea', 'error'));
+
+ALTER TABLE public.propuesta_mejora
+  DROP CONSTRAINT IF EXISTS propuesta_mejora_estado_check;
+
+ALTER TABLE public.propuesta_mejora
+  ADD CONSTRAINT propuesta_mejora_estado_check
+  CHECK (
+    estado IN (
+      'nueva_idea',
+      'en_estudio',
+      'lo_haremos',
+      'en_desarrollo',
+      'hechisimo',
+      'error_detectado',
+      'resolviendo',
+      'resuelto'
+    )
+  );
+
+COMMENT ON COLUMN public.propuesta_mejora.tipo IS 'Clasificación de la propuesta: idea o error';
+COMMENT ON COLUMN public.propuesta_mejora.estado IS 'Workflow ideas: nueva_idea → en_estudio → lo_haremos → en_desarrollo → hechisimo; errores: error_detectado → resolviendo → resuelto';
+
+CREATE INDEX IF NOT EXISTS propuesta_mejora_tipo_idx ON public.propuesta_mejora (tipo);


### PR DESCRIPTION
## Resumen
- Añadí soporte en la base de datos para clasificar cada propuesta como idea o error, ampliando el workflow con los estados de resolución de bugs.
- Actualicé el panel de propuestas para permitir compartir ideas o reportar errores, con dos tableros separados, selección de tipo en el diálogo y textos dinámicos.
- Ajusté tarjetas, comentarios y lógica de votos/estados para respetar los nuevos tipos y mensajes.

## Pruebas
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cc3cdcd5e48326a04fb8edda4c3af5