### PR TITLE
Refresca selector de categorías y unifica estilo

### DIFF
--- a/components/transactions/category-mega-selector.tsx
+++ b/components/transactions/category-mega-selector.tsx
@@ -45,10 +45,11 @@ export function CategoryMegaSelector({
     return () => cancelAnimationFrame(frame)
   }, [])
 
-  const { groups, orphans, parentLookup } = useMemo(() => {
+  const { groups, orphans, parentLookup, parentsWithoutChildren } = useMemo(() => {
     const parentCategories = categories.filter((cat) => !cat.categoria_padre_id)
     const childMap = new Map<string, Categoria[]>()
     const parentLookupMap = new Map<string, Categoria | undefined>()
+    const standaloneParents: Categoria[] = []
 
     categories.forEach((category) => {
       if (category.categoria_padre_id) {
@@ -71,6 +72,9 @@ export function CategoryMegaSelector({
         if (ordenA !== ordenB) return ordenA - ordenB
         return a.nombre.localeCompare(b.nombre)
       })
+      if (children.length === 0) {
+        standaloneParents.push(parent)
+      }
       children.forEach((child) => parentLookupMap.set(child.id, parent))
       parentLookupMap.set(parent.id, undefined)
       return {
@@ -98,7 +102,7 @@ export function CategoryMegaSelector({
       }
     })
 
-    return { groups, orphans, parentLookup: parentLookupMap }
+    return { groups, orphans, parentLookup: parentLookupMap, parentsWithoutChildren: standaloneParents }
   }, [categories])
 
   const normalizedSearch = searchValue.trim().toLowerCase()
@@ -243,19 +247,32 @@ export function CategoryMegaSelector({
               </div>
             ) : (
               <div className="space-y-5 pb-4">
-                {groups.map((group) => (
-                  <CategoryGroupSection
-                    key={group.parent.id}
-                    group={group}
-                    selectedCategoryId={selectedCategoryId}
-                    onSelect={handleSelect}
-                  />
-                ))}
+                {groups
+                  .filter((group) => group.children.length > 0)
+                  .map((group) => (
+                    <CategoryGroupSection
+                      key={group.parent.id}
+                      group={group}
+                      selectedCategoryId={selectedCategoryId}
+                      onSelect={handleSelect}
+                    />
+                  ))}
 
-                {orphans.length > 0 && (
+                {(parentsWithoutChildren.length > 0 || orphans.length > 0) && (
                   <div className="space-y-2">
-                    <p className="text-xs font-semibold text-muted-foreground uppercase">Otras categorías</p>
+                    <p className="text-xs font-semibold text-muted-foreground uppercase">
+                      Categorías sin subcategorías
+                    </p>
                     <div className="flex flex-wrap gap-2">
+                      {parentsWithoutChildren.map((category) => (
+                        <CategoryPill
+                          key={category.id}
+                          category={category}
+                          size="sm"
+                          isSelected={selectedCategoryId === category.id}
+                          onClick={() => handleSelect(category.id)}
+                        />
+                      ))}
                       {orphans.map((category) => (
                         <CategoryPill
                           key={category.id}
@@ -296,8 +313,9 @@ function CategoryResultRow({ category, parent, isSelected, onSelect }: CategoryR
       onClick={onSelect}
       style={style}
       className={cn(
-        "w-full rounded-3xl border border-transparent bg-[rgba(var(--category-color-rgb),0.06)] px-4 py-3 text-left transition hover:bg-[rgba(var(--category-color-rgb),0.12)]",
-        isSelected && "border-[rgba(var(--category-color-rgb),0.3)] ring-2 ring-offset-2 ring-[rgba(var(--category-color-rgb),0.45)]",
+        "w-full rounded-3xl border border-transparent bg-[rgba(var(--category-color-rgb),0.06)] px-4 py-3 text-left transition hover:bg-[rgba(var(--category-color-rgb),0.12)] dark:bg-[rgba(var(--category-color-rgb),0.2)] dark:hover:bg-[rgba(var(--category-color-rgb),0.32)]",
+        isSelected &&
+          "border-[rgba(var(--category-color-rgb),0.3)] ring-2 ring-offset-2 ring-offset-background ring-[rgba(var(--category-color-rgb),0.45)] dark:border-[rgba(var(--category-color-rgb),0.45)]",
       )}
     >
       <div className="flex flex-col gap-2">
@@ -329,7 +347,7 @@ function CategoryGroupSection({ group, selectedCategoryId, onSelect }: CategoryG
 
   return (
     <div
-      className="rounded-3xl border border-[rgba(var(--category-color-rgb),0.25)] bg-[rgba(var(--category-color-rgb),0.08)] p-4 shadow-sm transition hover:shadow-md"
+      className="rounded-3xl border border-[rgba(var(--category-color-rgb),0.18)] bg-[rgba(var(--category-color-rgb),0.08)] p-4 shadow-sm transition hover:shadow-md dark:border-[rgba(var(--category-color-rgb),0.32)] dark:bg-[rgba(var(--category-color-rgb),0.22)]"
       style={sectionStyle}
     >
       <div className="flex flex-wrap items-center justify-between gap-3">
@@ -339,11 +357,12 @@ function CategoryGroupSection({ group, selectedCategoryId, onSelect }: CategoryG
           onClick={() => onSelect(parent.id)}
           isSelected={isParentSelected}
           className={cn(
-            !isParentSelected && "bg-white/80 text-slate-900 hover:bg-white",
+            !isParentSelected &&
+              "border border-border/40 bg-card text-foreground hover:bg-muted dark:border-border/60 dark:bg-card dark:hover:bg-muted",
           )}
         />
         {children.length > 0 && (
-          <span className="text-xs font-medium text-[rgba(var(--category-color-rgb),0.9)] bg-white/70 px-2 py-1 rounded-full">
+          <span className="text-xs font-medium text-[color:var(--category-color)] dark:text-white bg-[rgba(var(--category-color-rgb),0.18)] dark:bg-[rgba(var(--category-color-rgb),0.35)] px-2 py-1 rounded-full shadow-sm">
             {children.length} subcategoría{children.length !== 1 ? "s" : ""}
           </span>
         )}

--- a/components/transactions/category-mega-selector.tsx
+++ b/components/transactions/category-mega-selector.tsx
@@ -3,13 +3,13 @@
 import { useMemo, useState, useEffect, useRef, type CSSProperties } from "react"
 import { X, Search, Plus } from "lucide-react"
 import { Input } from "@/components/ui/input"
-import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { BankAvatar } from "@/components/bank-avatar"
 import { formatCurrency } from "@/lib/utils/format"
 import { getCategoryColorTokens } from "@/lib/utils/category-colors"
 import type { Categoria, Movimiento, Cuenta } from "@/lib/types/database"
 import { cn } from "@/lib/utils"
+import { CategoryPill } from "./category-pill"
 
 interface CategoryMegaSelectorProps {
   categories: Categoria[]
@@ -285,22 +285,28 @@ interface CategoryResultRowProps {
 }
 
 function CategoryResultRow({ category, parent, isSelected, onSelect }: CategoryResultRowProps) {
+  const { rgbValue } = getCategoryColorTokens(parent ?? category)
+  const style: CSSProperties = {
+    ["--category-color-rgb" as string]: rgbValue,
+  }
+
   return (
     <button
       type="button"
       onClick={onSelect}
+      style={style}
       className={cn(
-        "w-full rounded-2xl border border-transparent bg-muted/30 px-4 py-3 text-left transition hover:bg-muted",
-        isSelected && "border-primary bg-primary/5",
+        "w-full rounded-3xl border border-transparent bg-[rgba(var(--category-color-rgb),0.06)] px-4 py-3 text-left transition hover:bg-[rgba(var(--category-color-rgb),0.12)]",
+        isSelected && "border-[rgba(var(--category-color-rgb),0.3)] ring-2 ring-offset-2 ring-[rgba(var(--category-color-rgb),0.45)]",
       )}
     >
-      <div className="flex items-center justify-between gap-4">
-        <div className="flex items-center gap-3">
-          <CategoryPill category={category} size={category.categoria_padre_id ? "xs" : "md"} />
-          {parent && (
-            <span className="text-xs text-muted-foreground">{parent.nombre}</span>
-          )}
-        </div>
+      <div className="flex flex-col gap-2">
+        <CategoryPill category={category} size={category.categoria_padre_id ? "sm" : "md"} isSelected={isSelected} />
+        {parent && (
+          <div className="text-xs text-muted-foreground">
+            Pertenece a <span className="font-medium text-foreground/80">{parent.nombre}</span>
+          </div>
+        )}
       </div>
     </button>
   )
@@ -314,24 +320,36 @@ interface CategoryGroupSectionProps {
 
 function CategoryGroupSection({ group, selectedCategoryId, onSelect }: CategoryGroupSectionProps) {
   const { parent, children } = group
+  const { color, rgbValue } = getCategoryColorTokens(parent)
+  const sectionStyle: CSSProperties = {
+    ["--category-color" as string]: color,
+    ["--category-color-rgb" as string]: rgbValue,
+  }
+  const isParentSelected = selectedCategoryId === parent.id
 
   return (
-    <div className="space-y-3">
-      <div className="flex items-center gap-3">
+    <div
+      className="rounded-3xl border border-[rgba(var(--category-color-rgb),0.25)] bg-[rgba(var(--category-color-rgb),0.08)] p-4 shadow-sm transition hover:shadow-md"
+      style={sectionStyle}
+    >
+      <div className="flex flex-wrap items-center justify-between gap-3">
         <CategoryPill
           category={parent}
           size="lg"
           onClick={() => onSelect(parent.id)}
-          isSelected={selectedCategoryId === parent.id}
+          isSelected={isParentSelected}
+          className={cn(
+            !isParentSelected && "bg-white/80 text-slate-900 hover:bg-white",
+          )}
         />
         {children.length > 0 && (
-          <span className="text-xs text-muted-foreground">
+          <span className="text-xs font-medium text-[rgba(var(--category-color-rgb),0.9)] bg-white/70 px-2 py-1 rounded-full">
             {children.length} subcategoría{children.length !== 1 ? "s" : ""}
           </span>
         )}
       </div>
       {children.length > 0 && (
-        <div className="flex flex-wrap gap-2 pl-6 sm:pl-12">
+        <div className="mt-3 flex flex-wrap gap-2">
           {children.map((child) => (
             <CategoryPill
               key={child.id}
@@ -344,47 +362,5 @@ function CategoryGroupSection({ group, selectedCategoryId, onSelect }: CategoryG
         </div>
       )}
     </div>
-  )
-}
-
-interface CategoryPillProps {
-  category: Categoria
-  size?: "xs" | "sm" | "md" | "lg"
-  isSelected?: boolean
-  onClick?: () => void
-}
-
-function CategoryPill({ category, size = "md", isSelected = false, onClick }: CategoryPillProps) {
-  const { color, textColor, rgbValue } = getCategoryColorTokens(category)
-  const badgeStyles: CSSProperties = {
-    ["--category-color" as string]: color,
-    ["--category-text-color" as string]: textColor,
-    ["--category-color-rgb" as string]: rgbValue,
-  }
-
-  const sizeClasses =
-    size === "lg"
-      ? "text-sm px-4 py-2"
-      : size === "sm"
-        ? "text-xs px-3 py-1.5"
-        : size === "xs"
-          ? "text-xs px-2.5 py-1"
-          : "text-xs px-3.5 py-1.5"
-
-  return (
-    <Badge
-      variant="outline"
-      onClick={onClick}
-      className={cn(
-        "inline-flex items-center gap-2 rounded-full border border-transparent shadow-sm transition-all duration-200 bg-[var(--category-color)] text-[var(--category-text-color)] hover:shadow-md cursor-pointer",
-        isSelected && "ring-2 ring-offset-2 ring-primary",
-        sizeClasses,
-        category.categoria_padre_id && size !== "lg" && "bg-[var(--category-color)]/90",
-      )}
-      style={badgeStyles}
-    >
-      {category.emoji && <span className="text-sm leading-none">{category.emoji}</span>}
-      <span className="font-medium leading-none">{category.nombre}</span>
-    </Badge>
   )
 }

--- a/components/transactions/category-pill.tsx
+++ b/components/transactions/category-pill.tsx
@@ -35,12 +35,12 @@ export function CategoryPill({
 
   const baseClasses = cn(
     "inline-flex items-center gap-2 rounded-full border transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
-    "bg-[rgba(var(--category-color-rgb),0.1)] text-slate-900 dark:text-slate-100",
+    "bg-[rgba(var(--category-color-rgb),0.1)] text-slate-900 dark:text-slate-100 dark:bg-[rgba(var(--category-color-rgb),0.28)]",
     category.categoria_padre_id
-      ? "border-[rgba(var(--category-color-rgb),0.25)] text-[color:var(--category-color)] hover:bg-[rgba(var(--category-color-rgb),0.18)]"
-      : "border-[rgba(var(--category-color-rgb),0.35)] hover:bg-[rgba(var(--category-color-rgb),0.16)]",
+      ? "border-[rgba(var(--category-color-rgb),0.25)] text-[color:var(--category-color)] hover:bg-[rgba(var(--category-color-rgb),0.18)] dark:border-[rgba(var(--category-color-rgb),0.35)] dark:text-[color:var(--category-color)] dark:hover:bg-[rgba(var(--category-color-rgb),0.36)]"
+      : "border-[rgba(var(--category-color-rgb),0.35)] hover:bg-[rgba(var(--category-color-rgb),0.16)] dark:border-[rgba(var(--category-color-rgb),0.45)] dark:hover:bg-[rgba(var(--category-color-rgb),0.32)]",
     isSelected &&
-      "ring-2 ring-offset-2 ring-[color:var(--category-color)] ring-offset-background border-[rgba(var(--category-color-rgb),0.45)] bg-[rgba(var(--category-color-rgb),0.2)]",
+      "ring-2 ring-offset-2 ring-[color:var(--category-color)] ring-offset-background border-[rgba(var(--category-color-rgb),0.45)] bg-[rgba(var(--category-color-rgb),0.2)] dark:bg-[rgba(var(--category-color-rgb),0.4)]",
     {
       lg: "text-sm px-4 py-2.5",
       md: "text-sm px-3.5 py-2",

--- a/components/transactions/category-pill.tsx
+++ b/components/transactions/category-pill.tsx
@@ -1,0 +1,85 @@
+"use client"
+
+import type { CSSProperties, ReactNode } from "react"
+
+import { cn } from "@/lib/utils"
+import { getCategoryColorTokens } from "@/lib/utils/category-colors"
+import type { Categoria } from "@/lib/types/database"
+
+interface CategoryPillProps {
+  category: Categoria
+  size?: "xs" | "sm" | "md" | "lg"
+  isSelected?: boolean
+  onClick?: () => void
+  className?: string
+  prefix?: ReactNode
+  suffix?: ReactNode
+}
+
+export function CategoryPill({
+  category,
+  size = "md",
+  isSelected = false,
+  onClick,
+  className,
+  prefix,
+  suffix,
+}: CategoryPillProps) {
+  const { color, textColor, rgbValue } = getCategoryColorTokens(category)
+
+  const style: CSSProperties = {
+    ["--category-color" as string]: color,
+    ["--category-text-color" as string]: textColor,
+    ["--category-color-rgb" as string]: rgbValue,
+  }
+
+  const baseClasses = cn(
+    "inline-flex items-center gap-2 rounded-full border transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
+    "bg-[rgba(var(--category-color-rgb),0.1)] text-slate-900 dark:text-slate-100",
+    category.categoria_padre_id
+      ? "border-[rgba(var(--category-color-rgb),0.25)] text-[color:var(--category-color)] hover:bg-[rgba(var(--category-color-rgb),0.18)]"
+      : "border-[rgba(var(--category-color-rgb),0.35)] hover:bg-[rgba(var(--category-color-rgb),0.16)]",
+    isSelected &&
+      "ring-2 ring-offset-2 ring-[color:var(--category-color)] ring-offset-background border-[rgba(var(--category-color-rgb),0.45)] bg-[rgba(var(--category-color-rgb),0.2)]",
+    {
+      lg: "text-sm px-4 py-2.5",
+      md: "text-sm px-3.5 py-2",
+      sm: "text-xs px-3 py-1.5",
+      xs: "text-xs px-2.5 py-1",
+    }[size],
+    onClick ? "cursor-pointer" : "cursor-default",
+    className,
+  )
+
+  const content = (
+    <>
+      {prefix}
+      {category.emoji && (
+        <span
+          className={cn(
+            "leading-none",
+            size === "xs" ? "text-sm" : size === "lg" ? "text-xl" : "text-lg",
+          )}
+        >
+          {category.emoji}
+        </span>
+      )}
+      <span className="font-medium leading-none truncate">{category.nombre}</span>
+      {suffix}
+    </>
+  )
+
+  if (onClick) {
+    return (
+      <button type="button" style={style} onClick={onClick} className={baseClasses}>
+        {content}
+      </button>
+    )
+  }
+
+  return (
+    <span style={style} className={baseClasses}>
+      {content}
+    </span>
+  )
+}

--- a/components/transactions/category-selector.tsx
+++ b/components/transactions/category-selector.tsx
@@ -2,15 +2,14 @@
 
 import type React from "react"
 
-import { useState, useMemo, useEffect, useRef, type CSSProperties } from "react"
+import { useState, useMemo, useEffect, useRef } from "react"
 import { Check, ChevronsUpDown, X, Search, Plus } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
-import { Badge } from "@/components/ui/badge"
 import { ScrollArea } from "@/components/ui/scroll-area"
-import { getCategoryColorTokens } from "@/lib/utils/category-colors"
 import type { Categoria } from "@/lib/types/database"
+import { CategoryPill } from "./category-pill"
 
 interface CategorySelectorProps {
   categories: Categoria[]
@@ -160,34 +159,21 @@ export function CategorySelector({
               ) : (
                 <div className="space-y-1">
                   {filteredCategories.map((category) => {
-                    const { color, textColor, rgbValue } = getCategoryColorTokens(category)
-                    const badgeStyles: CSSProperties = {
-                      ["--category-color" as string]: color,
-                      ["--category-text-color" as string]: textColor,
-                      ["--category-color-rgb" as string]: rgbValue,
-                    }
-
+                    const isSelected = selectedCategories.includes(category.id)
                     return (
-                      <div
-                        key={category.id}
-                        className="flex items-center gap-2 p-2 hover:bg-muted/50 rounded cursor-pointer"
-                        onClick={() => handleSelect(category.id)}
-                      >
-                        <Badge
-                          variant="outline"
-                          className="inline-flex items-center gap-2 rounded-full px-3 py-1.5 text-xs font-medium border border-transparent shadow-sm bg-[var(--category-color)] text-[var(--category-text-color)] transition-all duration-200 dark:bg-transparent dark:text-foreground dark:border-[var(--category-color)] dark:shadow-none"
-                          style={badgeStyles}
-                        >
-                          <span
-                            aria-hidden
-                            className="hidden h-2.5 w-2.5 shrink-0 rounded-full bg-[var(--category-color)] dark:inline-flex"
-                          />
-                          {category.emoji && <span className="text-xs">{category.emoji}</span>}
-                          <span className="text-xs font-medium leading-none">{category.nombre}</span>
-                        </Badge>
-                        <div className="ml-auto">
-                          {selectedCategories.includes(category.id) && <Check className="h-4 w-4 text-primary" />}
-                        </div>
+                      <div key={category.id} className="p-2">
+                        <CategoryPill
+                          category={category}
+                          size={category.categoria_padre_id ? "sm" : "md"}
+                          isSelected={isSelected}
+                          onClick={() => handleSelect(category.id)}
+                          className="flex w-full justify-between"
+                          suffix={
+                            isSelected ? (
+                              <Check className="h-4 w-4 text-[rgba(var(--category-color-rgb),0.95)]" />
+                            ) : undefined
+                          }
+                        />
                       </div>
                     )
                   })}
@@ -222,39 +208,24 @@ export function CategorySelector({
             </Button>
           </div>
           <div className="flex flex-wrap gap-2">
-            {selectedCategoryObjects.map((category) => {
-              const { color, textColor, rgbValue } = getCategoryColorTokens(category)
-              const badgeStyles: CSSProperties = {
-                ["--category-color" as string]: color,
-                ["--category-text-color" as string]: textColor,
-                ["--category-color-rgb" as string]: rgbValue,
-              }
-
-              return (
-                <Badge
-                  key={category.id}
-                  variant="outline"
-                  className="inline-flex items-center gap-2 rounded-full px-3 py-1.5 text-xs font-medium border border-transparent shadow-sm bg-[var(--category-color)] text-[var(--category-text-color)] dark:bg-transparent dark:text-foreground dark:border-[var(--category-color)] dark:shadow-none"
-                  style={badgeStyles}
-                >
-                  <span
-                    aria-hidden
-                    className="hidden h-2.5 w-2.5 shrink-0 rounded-full bg-[var(--category-color)] dark:inline-flex"
-                  />
-                  {category.emoji && <span className="text-xs">{category.emoji}</span>}
-                  <span className="text-xs font-medium leading-none">{category.nombre}</span>
-                  <Button
-                    variant="ghost"
-                    size="sm"
+            {selectedCategoryObjects.map((category) => (
+              <CategoryPill
+                key={category.id}
+                category={category}
+                size="sm"
+                className="gap-1"
+                suffix={
+                  <button
                     type="button"
-                    onClick={(e) => removeCategory(category.id, e)}
-                    className="h-auto p-0 ml-1 rounded-full text-muted-foreground hover:text-red-500 hover:bg-red-100/60 dark:hover:bg-red-950/20"
+                    className="ml-1 rounded-full p-0.5 text-[rgba(var(--category-color-rgb),0.85)] hover:bg-[rgba(var(--category-color-rgb),0.15)]"
+                    onClick={(event) => removeCategory(category.id, event)}
+                    aria-label={`Quitar ${category.nombre}`}
                   >
                     <X className="h-3 w-3" />
-                  </Button>
-                </Badge>
-              )
-            })}
+                  </button>
+                }
+              />
+            ))}
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- añade el componente reutilizable `CategoryPill` para renderizar chips de categorías con colores heredados
- actualiza el selector masivo de transacciones para mostrar grupos con tarjetas y subcategorías en chips legibles
- reutiliza los nuevos estilos dentro del selector emergente para transacciones y paneles del dashboard

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ce7067b87083269b8dfe411c050367