### PR TITLE
feat: cambiar contraseña deslumbrante

### DIFF
--- a/app/perfil/cambiar-contrasena/page.tsx
+++ b/app/perfil/cambiar-contrasena/page.tsx
@@ -1,0 +1,10 @@
+import { AppLayout } from "@/components/app-layout"
+import { ChangePasswordPage } from "@/components/perfil/change-password-page"
+
+export default function CambiarContrasenaPage() {
+  return (
+    <AppLayout>
+      <ChangePasswordPage />
+    </AppLayout>
+  )
+}

--- a/components/perfil/change-password-page.tsx
+++ b/components/perfil/change-password-page.tsx
@@ -1,0 +1,316 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { z } from "zod"
+import { toast } from "sonner"
+import { supabase } from "@/lib/supabase/client"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { cn } from "@/lib/utils"
+import { ShieldCheck, Sparkles, Stars } from "lucide-react"
+import { useAuth } from "@/contexts/auth-context"
+
+const MIN_PASSWORD_LENGTH = 6
+
+const passwordBlueprint = [
+  {
+    id: "length",
+    label: `Al menos ${MIN_PASSWORD_LENGTH} caracteres (requisito actual)`,
+    optional: false,
+    test: (password: string) => password.trim().length >= MIN_PASSWORD_LENGTH,
+  },
+  {
+    id: "uppercase",
+    label: "Una mayúscula para cuando nos pongamos exquisitos",
+    optional: true,
+    test: (password: string) => /[A-Z]/.test(password),
+  },
+  {
+    id: "number",
+    label: "Un número como guiño futurista",
+    optional: true,
+    test: (password: string) => /\d/.test(password),
+  },
+  {
+    id: "symbol",
+    label: "Un símbolo con personalidad (opcional)",
+    optional: true,
+    test: (password: string) => /[^\w\s]/.test(password),
+  },
+] as const
+
+const changePasswordSchema = z
+  .object({
+    currentPassword: z.string().optional(),
+    newPassword: z.string().min(MIN_PASSWORD_LENGTH, {
+      message: `Tu nueva contraseña debe tener al menos ${MIN_PASSWORD_LENGTH} caracteres`,
+    }),
+    confirmPassword: z.string().min(1, {
+      message: "Confirma tu nueva contraseña",
+    }),
+  })
+  .refine(data => data.newPassword === data.confirmPassword, {
+    message: "Las contraseñas no coinciden",
+    path: ["confirmPassword"],
+  })
+
+type ChangePasswordFormValues = z.infer<typeof changePasswordSchema>
+
+export function ChangePasswordPage() {
+  const { user } = useAuth()
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    watch,
+    formState: { errors },
+  } = useForm<ChangePasswordFormValues>({
+    resolver: zodResolver(changePasswordSchema),
+    defaultValues: {
+      currentPassword: "",
+      newPassword: "",
+      confirmPassword: "",
+    },
+  })
+
+  const newPasswordValue = watch("newPassword")
+
+  const requirements = useMemo(() => {
+    return passwordBlueprint.map(requirement => ({
+      ...requirement,
+      met: requirement.test(newPasswordValue ?? ""),
+    }))
+  }, [newPasswordValue])
+
+  const activeRequirementCount = requirements.filter(req => !req.optional).length || 1
+  const fulfilledActiveRequirementCount = requirements.filter(req => !req.optional && req.met).length
+  const progress = Math.min(100, Math.round((fulfilledActiveRequirementCount / activeRequirementCount) * 100))
+
+  const onSubmit = async (values: ChangePasswordFormValues) => {
+    try {
+      setIsSubmitting(true)
+      const { error } = await supabase.auth.updateUser({ password: values.newPassword })
+      if (error) {
+        throw error
+      }
+      reset({ currentPassword: "", newPassword: "", confirmPassword: "" })
+      toast.success("Contraseña actualizada", {
+        description: "Tu nueva clave ya está lista para seguir conquistando el banco más bonito.",
+      })
+    } catch (error: any) {
+      console.error("Error updating password", error)
+      toast.error("No hemos podido actualizar tu contraseña", {
+        description: error?.message ?? "Inténtalo de nuevo en unos segundos.",
+      })
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="relative isolate -mx-2 -mt-2 rounded-3xl border border-border/60 bg-gradient-to-br from-background via-background to-muted/50 px-4 py-12 shadow-[0px_40px_120px_-40px_rgba(15,23,42,0.45)] sm:-mx-4 lg:-mx-6 lg:px-10">
+      <div className="pointer-events-none absolute inset-0 overflow-hidden rounded-3xl">
+        <div className="absolute -left-24 top-16 h-64 w-64 rounded-full bg-primary/10 blur-3xl" />
+        <div className="absolute -right-20 bottom-10 h-72 w-72 rounded-full bg-purple-500/10 blur-3xl" />
+        <div className="absolute inset-x-16 top-1/2 h-px bg-gradient-to-r from-transparent via-border/60 to-transparent" />
+      </div>
+
+      <div className="relative mx-auto flex w-full max-w-5xl flex-col gap-12">
+        <header className="space-y-4 text-center lg:text-left">
+          <div className="inline-flex items-center gap-2 rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-primary">
+            <Sparkles className="h-3 w-3" />
+            Reset mágico
+          </div>
+          <h1 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl lg:text-5xl">
+            Reinventa tu contraseña con un ritual de lujo
+          </h1>
+          <p className="text-base text-muted-foreground sm:text-lg lg:max-w-2xl">
+            Dale a tu cuenta un aire nuevo en una experiencia cuidada al detalle. Por ahora solo necesitas una clave de {MIN_PASSWORD_LENGTH} caracteres, pero hemos preparado el terreno para cuando queramos subir el listón.
+          </p>
+        </header>
+
+        <div className="grid gap-10 lg:grid-cols-[minmax(0,1fr)_320px] lg:items-start">
+          <form
+            onSubmit={handleSubmit(onSubmit)}
+            className="relative overflow-hidden rounded-3xl border border-border/70 bg-background/95 p-8 shadow-[0px_30px_80px_-40px_rgba(15,23,42,0.45)] backdrop-blur-xl sm:p-10"
+          >
+            <div className="absolute -right-20 -top-32 h-56 w-56 rotate-12 rounded-full bg-gradient-to-br from-primary/60 via-indigo-500/60 to-transparent blur-3xl" />
+            <div className="absolute -left-24 bottom-12 h-64 w-64 rounded-full bg-emerald-400/20 blur-3xl" />
+
+            <div className="relative z-10 space-y-8">
+              <div className="rounded-2xl border border-border/70 bg-muted/40 p-4 text-xs uppercase tracking-[0.35em] text-muted-foreground">
+                {user?.email ? `Sesión iniciada como ${user.email}` : "Sesión segura activa"}
+              </div>
+
+              <div className="grid gap-6">
+                <div className="grid gap-2">
+                  <Label htmlFor="currentPassword" className="text-sm font-semibold text-foreground">
+                    Contraseña actual
+                    <span className="ml-2 text-xs font-normal uppercase tracking-[0.2em] text-muted-foreground">
+                      opcional por ahora
+                    </span>
+                  </Label>
+                  <Input
+                    id="currentPassword"
+                    type="password"
+                    autoComplete="current-password"
+                    placeholder="La pediremos cuando nos pongamos exigentes"
+                    {...register("currentPassword")}
+                    className="h-12 rounded-2xl border-border/70 bg-background/80 text-base"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Hoy no la necesitamos, pero ya está aquí para el futuro.
+                  </p>
+                </div>
+
+                <div className="grid gap-2">
+                  <Label htmlFor="newPassword" className="text-sm font-semibold text-foreground">
+                    Nueva contraseña
+                  </Label>
+                  <Input
+                    id="newPassword"
+                    type="password"
+                    autoComplete="new-password"
+                    placeholder="Un secreto a tu altura"
+                    {...register("newPassword")}
+                    className={cn(
+                      "h-12 rounded-2xl border-border/70 bg-background/80 text-base",
+                      errors.newPassword && "border-destructive/60 focus-visible:ring-destructive/60",
+                    )}
+                  />
+                  {errors.newPassword && (
+                    <p className="text-xs text-destructive">{errors.newPassword.message}</p>
+                  )}
+                </div>
+
+                <div className="grid gap-2">
+                  <Label htmlFor="confirmPassword" className="text-sm font-semibold text-foreground">
+                    Confirmar contraseña
+                  </Label>
+                  <Input
+                    id="confirmPassword"
+                    type="password"
+                    autoComplete="new-password"
+                    placeholder="Repetimos para asegurarnos"
+                    {...register("confirmPassword")}
+                    className={cn(
+                      "h-12 rounded-2xl border-border/70 bg-background/80 text-base",
+                      errors.confirmPassword && "border-destructive/60 focus-visible:ring-destructive/60",
+                    )}
+                  />
+                  {errors.confirmPassword && (
+                    <p className="text-xs text-destructive">{errors.confirmPassword.message}</p>
+                  )}
+                </div>
+              </div>
+
+              <div className="space-y-4">
+                <div>
+                  <div className="mb-2 flex items-center justify-between text-xs font-medium uppercase tracking-[0.25em] text-muted-foreground">
+                    <span>Progreso imprescindible</span>
+                    <span>{progress}%</span>
+                  </div>
+                  <div className="h-2 w-full overflow-hidden rounded-full bg-muted/80">
+                    <div
+                      className="h-full rounded-full bg-gradient-to-r from-primary via-purple-500 to-pink-500 transition-all duration-500"
+                      style={{ width: `${progress}%` }}
+                    />
+                  </div>
+                </div>
+                <ul className="grid gap-2 text-sm">
+                  {requirements.map(requirement => (
+                    <li
+                      key={requirement.id}
+                      className={cn(
+                        "flex items-start gap-3 rounded-2xl border border-transparent bg-muted/40 px-4 py-3 text-sm",
+                        requirement.met
+                          ? "border-emerald-400/40 bg-emerald-400/10 text-emerald-900 dark:text-emerald-100"
+                          : "text-muted-foreground",
+                        requirement.optional && !requirement.met && "opacity-75",
+                      )}
+                    >
+                      <ShieldCheck
+                        className={cn(
+                          "mt-0.5 h-4 w-4 flex-shrink-0",
+                          requirement.met ? "text-emerald-500" : "text-muted-foreground/60",
+                        )}
+                      />
+                      <div>
+                        <p className="font-medium leading-none">
+                          {requirement.label}
+                          {requirement.optional && !requirement.met && (
+                            <span className="ml-2 text-[0.65rem] uppercase tracking-[0.3em] text-muted-foreground/70">
+                              futuro
+                            </span>
+                          )}
+                        </p>
+                        {requirement.optional && (
+                          <p className="mt-1 text-xs text-muted-foreground">
+                            {requirement.met
+                              ? "Listo para el futuro."
+                              : "Sin presión: lo tendremos en cuenta cuando toque."}
+                          </p>
+                        )}
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              <Button
+                type="submit"
+                disabled={isSubmitting}
+                className="group relative h-12 w-full overflow-hidden rounded-2xl bg-gradient-to-r from-primary via-purple-500 to-pink-500 text-base font-semibold text-white shadow-lg transition hover:scale-[1.01] hover:shadow-[0_25px_45px_-20px_rgba(168,85,247,0.45)]"
+              >
+                <span className="relative z-10">
+                  {isSubmitting ? "Guardando tu nueva contraseña..." : "Guardar nueva contraseña"}
+                </span>
+                <span className="absolute inset-0 bg-gradient-to-r from-white/20 via-transparent to-white/20 opacity-0 transition group-hover:opacity-100" />
+              </Button>
+            </div>
+          </form>
+
+          <aside className="relative overflow-hidden rounded-3xl border border-border/70 bg-background/80 p-6 shadow-[0px_30px_80px_-50px_rgba(15,23,42,0.55)] backdrop-blur-xl sm:p-8">
+            <div className="absolute -right-16 top-16 h-40 w-40 rounded-full bg-primary/20 blur-3xl" />
+            <div className="absolute -left-10 bottom-10 h-32 w-32 rounded-full bg-pink-400/20 blur-3xl" />
+
+            <div className="relative z-10 space-y-6">
+              <div className="inline-flex items-center gap-2 rounded-full bg-muted/60 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">
+                <Stars className="h-3 w-3" />
+                Nota de estilo
+              </div>
+              <p className="text-lg font-semibold text-foreground">
+                Una experiencia diseñada para quienes cuidan cada detalle.
+              </p>
+              <p className="text-sm text-muted-foreground">
+                Sin complicaciones innecesarias hoy, pero con la arquitectura preparada para protocolos más exigentes mañana. Cada campo, animación y color están listos para crecer contigo.
+              </p>
+              <div className="rounded-2xl border border-border/60 bg-muted/40 p-4 text-sm text-muted-foreground">
+                <p className="font-medium text-foreground">¿Qué ocurrirá cuando pulses guardar?</p>
+                <ul className="mt-3 space-y-2">
+                  <li className="flex items-start gap-2">
+                    <span className="mt-1 h-2 w-2 rounded-full bg-emerald-400" />
+                    <span>Actualizamos tu contraseña al instante mediante Supabase.</span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span className="mt-1 h-2 w-2 rounded-full bg-primary" />
+                    <span>Te confirmamos el cambio con un mensaje brillante.</span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span className="mt-1 h-2 w-2 rounded-full bg-pink-400" />
+                    <span>Preparado para añadir nuevas reglas de seguridad sin rehacer la UI.</span>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/topbar.tsx
+++ b/components/topbar.tsx
@@ -6,9 +6,18 @@ import { useAuth } from "@/contexts/auth-context"
 import { usePerfil } from "@/hooks/use-perfil"
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar"
 import { Button } from "@/components/ui/button"
-import { LogOut, BookOpen, Moon, Sun, Monitor } from "lucide-react"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { LogOut, BookOpen, Moon, Sun, Monitor, ChevronDown, Sparkles } from "lucide-react"
 import { useTheme } from "next-themes"
 import { useEffect, useMemo, useState } from "react"
+import Link from "next/link"
 
 interface TopbarProps {
   selectedDelegation?: string | null
@@ -152,24 +161,65 @@ export function Topbar({ selectedDelegation, onDelegationChange }: TopbarProps) 
 
         {/* User info and logout */}
         <div className="flex items-center gap-3 pl-2 border-l border-border">
-          <div className="flex items-center gap-2">
-            <Avatar className="h-8 w-8">
-              <AvatarImage src="" alt={getUserDisplayName()} />
-              <AvatarFallback className="text-xs font-medium">
-                {getUserInitials(perfil?.nombre_completo, user?.email)}
-              </AvatarFallback>
-            </Avatar>
-            <div className="hidden sm:flex flex-col items-start text-sm">
-              <span className="font-medium text-foreground leading-none">
-                {getUserDisplayName()}
-              </span>
-              {user?.email && (
-                <span className="text-xs text-muted-foreground mt-0.5">
-                  {user.email}
-                </span>
-              )}
-            </div>
-          </div>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                aria-label="Abrir menú de perfil y acciones personales"
+                className="group flex items-center gap-3 rounded-full border border-transparent bg-transparent px-2 py-1.5 text-left transition hover:border-border/80 hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              >
+                <div className="flex items-center gap-2">
+                  <Avatar className="h-8 w-8 border border-border/60 shadow-sm">
+                    <AvatarImage src="" alt={getUserDisplayName()} />
+                    <AvatarFallback className="text-xs font-medium">
+                      {getUserInitials(perfil?.nombre_completo, user?.email)}
+                    </AvatarFallback>
+                  </Avatar>
+                  <div className="hidden sm:flex flex-col items-start text-sm">
+                    <span className="font-semibold text-foreground leading-none">
+                      {getUserDisplayName()}
+                    </span>
+                    {user?.email && (
+                      <span className="text-xs text-muted-foreground mt-0.5">
+                        {user.email}
+                      </span>
+                    )}
+                  </div>
+                </div>
+                <ChevronDown className="ml-2 h-4 w-4 text-muted-foreground transition group-hover:text-foreground" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="min-w-[18rem]">
+              <DropdownMenuLabel className="flex items-center gap-2 text-muted-foreground/70">
+                <Sparkles className="h-4 w-4 text-primary" />
+                Centro de control personal
+              </DropdownMenuLabel>
+              <div className="rounded-2xl border border-border/60 bg-gradient-to-br from-background via-background/90 to-muted/60 p-3">
+                <p className="text-xs uppercase tracking-[0.25em] text-muted-foreground/70">Sesión activa</p>
+                <p className="mt-2 text-sm font-semibold text-foreground">{getUserDisplayName()}</p>
+                {user?.email && (
+                  <p className="text-xs text-muted-foreground">{user.email}</p>
+                )}
+              </div>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem asChild className="cursor-pointer">
+                <Link href="/perfil/cambiar-contrasena" className="flex w-full items-center justify-between">
+                  <span>Cambiar contraseña</span>
+                  <span className="text-xs text-muted-foreground">Seguro y elegante</span>
+                </Link>
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                className="cursor-pointer text-red-600 focus:bg-red-50 focus:text-red-700 dark:focus:bg-red-950/40"
+                onSelect={(event) => {
+                  event.preventDefault()
+                  handleSignOut()
+                }}
+              >
+                <span>Cerrar sesión</span>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
 
           {/* Logout button */}
           <Button

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -1,0 +1,190 @@
+"use client"
+
+import * as React from "react"
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
+import { Check, ChevronRight, Circle } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const DropdownMenu = DropdownMenuPrimitive.Root
+
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger
+
+const DropdownMenuGroup = DropdownMenuPrimitive.Group
+
+const DropdownMenuPortal = DropdownMenuPrimitive.Portal
+
+const DropdownMenuSub = DropdownMenuPrimitive.Sub
+
+const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup
+
+const DropdownMenuSubTrigger = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
+    inset?: boolean
+  }
+>(({ className, inset, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubTrigger
+    ref={ref}
+    className={cn(
+      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent",
+      inset && "pl-8",
+      className,
+    )}
+    {...props}
+  >
+    {children}
+    <ChevronRight className="ml-auto h-4 w-4" />
+  </DropdownMenuPrimitive.SubTrigger>
+))
+DropdownMenuSubTrigger.displayName = DropdownMenuPrimitive.SubTrigger.displayName
+
+const DropdownMenuSubContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubContent
+    ref={ref}
+    className={cn(
+      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      className,
+    )}
+    {...props}
+  />
+))
+DropdownMenuSubContent.displayName = DropdownMenuPrimitive.SubContent.displayName
+
+const DropdownMenuContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 min-w-[12rem] overflow-hidden rounded-2xl border border-border/60 bg-background/95 p-2 text-foreground shadow-[0px_30px_60px_-20px_rgba(15,23,42,0.4)] backdrop-blur-xl data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
+        className,
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+))
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName
+
+const DropdownMenuItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
+    inset?: boolean
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center gap-2 rounded-xl px-3 py-2 text-sm font-medium text-foreground transition-colors outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      inset && "pl-8",
+      className,
+    )}
+    {...props}
+  />
+))
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName
+
+const DropdownMenuCheckboxItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
+>(({ className, children, checked, ...props }, ref) => (
+  <DropdownMenuPrimitive.CheckboxItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    checked={checked}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.CheckboxItem>
+))
+DropdownMenuCheckboxItem.displayName = DropdownMenuPrimitive.CheckboxItem.displayName
+
+const DropdownMenuRadioItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
+>(({ className, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.RadioItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Circle className="h-2 w-2 fill-current" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.RadioItem>
+))
+DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName
+
+const DropdownMenuLabel = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
+    inset?: boolean
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Label
+    ref={ref}
+    className={cn("px-2 py-1.5 text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground", inset && "pl-8", className)}
+    {...props}
+  />
+))
+DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName
+
+const DropdownMenuSeparator = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-gradient-to-r from-transparent via-border/80 to-transparent", className)}
+    {...props}
+  />
+))
+DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName
+
+const DropdownMenuShortcut = ({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>) => {
+  return (
+    <span
+      className={cn("ml-auto text-xs tracking-widest text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+DropdownMenuShortcut.displayName = "DropdownMenuShortcut"
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuGroup,
+  DropdownMenuPortal,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuRadioGroup,
+}


### PR DESCRIPTION
## Summary
- create a polished profile dropdown in the topbar with a change-password action and contextual account details
- add an immersive change-password experience that meets Supabase requirements today and anticipates stricter rules tomorrow
- expose a reusable dropdown menu primitive and wire a dedicated `/perfil/cambiar-contrasena` route for the new screen

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d732b790a8832688f5a20d1c3bae72