### PR TITLE
Mejoras visuales en el selector de categorías

### DIFF
--- a/components/transactions/category-selector.tsx
+++ b/components/transactions/category-selector.tsx
@@ -71,6 +71,7 @@ export function CategorySelector({
   const [searchValue, setSearchValue] = useState("")
   const searchInputRef = useRef<HTMLInputElement>(null)
   const normalizedSearch = searchValue.trim().toLowerCase()
+  const hasSearch = normalizedSearch.length > 0
 
   const { groups, orphans, parentLookup } = useMemo(() => {
     const parentCategories = categories.filter((cat) => !cat.categoria_padre_id)
@@ -164,6 +165,24 @@ export function CategorySelector({
     return categories.filter((cat) => selectedCategories.includes(cat.id))
   }, [categories, selectedCategories])
 
+  const selectionLabel = useMemo(() => {
+    if (selectedCategories.length === 0) {
+      return placeholder
+    }
+
+    if (allowMultiple) {
+      if (selectedCategories.length === 1) {
+        return selectedCategoryObjects[0]?.nombre ?? placeholder
+      }
+
+      return `${selectedCategories.length} categoría${selectedCategories.length !== 1 ? "s" : ""} seleccionada${
+        selectedCategories.length !== 1 ? "s" : ""
+      }`
+    }
+
+    return selectedCategoryObjects[0]?.nombre ?? "Categoría seleccionada"
+  }, [allowMultiple, placeholder, selectedCategories, selectedCategoryObjects])
+
   const selectedCategorySet = useMemo(() => new Set(selectedCategories), [selectedCategories])
 
   const handleSelect = (categoryId: string) => {
@@ -202,22 +221,42 @@ export function CategorySelector({
             aria-expanded={open}
             type="button"
             onClick={() => setOpenState(!open)}
-            className="w-full justify-between bg-background border-border hover:bg-muted/50 h-9"
+            className={cn(
+              "group flex h-11 w-full min-w-[260px] items-center justify-between gap-3 rounded-xl border border-border/60",
+              "bg-background/90 px-4 text-left text-sm font-medium shadow-sm transition-all duration-200",
+              "hover:border-primary/40 hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:ring-offset-1",
+              open && "border-primary/50 bg-primary/5",
+            )}
           >
-            <span className="truncate text-sm">
-              {selectedCategories.length === 0
-                ? placeholder
-                : allowMultiple
-                  ? `${selectedCategories.length} categoría${selectedCategories.length !== 1 ? "s" : ""} seleccionada${selectedCategories.length !== 1 ? "s" : ""}`
-                  : selectedCategoryObjects[0]?.nombre || "Categoría seleccionada"}
-            </span>
-            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+            <div className="flex min-w-0 flex-1 flex-col">
+              <span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground/80">
+                Categorías
+              </span>
+              <span className="truncate text-sm text-foreground">{selectionLabel}</span>
+            </div>
+            <div className="flex items-center gap-2">
+              {allowMultiple && selectedCategories.length > 0 && (
+                <span className="inline-flex h-6 min-w-[1.75rem] items-center justify-center rounded-full bg-primary/15 px-2 text-xs font-semibold text-primary">
+                  {selectedCategories.length}
+                </span>
+              )}
+              <ChevronsUpDown
+                className={cn(
+                  "h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200",
+                  open && "rotate-180",
+                )}
+              />
+            </div>
           </Button>
         </PopoverTrigger>
-        <PopoverContent className="w-[360px] p-0" align="start">
-          <div className="border-b p-3">
+        <PopoverContent
+          className="w-[320px] rounded-2xl border border-border/70 bg-popover p-0 shadow-xl sm:w-[360px]"
+          align="start"
+          sideOffset={8}
+        >
+          <div className="border-b border-border/60 bg-background/95 p-3 backdrop-blur supports-[backdrop-filter]:bg-background/80">
             <div className="relative">
-              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 transform text-muted-foreground" />
+              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 transform text-muted-foreground" />
               <Input
                 placeholder="Buscar categorías..."
                 value={searchValue}
@@ -231,14 +270,38 @@ export function CategorySelector({
                     }
                   }
                 }}
-                className="h-9 bg-background pl-9"
+                className="h-10 rounded-lg border-border bg-background/90 pl-9 pr-9 text-sm"
                 ref={searchInputRef}
               />
+              {searchValue && (
+                <button
+                  type="button"
+                  onClick={() => setSearchValue("")}
+                  className="absolute right-2.5 top-1/2 -translate-y-1/2 rounded-full p-1 text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:ring-offset-1"
+                  aria-label="Limpiar búsqueda"
+                >
+                  <X className="h-3.5 w-3.5" />
+                </button>
+              )}
             </div>
+            {hasSearch && (
+              <div className="mt-3 flex items-center justify-between rounded-lg border border-border/60 bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+                <span>
+                  {filteredCategories.length === 0
+                    ? "Sin resultados"
+                    : `${filteredCategories.length} resultado${filteredCategories.length !== 1 ? "s" : ""}`}
+                </span>
+                {filteredCategories.length > 0 && (
+                  <span className="font-medium text-foreground/80">
+                    Pulsa Enter para elegir el primero
+                  </span>
+                )}
+              </div>
+            )}
           </div>
           <ScrollArea className="max-h-[320px]">
-            <div className="space-y-3 p-3">
-              {normalizedSearch ? (
+            <div className="space-y-3 px-3 py-4">
+              {hasSearch ? (
                 filteredCategories.length === 0 ? (
                   <div className="py-8 text-center text-muted-foreground">
                     <p className="text-sm">No se encontraron categorías</p>
@@ -298,7 +361,12 @@ export function CategorySelector({
             </div>
           </ScrollArea>
           <div className="border-t p-3">
-            <Button variant="outline" size="sm" className="h-9 w-full bg-transparent" type="button">
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-9 w-full rounded-xl border-border/60 bg-transparent text-sm hover:border-primary/40 hover:bg-primary/5"
+              type="button"
+            >
               <Plus className="mr-2 h-4 w-4" />
               Crear nueva categoría
             </Button>


### PR DESCRIPTION
## Resumen
- aplicar un contenedor con anchura fija y estilos consistentes al trigger y al contenido del selector de categorías
- añadir resumen de selección, contador visual y controles de búsqueda con indicador de resultados y botón para limpiar
- mejorar la sensación de popover con bordes redondeados, sombras y mensajes de estado para búsquedas vacías

## Pruebas
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d7321bcb8c8326a8ae5ed3a17b3cfb