### PR TITLE
Mejora visual del selector de categorías

### DIFF
--- a/components/dashboard/activity-balance.tsx
+++ b/components/dashboard/activity-balance.tsx
@@ -261,22 +261,6 @@ export function ActivityBalanceDashboard({ from, to }: Props) {
               allowMultiple
               placeholder="Seleccionar categorías..."
             />
-            {categoryIds.length > 0 && (
-              <div className="mt-4 flex flex-wrap gap-2">
-                {categoryIds.map((id) => {
-                  const categoria = categorias.find((c) => c.id === id)
-                  return (
-                    <div key={id} className="flex items-center gap-1 bg-secondary px-2 py-1 rounded-md text-sm">
-                      {categoria?.emoji && <span>{categoria.emoji}</span>}
-                      {categoria?.nombre || "Sin categoría"}
-                    </div>
-                  )
-                })}
-                <Button variant="outline" size="sm" onClick={clearFilters}>
-                  Limpiar
-                </Button>
-              </div>
-            )}
           </CardContent>
         </Card>
       </div>

--- a/components/transactions/category-selector.tsx
+++ b/components/transactions/category-selector.tsx
@@ -7,10 +7,40 @@ import { Check, ChevronsUpDown, X, Search, Plus } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
-import { Badge } from "@/components/ui/badge"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { getCategoryColorTokens } from "@/lib/utils/category-colors"
+import { cn } from "@/lib/utils"
 import type { Categoria } from "@/lib/types/database"
+
+interface CategoryGroup {
+  parent: Categoria
+  children: Categoria[]
+}
+
+type CategoriaWithOptionalOrder = Categoria & {
+  orden_efectivo?: number | null
+}
+
+function getCategoryOrderValue(category: CategoriaWithOptionalOrder) {
+  if (typeof category.orden_efectivo === "number") {
+    return category.orden_efectivo
+  }
+
+  return category.orden
+}
+
+function sortCategoriesByOrder(categories: Categoria[]) {
+  return [...categories].sort((a, b) => {
+    const orderA = getCategoryOrderValue(a as CategoriaWithOptionalOrder)
+    const orderB = getCategoryOrderValue(b as CategoriaWithOptionalOrder)
+
+    if (orderA !== orderB) {
+      return orderA - orderB
+    }
+
+    return a.nombre.localeCompare(b.nombre)
+  })
+}
 
 interface CategorySelectorProps {
   categories: Categoria[]
@@ -40,6 +70,52 @@ export function CategorySelector({
   const [internalOpen, setInternalOpen] = useState(defaultOpen)
   const [searchValue, setSearchValue] = useState("")
   const searchInputRef = useRef<HTMLInputElement>(null)
+  const normalizedSearch = searchValue.trim().toLowerCase()
+
+  const { groups, orphans, parentLookup } = useMemo(() => {
+    const parentCategories = categories.filter((cat) => !cat.categoria_padre_id)
+    const childMap = new Map<string, Categoria[]>()
+    const parentLookupMap = new Map<string, Categoria | undefined>()
+
+    categories.forEach((category) => {
+      if (!category.categoria_padre_id) {
+        return
+      }
+
+      const children = childMap.get(category.categoria_padre_id) ?? []
+      children.push(category)
+      childMap.set(category.categoria_padre_id, children)
+    })
+
+    const sortedParents = sortCategoriesByOrder(parentCategories)
+    const groups: CategoryGroup[] = sortedParents.map((parent) => {
+      const children = sortCategoriesByOrder(childMap.get(parent.id) ?? [])
+      children.forEach((child) => parentLookupMap.set(child.id, parent))
+      parentLookupMap.set(parent.id, undefined)
+      return {
+        parent,
+        children,
+      }
+    })
+
+    const parentIds = new Set(parentCategories.map((cat) => cat.id))
+    const orphans = sortCategoriesByOrder(
+      categories.filter((cat) => cat.categoria_padre_id && !parentIds.has(cat.categoria_padre_id)),
+    )
+
+    orphans.forEach((orphan) => {
+      if (!orphan.categoria_padre_id) {
+        return
+      }
+
+      const parent = categories.find((cat) => cat.id === orphan.categoria_padre_id)
+      if (parent) {
+        parentLookupMap.set(orphan.id, parent)
+      }
+    })
+
+    return { groups, orphans, parentLookup: parentLookupMap }
+  }, [categories])
 
   const isControlled = openProp !== undefined
   const open = isControlled ? openProp : internalOpen
@@ -69,17 +145,26 @@ export function CategorySelector({
   }, [open, focusSearchOnOpen])
 
   const filteredCategories = useMemo(() => {
-    if (!searchValue) return categories
-    return categories.filter(
-      (category) =>
-        category.nombre.toLowerCase().includes(searchValue.toLowerCase()) ||
-        (category.emoji && category.emoji.includes(searchValue)),
+    if (!normalizedSearch) {
+      return []
+    }
+
+    const emojiSearch = searchValue.trim()
+
+    return sortCategoriesByOrder(
+      categories.filter(
+        (category) =>
+          category.nombre.toLowerCase().includes(normalizedSearch) ||
+          (emojiSearch && category.emoji && category.emoji.includes(emojiSearch)),
+      ),
     )
-  }, [categories, searchValue])
+  }, [categories, normalizedSearch, searchValue])
 
   const selectedCategoryObjects = useMemo(() => {
     return categories.filter((cat) => selectedCategories.includes(cat.id))
   }, [categories, selectedCategories])
+
+  const selectedCategorySet = useMemo(() => new Set(selectedCategories), [selectedCategories])
 
   const handleSelect = (categoryId: string) => {
     if (allowMultiple) {
@@ -129,10 +214,10 @@ export function CategorySelector({
             <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
           </Button>
         </PopoverTrigger>
-        <PopoverContent className="w-[320px] p-0" align="start">
-          <div className="p-3 border-b">
+        <PopoverContent className="w-[360px] p-0" align="start">
+          <div className="border-b p-3">
             <div className="relative">
-              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 transform text-muted-foreground" />
               <Input
                 placeholder="Buscar categorías..."
                 value={searchValue}
@@ -146,58 +231,75 @@ export function CategorySelector({
                     }
                   }
                 }}
-                className="pl-9 bg-background h-8"
+                className="h-9 bg-background pl-9"
                 ref={searchInputRef}
               />
             </div>
           </div>
-          <ScrollArea className="h-[280px]">
-            <div className="p-2">
-              {filteredCategories.length === 0 ? (
-                <div className="text-center py-6 text-muted-foreground">
-                  <p className="text-sm">No se encontraron categorías</p>
+          <ScrollArea className="max-h-[320px]">
+            <div className="space-y-3 p-3">
+              {normalizedSearch ? (
+                filteredCategories.length === 0 ? (
+                  <div className="py-8 text-center text-muted-foreground">
+                    <p className="text-sm">No se encontraron categorías</p>
+                  </div>
+                ) : (
+                  filteredCategories.map((category) => (
+                    <CategorySearchResult
+                      key={category.id}
+                      category={category}
+                      parent={parentLookup.get(category.id)}
+                      isSelected={selectedCategorySet.has(category.id)}
+                      onSelect={() => handleSelect(category.id)}
+                    />
+                  ))
+                )
+              ) : groups.length === 0 && orphans.length === 0 ? (
+                <div className="py-8 text-center text-muted-foreground">
+                  <p className="text-sm">No hay categorías disponibles</p>
                 </div>
               ) : (
-                <div className="space-y-1">
-                  {filteredCategories.map((category) => {
-                    const { color, textColor, rgbValue } = getCategoryColorTokens(category)
-                    const badgeStyles: CSSProperties = {
-                      ["--category-color" as string]: color,
-                      ["--category-text-color" as string]: textColor,
-                      ["--category-color-rgb" as string]: rgbValue,
-                    }
+                <>
+                  {groups.map((group) => (
+                    <CategoryGroupCard
+                      key={group.parent.id}
+                      group={group}
+                      onSelectParent={() => handleSelect(group.parent.id)}
+                      onSelectChild={(categoryId) => handleSelect(categoryId)}
+                      selectedCategorySet={selectedCategorySet}
+                    />
+                  ))}
 
-                    return (
-                      <div
-                        key={category.id}
-                        className="flex items-center gap-2 p-2 hover:bg-muted/50 rounded cursor-pointer"
-                        onClick={() => handleSelect(category.id)}
-                      >
-                        <Badge
-                          variant="outline"
-                          className="inline-flex items-center gap-2 rounded-full px-3 py-1.5 text-xs font-medium border border-transparent shadow-sm bg-[var(--category-color)] text-[var(--category-text-color)] transition-all duration-200 dark:bg-transparent dark:text-foreground dark:border-[var(--category-color)] dark:shadow-none"
-                          style={badgeStyles}
-                        >
-                          <span
-                            aria-hidden
-                            className="hidden h-2.5 w-2.5 shrink-0 rounded-full bg-[var(--category-color)] dark:inline-flex"
-                          />
-                          {category.emoji && <span className="text-xs">{category.emoji}</span>}
-                          <span className="text-xs font-medium leading-none">{category.nombre}</span>
-                        </Badge>
-                        <div className="ml-auto">
-                          {selectedCategories.includes(category.id) && <Check className="h-4 w-4 text-primary" />}
-                        </div>
+                  {orphans.length > 0 && (
+                    <div className="space-y-2">
+                      <p className="px-1 text-xs font-semibold uppercase text-muted-foreground">
+                        Subcategorías sin grupo
+                      </p>
+                      <div className="flex flex-wrap gap-2">
+                        {orphans.map((category) => {
+                          const parent = parentLookup.get(category.id)
+                          const colorSource = parent ?? category
+
+                          return (
+                            <CategoryChipButton
+                              key={category.id}
+                              category={category}
+                              colorSource={colorSource}
+                              selected={selectedCategorySet.has(category.id)}
+                              onSelect={() => handleSelect(category.id)}
+                            />
+                          )
+                        })}
                       </div>
-                    )
-                  })}
-                </div>
+                    </div>
+                  )}
+                </>
               )}
             </div>
           </ScrollArea>
-          <div className="p-3 border-t">
-            <Button variant="outline" size="sm" className="w-full bg-transparent h-8" type="button">
-              <Plus className="h-4 w-4 mr-2" />
+          <div className="border-t p-3">
+            <Button variant="outline" size="sm" className="h-9 w-full bg-transparent" type="button">
+              <Plus className="mr-2 h-4 w-4" />
               Crear nueva categoría
             </Button>
           </div>
@@ -223,41 +325,216 @@ export function CategorySelector({
           </div>
           <div className="flex flex-wrap gap-2">
             {selectedCategoryObjects.map((category) => {
-              const { color, textColor, rgbValue } = getCategoryColorTokens(category)
-              const badgeStyles: CSSProperties = {
-                ["--category-color" as string]: color,
-                ["--category-text-color" as string]: textColor,
-                ["--category-color-rgb" as string]: rgbValue,
-              }
+              const parent = parentLookup.get(category.id)
+              const colorSource = parent ?? category
 
               return (
-                <Badge
+                <SelectedCategoryBadge
                   key={category.id}
-                  variant="outline"
-                  className="inline-flex items-center gap-2 rounded-full px-3 py-1.5 text-xs font-medium border border-transparent shadow-sm bg-[var(--category-color)] text-[var(--category-text-color)] dark:bg-transparent dark:text-foreground dark:border-[var(--category-color)] dark:shadow-none"
-                  style={badgeStyles}
-                >
-                  <span
-                    aria-hidden
-                    className="hidden h-2.5 w-2.5 shrink-0 rounded-full bg-[var(--category-color)] dark:inline-flex"
-                  />
-                  {category.emoji && <span className="text-xs">{category.emoji}</span>}
-                  <span className="text-xs font-medium leading-none">{category.nombre}</span>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    type="button"
-                    onClick={(e) => removeCategory(category.id, e)}
-                    className="h-auto p-0 ml-1 rounded-full text-muted-foreground hover:text-red-500 hover:bg-red-100/60 dark:hover:bg-red-950/20"
-                  >
-                    <X className="h-3 w-3" />
-                  </Button>
-                </Badge>
+                  category={category}
+                  colorSource={colorSource}
+                  onRemove={(event) => removeCategory(category.id, event)}
+                />
               )
             })}
           </div>
         </div>
       )}
     </div>
+  )
+}
+
+interface CategoryGroupCardProps {
+  group: CategoryGroup
+  onSelectParent: () => void
+  onSelectChild: (categoryId: string) => void
+  selectedCategorySet: Set<string>
+}
+
+function CategoryGroupCard({ group, onSelectParent, onSelectChild, selectedCategorySet }: CategoryGroupCardProps) {
+  const { parent, children } = group
+  const { color, textColor, rgbValue } = getCategoryColorTokens(parent)
+  const style: CSSProperties = {
+    ["--category-color" as string]: color,
+    ["--category-text-color" as string]: textColor,
+    ["--category-color-rgb" as string]: rgbValue,
+  }
+
+  const isParentSelected = selectedCategorySet.has(parent.id)
+  const hasChildSelected = children.some((child) => selectedCategorySet.has(child.id))
+  const isActive = isParentSelected || hasChildSelected
+
+  return (
+    <div
+      className={cn(
+        "rounded-2xl border border-border/60 bg-[rgba(var(--category-color-rgb),0.08)] p-3 transition-all duration-200",
+        "hover:border-[var(--category-color)] hover:bg-[rgba(var(--category-color-rgb),0.12)] hover:shadow-[0_12px_30px_-18px_rgba(var(--category-color-rgb),0.6)]",
+        isActive &&
+          "border-[var(--category-color)] bg-[rgba(var(--category-color-rgb),0.16)] shadow-[0_16px_40px_-24px_rgba(var(--category-color-rgb),0.7)]",
+      )}
+      style={style}
+    >
+      <button
+        type="button"
+        onClick={onSelectParent}
+        className="flex w-full items-center justify-between gap-3 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(var(--category-color-rgb),0.45)] focus-visible:ring-offset-2"
+      >
+        <div className="flex items-center gap-3">
+          <div
+            className={cn(
+              "flex h-8 w-8 items-center justify-center rounded-full border border-[rgba(var(--category-color-rgb),0.35)] bg-white text-[var(--category-color)] shadow-sm transition-colors",
+              "dark:bg-background",
+              isParentSelected && "border-transparent bg-[var(--category-color)] text-[var(--category-text-color)]",
+            )}
+          >
+            {isParentSelected ? (
+              <Check className="h-4 w-4" />
+            ) : (
+              <span className="h-2.5 w-2.5 rounded-full bg-[var(--category-color)]" />
+            )}
+          </div>
+          <span className="flex items-center gap-2 text-sm font-semibold leading-none text-foreground">
+            {parent.emoji && <span className="text-base leading-none">{parent.emoji}</span>}
+            {parent.nombre}
+          </span>
+        </div>
+        {children.length > 0 && (
+          <span className="text-xs font-medium text-muted-foreground">
+            {children.length} subcategoría{children.length !== 1 ? "s" : ""}
+          </span>
+        )}
+      </button>
+
+      {children.length > 0 && (
+        <div className="mt-3 flex flex-wrap gap-2 pl-11">
+          {children.map((child) => (
+            <CategoryChipButton
+              key={child.id}
+              category={child}
+              colorSource={parent}
+              selected={selectedCategorySet.has(child.id)}
+              onSelect={() => onSelectChild(child.id)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface CategoryChipButtonProps {
+  category: Categoria
+  colorSource: Categoria
+  selected: boolean
+  onSelect: () => void
+}
+
+function CategoryChipButton({ category, colorSource, selected, onSelect }: CategoryChipButtonProps) {
+  const { color, textColor, rgbValue } = getCategoryColorTokens(colorSource)
+  const style: CSSProperties = {
+    ["--category-color" as string]: color,
+    ["--category-text-color" as string]: textColor,
+    ["--category-color-rgb" as string]: rgbValue,
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={cn(
+        "inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(var(--category-color-rgb),0.45)] focus-visible:ring-offset-2",
+        selected
+          ? "border-transparent bg-[var(--category-color)] text-[var(--category-text-color)] shadow-sm"
+          : "border-transparent bg-[rgba(var(--category-color-rgb),0.14)] text-[var(--category-color)] hover:bg-[rgba(var(--category-color-rgb),0.22)] dark:bg-[rgba(var(--category-color-rgb),0.18)] dark:hover:bg-[rgba(var(--category-color-rgb),0.26)]",
+      )}
+      style={style}
+    >
+      {category.emoji && <span className="text-sm leading-none">{category.emoji}</span>}
+      <span className="leading-none">{category.nombre}</span>
+      {selected && <Check className="h-3.5 w-3.5" />}
+    </button>
+  )
+}
+
+interface CategorySearchResultProps {
+  category: Categoria
+  parent?: Categoria
+  isSelected: boolean
+  onSelect: () => void
+}
+
+function CategorySearchResult({ category, parent, isSelected, onSelect }: CategorySearchResultProps) {
+  const colorSource = parent ?? category
+  const { color, textColor, rgbValue } = getCategoryColorTokens(colorSource)
+  const style: CSSProperties = {
+    ["--category-color" as string]: color,
+    ["--category-text-color" as string]: textColor,
+    ["--category-color-rgb" as string]: rgbValue,
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={cn(
+        "w-full rounded-2xl border border-transparent bg-[rgba(var(--category-color-rgb),0.08)] px-4 py-3 text-left transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(var(--category-color-rgb),0.4)] focus-visible:ring-offset-2",
+        "hover:bg-[rgba(var(--category-color-rgb),0.14)]",
+        isSelected &&
+          "border-[var(--category-color)] bg-[rgba(var(--category-color-rgb),0.16)] shadow-[0_12px_32px_-20px_rgba(var(--category-color-rgb),0.6)]",
+      )}
+      style={style}
+    >
+      <div className="flex items-center justify-between gap-3">
+        <div className="space-y-1">
+          <span className="flex items-center gap-2 text-sm font-semibold leading-none">
+            {category.emoji && <span className="text-base leading-none">{category.emoji}</span>}
+            {category.nombre}
+          </span>
+          {parent && (
+            <span className="flex items-center gap-1 text-xs text-muted-foreground">
+              {parent.emoji && <span className="text-sm leading-none">{parent.emoji}</span>}
+              {parent.nombre}
+            </span>
+          )}
+        </div>
+        {isSelected && (
+          <span className="flex h-7 w-7 items-center justify-center rounded-full bg-[var(--category-color)] text-[var(--category-text-color)] shadow-sm">
+            <Check className="h-4 w-4" />
+          </span>
+        )}
+      </div>
+    </button>
+  )
+}
+
+interface SelectedCategoryBadgeProps {
+  category: Categoria
+  colorSource: Categoria
+  onRemove: (event: React.MouseEvent<HTMLButtonElement>) => void
+}
+
+function SelectedCategoryBadge({ category, colorSource, onRemove }: SelectedCategoryBadgeProps) {
+  const { color, textColor, rgbValue } = getCategoryColorTokens(colorSource)
+  const style: CSSProperties = {
+    ["--category-color" as string]: color,
+    ["--category-text-color" as string]: textColor,
+    ["--category-color-rgb" as string]: rgbValue,
+  }
+
+  return (
+    <span
+      className="inline-flex items-center gap-2 rounded-full border border-transparent bg-[rgba(var(--category-color-rgb),0.16)] px-3 py-1.5 text-xs font-medium text-[var(--category-color)] shadow-sm transition-colors duration-200 dark:bg-[rgba(var(--category-color-rgb),0.26)]"
+      style={style}
+    >
+      {category.emoji && <span className="text-sm leading-none">{category.emoji}</span>}
+      <span className="leading-none">{category.nombre}</span>
+      <button
+        type="button"
+        onClick={onRemove}
+        className="flex h-5 w-5 items-center justify-center rounded-full bg-transparent text-[var(--category-color)] transition-colors duration-200 hover:bg-[rgba(var(--category-color-rgb),0.18)] hover:text-[var(--category-text-color)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(var(--category-color-rgb),0.4)] focus-visible:ring-offset-1"
+      >
+        <X className="h-3 w-3" />
+      </button>
+    </span>
   )
 }


### PR DESCRIPTION
## Summary
- reorganize the CategorySelector to group parent labels with their subcategory chips and improve search result styling and emoji placement
- add shared helpers for child chips and selected badges so colors inherit from the parent category
- remove the extra manual category chip list in the activity balance dashboard to reuse the enhanced selector UI

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ce7067b87083269b8dfe411c050367