### PR TITLE
feat: gestionar solicitudes de acceso por correo

### DIFF
--- a/components/auth/sign-up-form.tsx
+++ b/components/auth/sign-up-form.tsx
@@ -17,10 +17,10 @@ function SubmitButton() {
       {pending ? (
         <>
           <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-          Registrando...
+          Enviando...
         </>
       ) : (
-        "Registrarse"
+        "Pedir acceso"
       )}
     </Button>
   )
@@ -32,8 +32,10 @@ export default function SignUpForm() {
   return (
     <Card className="w-full max-w-md">
       <CardHeader className="space-y-1">
-        <CardTitle className="text-2xl font-bold text-center">Crear Cuenta</CardTitle>
-        <CardDescription className="text-center">Regístrate en MCM Bank</CardDescription>
+        <CardTitle className="text-2xl font-bold text-center">Solicitar acceso</CardTitle>
+        <CardDescription className="text-center">
+          Cuéntanos qué delegación necesitas y te avisaremos cuando esté listo.
+        </CardDescription>
       </CardHeader>
       <CardContent>
         <form action={formAction} className="space-y-4">
@@ -50,17 +52,28 @@ export default function SignUpForm() {
           )}
 
           <div className="space-y-2">
-            <label htmlFor="email" className="block text-sm font-medium">
-              Email
+            <label htmlFor="delegation" className="block text-sm font-medium">
+              Delegación a la que quieres acceder
             </label>
-            <Input id="email" name="email" type="email" placeholder="tu@email.com" required />
+            <Input
+              id="delegation"
+              name="delegation"
+              placeholder="Ej. Madrid Centro, Valencia..."
+              required
+            />
           </div>
 
           <div className="space-y-2">
-            <label htmlFor="password" className="block text-sm font-medium">
-              Contraseña
+            <label htmlFor="email" className="block text-sm font-medium">
+              Correo de contacto
             </label>
-            <Input id="password" name="password" type="password" required />
+            <Input
+              id="email"
+              name="email"
+              type="email"
+              placeholder="tu@email.com"
+              required
+            />
           </div>
 
           <SubmitButton />
@@ -71,6 +84,10 @@ export default function SignUpForm() {
               Inicia sesión
             </Link>
           </div>
+
+          <p className="text-center text-xs text-muted-foreground">
+            Respondemos cuando podemos, así que paciencia y mantén el ojo en tu bandeja de entrada.
+          </p>
         </form>
       </CardContent>
     </Card>

--- a/lib/actions/auth.ts
+++ b/lib/actions/auth.ts
@@ -31,33 +31,88 @@ export async function signIn(prevState: any, formData: FormData) {
 }
 
 export async function signUp(prevState: any, formData: FormData) {
-  const email = formData.get("email") as string
-  const password = formData.get("password") as string
+  const email = (formData.get("email") as string | null)?.trim()
+  const delegation = (formData.get("delegation") as string | null)?.trim()
 
-  if (!email || !password) {
-    return { error: "Email and password are required" }
+  if (!email || !delegation) {
+    return { error: "Necesitamos tu correo y la delegación que quieres visitar." }
   }
 
-  const supabase = createClient()
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+  if (!emailRegex.test(email)) {
+    return { error: "El correo no tiene pinta de ser válido. Revísalo, porfa." }
+  }
+
+  const resendApiKey = process.env.RESEND_API_KEY
+
+  if (!resendApiKey) {
+    console.error("Missing RESEND_API_KEY environment variable. Unable to send email request.")
+    return {
+      error:
+        "No pudimos enviar tu solicitud porque el servicio de correo no está configurado. Habla con el equipo para revisarlo.",
+    }
+  }
+
+  const subject = `✨ Nueva solicitud de acceso - ${delegation}`
+  const html = `
+    <div style="background: linear-gradient(135deg, #ff9a9e 0%, #fad0c4 100%); padding: 32px; font-family: 'Segoe UI', Arial, sans-serif; color: #1f2937;">
+      <div style="max-width: 520px; margin: 0 auto; background: #ffffffdd; border-radius: 20px; box-shadow: 0 20px 45px rgba(255, 105, 180, 0.25); overflow: hidden;">
+        <div style="background: #9333ea; color: #f8fafc; text-align: center; padding: 28px 24px;">
+          <h1 style="margin: 0; font-size: 28px; letter-spacing: 1px;">¡Nueva petición brillante! ✨</h1>
+        </div>
+        <div style="padding: 32px;">
+          <p style="font-size: 16px; line-height: 1.6; margin-bottom: 16px;">
+            Hola equipo MCM Bank,
+          </p>
+          <p style="font-size: 16px; line-height: 1.6; margin-bottom: 16px;">
+            <strong style="color: #7c3aed;">${email}</strong> está pidiendo acceso para la delegación
+            <strong style="color: #ea580c;">${delegation}</strong>.
+          </p>
+          <p style="font-size: 16px; line-height: 1.6; margin-bottom: 24px;">
+            ¿Le damos la bienvenida con purpurina virtual? 💌
+          </p>
+          <div style="background: #fdf4ff; border-radius: 16px; padding: 20px; text-align: center;">
+            <p style="margin: 0; font-size: 18px; font-weight: 600; color: #be185d;">
+              Cuando tengamos un momento, contestemos y hagamos magia.
+            </p>
+          </div>
+        </div>
+        <div style="text-align: center; padding: 20px; background: #f8fafc; font-size: 14px; color: #6b7280;">
+          Enviado automáticamente desde el portal de acceso chulísimo de MCM Bank ✨
+        </div>
+      </div>
+    </div>
+  `
 
   try {
-    const { error } = await supabase.auth.signUp({
-      email,
-      password,
-      options: {
-        emailRedirectTo:
-          process.env.NEXT_PUBLIC_DEV_SUPABASE_REDIRECT_URL || `${process.env.NEXT_PUBLIC_SITE_URL}/auth/callback`,
+    const response = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${resendApiKey}`,
+        "Content-Type": "application/json",
       },
+      body: JSON.stringify({
+        from: "MCM Bank Accesos <no-reply@movimientoconsolacion.com>",
+        to: ["ajmcm@movimientoconsolacion.com"],
+        subject,
+        html,
+        reply_to: [email],
+      }),
     })
 
-    if (error) {
-      return { error: error.message }
+    if (!response.ok) {
+      const errorMessage = await response.text()
+      console.error("Error sending access request email:", errorMessage)
+      return { error: "No pudimos enviar tu solicitud. Inténtalo de nuevo en un ratito." }
     }
 
-    return { success: "Check your email to confirm your account." }
+    return {
+      success: "¡Solicitud enviada! Nos lo tomamos con calma, así que paciencia que ya te diremos algo.",
+    }
   } catch (error) {
-    console.error("Sign up error:", error)
-    return { error: "An unexpected error occurred. Please try again." }
+    console.error("Sign up request error:", error)
+    return { error: "Algo ha fallado al enviar tu solicitud. Prueba otra vez en unos minutos." }
   }
 }
 


### PR DESCRIPTION
## Summary
- replace the signup flow with an access request form that asks for the desired delegación and contact email and sets expectations about response times
- send a colorful HTML email to ajmcm@movimientoconsolacion.com via Resend when a request is submitted, including basic validation and reply-to handling

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d7326864808326b79db8082354f0e8