### PR TITLE
feat(contactos): nueva sección de contactos con vínculo a movimientos

### DIFF
--- a/app/contactos/page.tsx
+++ b/app/contactos/page.tsx
@@ -1,0 +1,10 @@
+import { AppLayout } from "@/components/app-layout"
+import { ContactosManager } from "@/components/contactos/contactos-manager"
+
+export default function ContactosPage() {
+  return (
+    <AppLayout>
+      <ContactosManager />
+    </AppLayout>
+  )
+}

--- a/components/contactos/contacto-detail-sheet.tsx
+++ b/components/contactos/contacto-detail-sheet.tsx
@@ -1,0 +1,358 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import { toast } from "sonner"
+import {
+  Archive,
+  ArchiveRestore,
+  ArrowDownRight,
+  ArrowUpRight,
+  Copy,
+  Edit3,
+  Globe,
+  Hash,
+  Loader2,
+  Mail,
+  MapPin,
+  Phone,
+  Plus,
+  Trash2,
+} from "lucide-react"
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet"
+import { Button } from "@/components/ui/button"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { EmptyState } from "@/components/ui/empty-state"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { cn } from "@/lib/utils"
+import { formatCurrency, formatDate, getAmountColorClass } from "@/lib/utils/format"
+import { formatearIban } from "@/lib/utils/iban"
+import { CONTACTO_TIPO_INFO } from "@/lib/utils/contacto-tipos"
+import { useClipboard } from "@/hooks/use-clipboard"
+import { useContactoDetalle } from "@/hooks/use-contactos"
+import { ContactoTipoBadge } from "./contacto-tipo-badge"
+import type { ContactoConCategoriaPredeterminada } from "@/lib/types/database"
+
+interface ContactoDetailSheetProps {
+  contactoId: string | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onEdit: (contacto: ContactoConCategoriaPredeterminada) => void
+  onDelete: (contacto: ContactoConCategoriaPredeterminada) => void
+  onArchive?: (contacto: ContactoConCategoriaPredeterminada) => void
+  onCreateMovimiento?: (contacto: ContactoConCategoriaPredeterminada) => void
+  canEdit: boolean
+}
+
+export function ContactoDetailSheet({
+  contactoId,
+  open,
+  onOpenChange,
+  onEdit,
+  onDelete,
+  onArchive,
+  onCreateMovimiento,
+  canEdit,
+}: ContactoDetailSheetProps) {
+  const { contacto, movimientos, totales, loading, error } = useContactoDetalle(open ? contactoId : null)
+  const { copy, isCopied } = useClipboard()
+  const [tab, setTab] = useState("info")
+
+  const tipoInfo = contacto ? CONTACTO_TIPO_INFO[contacto.tipo] : null
+
+  const handleCopy = async (value: string | null | undefined, label: string) => {
+    if (!value) return
+    const ok = await copy(value)
+    if (ok) toast.success(`${label} copiado`)
+  }
+
+  const direccionCompleta = useMemo(() => {
+    if (!contacto) return null
+    const parts = [contacto.direccion, [contacto.codigo_postal, contacto.ciudad].filter(Boolean).join(" ")]
+      .filter(Boolean)
+      .filter((part) => (part as string).trim().length > 0)
+    return parts.length > 0 ? parts.join(", ") : null
+  }, [contacto])
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="w-full sm:max-w-xl overflow-hidden flex flex-col p-0">
+        {loading && !contacto && (
+          <div className="flex flex-1 items-center justify-center p-8">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        )}
+
+        {error && (
+          <div className="p-6">
+            <EmptyState title="No se pudo cargar el contacto" description={error} />
+          </div>
+        )}
+
+        {contacto && tipoInfo && (
+          <>
+            <SheetHeader className="border-b border-border/30 p-6 pb-4 space-y-3">
+              <div className="flex items-start gap-3">
+                <div
+                  className="flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl text-2xl shadow"
+                  style={{ backgroundColor: contacto.color ?? tipoInfo.color }}
+                  aria-hidden
+                >
+                  {contacto.emoji ?? tipoInfo.emoji}
+                </div>
+                <div className="flex-1 min-w-0 pr-8">
+                  <SheetTitle className="truncate text-xl">{contacto.nombre}</SheetTitle>
+                  <div className="mt-1 flex flex-wrap items-center gap-1.5">
+                    <ContactoTipoBadge tipo={contacto.tipo} size="sm" />
+                    {contacto.es_global && (
+                      <span className="inline-flex items-center gap-1 rounded-full bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+                        <Globe className="h-2.5 w-2.5" /> Global
+                      </span>
+                    )}
+                    {contacto.archivado && (
+                      <span className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-1.5 py-0.5 text-[10px] text-amber-700 dark:bg-amber-950/40 dark:text-amber-300">
+                        <Archive className="h-2.5 w-2.5" /> Archivado
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </div>
+
+              <div className="flex flex-wrap gap-2">
+                {onCreateMovimiento && (
+                  <Button size="sm" onClick={() => onCreateMovimiento(contacto)} className="gap-1.5">
+                    <Plus className="h-3.5 w-3.5" /> Nuevo movimiento
+                  </Button>
+                )}
+                {canEdit && (
+                  <Button size="sm" variant="outline" onClick={() => onEdit(contacto)} className="gap-1.5">
+                    <Edit3 className="h-3.5 w-3.5" /> Editar
+                  </Button>
+                )}
+                {canEdit && onArchive && (
+                  <Button size="sm" variant="outline" onClick={() => onArchive(contacto)} className="gap-1.5">
+                    {contacto.archivado ? <ArchiveRestore className="h-3.5 w-3.5" /> : <Archive className="h-3.5 w-3.5" />}
+                    {contacto.archivado ? "Desarchivar" : "Archivar"}
+                  </Button>
+                )}
+                {canEdit && (
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => onDelete(contacto)}
+                    className="gap-1.5 text-destructive hover:text-destructive"
+                  >
+                    <Trash2 className="h-3.5 w-3.5" /> Eliminar
+                  </Button>
+                )}
+              </div>
+            </SheetHeader>
+
+            <Tabs value={tab} onValueChange={setTab} className="flex flex-1 flex-col overflow-hidden">
+              <div className="px-6 pt-3">
+                <TabsList className="grid w-full grid-cols-2">
+                  <TabsTrigger value="info">Información</TabsTrigger>
+                  <TabsTrigger value="movimientos">
+                    Movimientos ({totales.total})
+                  </TabsTrigger>
+                </TabsList>
+              </div>
+
+              <TabsContent value="info" className="flex-1 overflow-hidden">
+                <ScrollArea className="h-full">
+                  <div className="space-y-2 p-6">
+                    {contacto.identificador_fiscal && (
+                      <CopyableRow
+                        icon={<Hash className="h-4 w-4" />}
+                        label="CIF / NIF / DNI"
+                        value={contacto.identificador_fiscal}
+                        onCopy={() => handleCopy(contacto.identificador_fiscal, "Identificador fiscal")}
+                        copied={isCopied(contacto.identificador_fiscal)}
+                      />
+                    )}
+                    {contacto.email && (
+                      <CopyableRow
+                        icon={<Mail className="h-4 w-4" />}
+                        label="Email"
+                        value={contacto.email}
+                        onCopy={() => handleCopy(contacto.email, "Email")}
+                        copied={isCopied(contacto.email)}
+                      />
+                    )}
+                    {contacto.telefono && (
+                      <CopyableRow
+                        icon={<Phone className="h-4 w-4" />}
+                        label="Teléfono"
+                        value={contacto.telefono}
+                        onCopy={() => handleCopy(contacto.telefono, "Teléfono")}
+                        copied={isCopied(contacto.telefono)}
+                      />
+                    )}
+                    {contacto.iban && (
+                      <CopyableRow
+                        icon={<span className="text-[10px] font-bold tracking-wider">IBAN</span>}
+                        label="IBAN"
+                        value={formatearIban(contacto.iban)}
+                        copyValue={contacto.iban}
+                        onCopy={() => handleCopy(contacto.iban, "IBAN")}
+                        copied={isCopied(contacto.iban)}
+                        mono
+                      />
+                    )}
+                    {direccionCompleta && (
+                      <CopyableRow
+                        icon={<MapPin className="h-4 w-4" />}
+                        label="Dirección"
+                        value={direccionCompleta}
+                        onCopy={() => handleCopy(direccionCompleta, "Dirección")}
+                        copied={isCopied(direccionCompleta)}
+                      />
+                    )}
+                    {contacto.categoria_predeterminada && (
+                      <div className="rounded-xl border border-border/30 bg-card/40 p-3">
+                        <div className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                          Categoría sugerida
+                        </div>
+                        <div className="mt-1 flex items-center gap-2 text-sm">
+                          <span>{contacto.categoria_predeterminada.emoji ?? "🏷️"}</span>
+                          <span>{contacto.categoria_predeterminada.nombre}</span>
+                        </div>
+                      </div>
+                    )}
+                    {contacto.notas && (
+                      <div className="rounded-xl border border-border/30 bg-card/40 p-3">
+                        <div className="text-[11px] uppercase tracking-wide text-muted-foreground">Notas</div>
+                        <p className="mt-1 whitespace-pre-wrap text-sm">{contacto.notas}</p>
+                      </div>
+                    )}
+                    {!contacto.identificador_fiscal &&
+                      !contacto.email &&
+                      !contacto.telefono &&
+                      !contacto.iban &&
+                      !direccionCompleta &&
+                      !contacto.categoria_predeterminada &&
+                      !contacto.notas && (
+                        <EmptyState
+                          title="Sin datos adicionales"
+                          description="Edita el contacto para añadir email, teléfono, IBAN o más detalles."
+                        />
+                      )}
+                  </div>
+                </ScrollArea>
+              </TabsContent>
+
+              <TabsContent value="movimientos" className="flex-1 overflow-hidden">
+                <div className="grid grid-cols-3 gap-2 border-b border-border/30 p-4">
+                  <Stat label="Ingresos" value={totales.ingresos} positive />
+                  <Stat label="Gastos" value={totales.gastos} />
+                  <Stat label="Neto" value={totales.neto} neutral />
+                </div>
+                <ScrollArea className="h-[calc(100%-5rem)]">
+                  <div className="p-4">
+                    {movimientos.length === 0 ? (
+                      <EmptyState
+                        title="Sin movimientos vinculados"
+                        description="Vincula este contacto desde un movimiento existente o crea uno nuevo."
+                      />
+                    ) : (
+                      <ul className="space-y-1.5">
+                        {movimientos.map((m) => (
+                          <li
+                            key={m.id}
+                            className="flex items-start justify-between gap-3 rounded-lg border border-border/30 bg-card/40 px-3 py-2 text-sm"
+                          >
+                            <div className="min-w-0 flex-1">
+                              <div className="flex items-center gap-2">
+                                {m.importe >= 0 ? (
+                                  <ArrowUpRight className="h-3.5 w-3.5 text-green-600" />
+                                ) : (
+                                  <ArrowDownRight className="h-3.5 w-3.5 text-red-600" />
+                                )}
+                                <span className="truncate font-medium">{m.concepto}</span>
+                              </div>
+                              <div className="mt-0.5 flex items-center gap-2 text-[11px] text-muted-foreground">
+                                <span>{formatDate(m.fecha)}</span>
+                                {m.categoria && (
+                                  <span className="inline-flex items-center gap-1">
+                                    <span>{m.categoria.emoji ?? "🏷️"}</span>
+                                    <span className="truncate">{m.categoria.nombre}</span>
+                                  </span>
+                                )}
+                              </div>
+                            </div>
+                            <span className={cn("text-sm tabular-nums", getAmountColorClass(m.importe))}>
+                              {formatCurrency(m.importe)}
+                            </span>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
+                </ScrollArea>
+              </TabsContent>
+            </Tabs>
+          </>
+        )}
+      </SheetContent>
+    </Sheet>
+  )
+}
+
+function CopyableRow({
+  icon,
+  label,
+  value,
+  copyValue,
+  onCopy,
+  copied,
+  mono,
+}: {
+  icon: React.ReactNode
+  label: string
+  value: string
+  copyValue?: string
+  onCopy: () => void
+  copied: boolean
+  mono?: boolean
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onCopy}
+      className={cn(
+        "flex w-full items-center gap-3 rounded-xl border border-transparent bg-card/40 px-3 py-2 text-left transition-all hover:border-border/50 hover:bg-card",
+        copied && "bg-green-50 border-green-200 dark:bg-green-950/30 dark:border-green-900",
+      )}
+      title="Copiar"
+    >
+      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted/60 text-muted-foreground">
+        {icon}
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="text-[10px] uppercase tracking-wide text-muted-foreground">{label}</div>
+        <div className={cn("truncate text-sm", mono && "font-mono")}>{value}</div>
+      </div>
+      <Copy className={cn("h-4 w-4 shrink-0", copied ? "text-green-600" : "text-muted-foreground")} />
+    </button>
+  )
+}
+
+function Stat({ label, value, positive, neutral }: { label: string; value: number; positive?: boolean; neutral?: boolean }) {
+  return (
+    <div className="rounded-lg border border-border/30 bg-card/40 p-2 text-center">
+      <div className="text-[10px] uppercase tracking-wide text-muted-foreground">{label}</div>
+      <div
+        className={cn(
+          "mt-0.5 text-sm font-semibold tabular-nums",
+          !neutral && (positive ? "text-green-600" : value < 0 ? "text-red-600" : ""),
+        )}
+      >
+        {formatCurrency(value)}
+      </div>
+    </div>
+  )
+}

--- a/components/contactos/contacto-form.tsx
+++ b/components/contactos/contacto-form.tsx
@@ -1,0 +1,398 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+import { toast } from "sonner"
+import { ChevronDown, Copy, Globe, MapPin } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { ColorPicker } from "@/components/ui/color-picker"
+import { EmojiPickerButton } from "@/components/ui/emoji-picker"
+import { Checkbox } from "@/components/ui/checkbox"
+import { cn } from "@/lib/utils"
+import { CONTACTO_TIPO_INFO, CONTACTO_TIPO_ORDER, getDefaultColor, getDefaultEmoji } from "@/lib/utils/contacto-tipos"
+import { formatearIban, normalizarIban, validarIban } from "@/lib/utils/iban"
+import { useClipboard } from "@/hooks/use-clipboard"
+import type {
+  Categoria,
+  Contacto,
+  ContactoConCategoriaPredeterminada,
+  ContactoInsert,
+  ContactoTipo,
+  ContactoUpdate,
+} from "@/lib/types/database"
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+export interface ContactoFormSubmitPayload {
+  insert?: Omit<ContactoInsert, "creado_en" | "actualizado_en">
+  update?: ContactoUpdate
+  esGlobal: boolean
+}
+
+interface ContactoFormProps {
+  delegacionId: string | null
+  contacto?: ContactoConCategoriaPredeterminada | null
+  categorias: Pick<Categoria, "id" | "nombre" | "emoji" | "color">[]
+  canManageGlobal: boolean
+  defaultTipo?: ContactoTipo
+  defaultNombre?: string
+  onSubmit: (payload: ContactoFormSubmitPayload) => Promise<Contacto | void>
+  onCancel: () => void
+  onSaved?: (contacto: Contacto | void) => void
+}
+
+export function ContactoForm({
+  delegacionId,
+  contacto,
+  categorias,
+  canManageGlobal,
+  defaultTipo = "proveedor",
+  defaultNombre,
+  onSubmit,
+  onCancel,
+  onSaved,
+}: ContactoFormProps) {
+  const isEdit = Boolean(contacto?.id)
+  const { copy, isCopied } = useClipboard()
+
+  const [tipo, setTipo] = useState<ContactoTipo>(contacto?.tipo ?? defaultTipo)
+  const [nombre, setNombre] = useState(contacto?.nombre ?? defaultNombre ?? "")
+  const [esGlobal, setEsGlobal] = useState<boolean>(Boolean(contacto?.es_global))
+  const [emoji, setEmoji] = useState<string>(contacto?.emoji ?? getDefaultEmoji(contacto?.tipo ?? defaultTipo))
+  const [color, setColor] = useState<string>(contacto?.color ?? getDefaultColor(contacto?.tipo ?? defaultTipo))
+  const [identificadorFiscal, setIdentificadorFiscal] = useState(contacto?.identificador_fiscal ?? "")
+  const [iban, setIban] = useState(contacto?.iban ? formatearIban(contacto.iban) : "")
+  const [email, setEmail] = useState(contacto?.email ?? "")
+  const [telefono, setTelefono] = useState(contacto?.telefono ?? "")
+  const [direccion, setDireccion] = useState(contacto?.direccion ?? "")
+  const [ciudad, setCiudad] = useState(contacto?.ciudad ?? "")
+  const [codigoPostal, setCodigoPostal] = useState(contacto?.codigo_postal ?? "")
+  const [categoriaPredeterminadaId, setCategoriaPredeterminadaId] = useState<string | "ninguna">(
+    contacto?.categoria_id_predeterminada ?? "ninguna",
+  )
+  const [notas, setNotas] = useState(contacto?.notas ?? "")
+  const [direccionAbierta, setDireccionAbierta] = useState(Boolean(contacto?.direccion || contacto?.ciudad || contacto?.codigo_postal))
+  const [loading, setLoading] = useState(false)
+
+  const ibanNormalizado = useMemo(() => normalizarIban(iban), [iban])
+  const ibanValido = useMemo(() => validarIban(iban), [iban])
+
+  useEffect(() => {
+    if (isEdit) return
+    setEmoji(getDefaultEmoji(tipo))
+    setColor(getDefaultColor(tipo))
+  }, [tipo, isEdit])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const nombreTrim = nombre.trim()
+    if (!nombreTrim) {
+      toast.error("El nombre es obligatorio")
+      return
+    }
+    if (email && !EMAIL_REGEX.test(email.trim())) {
+      toast.error("El email no parece válido")
+      return
+    }
+    if (!ibanValido) {
+      toast.error("El IBAN no parece válido. Revísalo o déjalo vacío.")
+      return
+    }
+    if (!esGlobal && !delegacionId) {
+      toast.error("Selecciona una delegación antes de guardar un contacto local")
+      return
+    }
+
+    setLoading(true)
+    try {
+      const baseFields = {
+        tipo,
+        nombre: nombreTrim,
+        emoji: emoji || null,
+        color: color || null,
+        identificador_fiscal: identificadorFiscal.trim() || null,
+        iban: ibanNormalizado || null,
+        email: email.trim() || null,
+        telefono: telefono.trim() || null,
+        direccion: direccion.trim() || null,
+        ciudad: ciudad.trim() || null,
+        codigo_postal: codigoPostal.trim() || null,
+        categoria_id_predeterminada: categoriaPredeterminadaId === "ninguna" ? null : categoriaPredeterminadaId,
+        notas: notas.trim() || null,
+      }
+
+      let result: Contacto | void
+      if (isEdit && contacto) {
+        result = (await onSubmit({
+          esGlobal,
+          update: {
+            ...baseFields,
+            es_global: esGlobal,
+            delegacion_id: esGlobal ? null : (delegacionId as string),
+          },
+        })) as Contacto | void
+      } else {
+        result = (await onSubmit({
+          esGlobal,
+          insert: {
+            ...baseFields,
+            es_global: esGlobal,
+            delegacion_id: esGlobal ? null : (delegacionId as string),
+          },
+        })) as Contacto | void
+      }
+      toast.success(isEdit ? "Contacto actualizado" : "Contacto creado")
+      onSaved?.(result)
+    } catch (err) {
+      console.error("Error guardando contacto:", err)
+      toast.error("No se pudo guardar el contacto: " + (err instanceof Error ? err.message : "error desconocido"))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6 pt-2">
+      {/* Selector de tipo */}
+      <div className="space-y-2">
+        <Label>Tipo de contacto *</Label>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+          {CONTACTO_TIPO_ORDER.map((t) => {
+            const info = CONTACTO_TIPO_INFO[t]
+            const isSelected = tipo === t
+            return (
+              <button
+                key={t}
+                type="button"
+                onClick={() => setTipo(t)}
+                className={cn(
+                  "flex flex-col items-start gap-1 p-3 rounded-xl border-2 text-left transition-all",
+                  isSelected
+                    ? `${info.bgClass} ${info.borderClass} shadow-md`
+                    : "border-border/40 bg-card hover:border-border",
+                )}
+              >
+                <div className="flex items-center gap-2 font-semibold text-sm">
+                  <span>{info.emoji}</span>
+                  <span className={cn(isSelected && info.textClass)}>{info.label}</span>
+                </div>
+                <p className="text-[11px] text-muted-foreground line-clamp-2">{info.descripcion}</p>
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      {/* Identidad */}
+      <div className="space-y-3 rounded-xl border border-border/40 bg-card/40 p-4">
+        <div className="flex items-end gap-3">
+          <div className="space-y-1.5">
+            <Label>Emoji</Label>
+            <EmojiPickerButton value={emoji} onChange={setEmoji} size="md" />
+          </div>
+          <div className="flex-1 space-y-1.5">
+            <Label htmlFor="contacto-nombre">Nombre *</Label>
+            <Input
+              id="contacto-nombre"
+              value={nombre}
+              onChange={(e) => setNombre(e.target.value)}
+              placeholder={tipo === "proveedor" ? "Mercadona, Luz García SL…" : tipo === "persona_mcm" ? "Juan Pérez" : "Familia López"}
+              required
+              autoFocus
+            />
+          </div>
+        </div>
+        <div className="space-y-1.5">
+          <Label>Color</Label>
+          <ColorPicker value={color} onChange={setColor} />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="contacto-id-fiscal">CIF / NIF / DNI</Label>
+          <Input
+            id="contacto-id-fiscal"
+            value={identificadorFiscal}
+            onChange={(e) => setIdentificadorFiscal(e.target.value)}
+            placeholder="B12345678 · 12345678X"
+          />
+        </div>
+
+        {canManageGlobal && (
+          <label className="flex items-start gap-2 rounded-lg border border-border/40 bg-background/60 p-3 cursor-pointer">
+            <Checkbox checked={esGlobal} onCheckedChange={(v) => setEsGlobal(Boolean(v))} />
+            <div className="flex-1">
+              <div className="flex items-center gap-2 text-sm font-medium">
+                <Globe className="h-3.5 w-3.5" />
+                Contacto global
+              </div>
+              <p className="text-[11px] text-muted-foreground mt-0.5">
+                Compartido por todas las delegaciones. Solo los gestores centrales pueden crearlos o editarlos.
+              </p>
+            </div>
+          </label>
+        )}
+      </div>
+
+      {/* Contacto */}
+      <div className="space-y-3 rounded-xl border border-border/40 bg-card/40 p-4">
+        <div className="space-y-1.5">
+          <Label htmlFor="contacto-email">Email</Label>
+          <div className="flex gap-2">
+            <Input
+              id="contacto-email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="hola@ejemplo.com"
+            />
+            {email && (
+              <Button type="button" variant="outline" size="icon" onClick={() => copy(email.trim())} title="Copiar email">
+                <Copy className={cn("h-4 w-4", isCopied(email.trim()) && "text-green-600")} />
+              </Button>
+            )}
+          </div>
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="contacto-telefono">Teléfono</Label>
+          <div className="flex gap-2">
+            <Input
+              id="contacto-telefono"
+              type="tel"
+              value={telefono}
+              onChange={(e) => setTelefono(e.target.value)}
+              placeholder="+34 600 000 000"
+            />
+            {telefono && (
+              <Button type="button" variant="outline" size="icon" onClick={() => copy(telefono.trim())} title="Copiar teléfono">
+                <Copy className={cn("h-4 w-4", isCopied(telefono.trim()) && "text-green-600")} />
+              </Button>
+            )}
+          </div>
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="contacto-iban">IBAN</Label>
+          <div className="flex gap-2">
+            <Input
+              id="contacto-iban"
+              value={iban}
+              onChange={(e) => setIban(e.target.value)}
+              onBlur={() => setIban(formatearIban(iban))}
+              placeholder="ES91 2100 0418 4502 0005 1332"
+              className={cn(!ibanValido && "border-red-500 focus-visible:ring-red-500/30")}
+            />
+            {ibanNormalizado && (
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                onClick={() => copy(ibanNormalizado)}
+                title="Copiar IBAN"
+              >
+                <Copy className={cn("h-4 w-4", isCopied(ibanNormalizado) && "text-green-600")} />
+              </Button>
+            )}
+          </div>
+          {iban && !ibanValido && (
+            <p className="text-[11px] text-red-600">El dígito de control no cuadra. Revísalo o déjalo vacío.</p>
+          )}
+        </div>
+      </div>
+
+      {/* Dirección colapsable */}
+      <div className="rounded-xl border border-border/40 bg-card/40">
+        <button
+          type="button"
+          onClick={() => setDireccionAbierta((v) => !v)}
+          className="flex w-full items-center justify-between px-4 py-3 text-sm font-medium hover:bg-accent/40 transition-colors"
+        >
+          <span className="flex items-center gap-2 text-muted-foreground">
+            <MapPin className="h-4 w-4" /> Dirección postal (opcional)
+          </span>
+          <ChevronDown className={cn("h-4 w-4 transition-transform", direccionAbierta && "rotate-180")} />
+        </button>
+        {direccionAbierta && (
+          <div className="space-y-3 px-4 pb-4">
+            <div className="space-y-1.5">
+              <Label htmlFor="contacto-direccion">Dirección</Label>
+              <Input
+                id="contacto-direccion"
+                value={direccion}
+                onChange={(e) => setDireccion(e.target.value)}
+                placeholder="Calle, número, piso…"
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5">
+                <Label htmlFor="contacto-ciudad">Ciudad</Label>
+                <Input
+                  id="contacto-ciudad"
+                  value={ciudad}
+                  onChange={(e) => setCiudad(e.target.value)}
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="contacto-cp">Código postal</Label>
+                <Input
+                  id="contacto-cp"
+                  value={codigoPostal}
+                  onChange={(e) => setCodigoPostal(e.target.value)}
+                />
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Categoría predeterminada */}
+      <div className="space-y-1.5">
+        <Label>Categoría sugerida (opcional)</Label>
+        <Select
+          value={categoriaPredeterminadaId}
+          onValueChange={(v) => setCategoriaPredeterminadaId(v as string | "ninguna")}
+        >
+          <SelectTrigger>
+            <SelectValue placeholder="Ninguna" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="ninguna">Ninguna</SelectItem>
+            {categorias.map((cat) => (
+              <SelectItem key={cat.id} value={cat.id}>
+                <span className="inline-flex items-center gap-2">
+                  <span>{cat.emoji ?? "🏷️"}</span>
+                  <span>{cat.nombre}</span>
+                </span>
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <p className="text-[11px] text-muted-foreground">
+          Se sugerirá automáticamente al crear un movimiento vinculado a este contacto.
+        </p>
+      </div>
+
+      {/* Notas */}
+      <div className="space-y-1.5">
+        <Label htmlFor="contacto-notas">Notas</Label>
+        <Textarea
+          id="contacto-notas"
+          value={notas}
+          onChange={(e) => setNotas(e.target.value)}
+          rows={3}
+          placeholder="Cualquier detalle útil sobre este contacto"
+        />
+      </div>
+
+      {/* Acciones */}
+      <div className="flex gap-3 pt-2">
+        <Button type="submit" disabled={loading} className="flex-1">
+          {loading ? "Guardando…" : isEdit ? "Actualizar contacto" : "Crear contacto"}
+        </Button>
+        <Button type="button" variant="outline" onClick={onCancel} className="flex-1" disabled={loading}>
+          Cancelar
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/components/contactos/contacto-form.tsx
+++ b/components/contactos/contacto-form.tsx
@@ -159,7 +159,7 @@ export function ContactoForm({
       {/* Selector de tipo */}
       <div className="space-y-2">
         <Label>Tipo de contacto *</Label>
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+        <div className="grid grid-cols-3 gap-2">
           {CONTACTO_TIPO_ORDER.map((t) => {
             const info = CONTACTO_TIPO_INFO[t]
             const isSelected = tipo === t
@@ -169,32 +169,37 @@ export function ContactoForm({
                 type="button"
                 onClick={() => setTipo(t)}
                 className={cn(
-                  "flex flex-col items-start gap-1 p-3 rounded-xl border-2 text-left transition-all",
+                  "flex flex-col items-start gap-1 p-3 rounded-xl border-2 text-left transition-all h-full",
                   isSelected
                     ? `${info.bgClass} ${info.borderClass} shadow-md`
                     : "border-border/40 bg-card hover:border-border",
                 )}
               >
-                <div className="flex items-center gap-2 font-semibold text-sm">
+                <div className="flex items-center gap-1.5 font-semibold text-sm">
                   <span>{info.emoji}</span>
-                  <span className={cn(isSelected && info.textClass)}>{info.label}</span>
+                  <span className={cn("leading-tight", isSelected && info.textClass)}>{info.label}</span>
                 </div>
-                <p className="text-[11px] text-muted-foreground line-clamp-2">{info.descripcion}</p>
+                <p className="text-[10px] text-muted-foreground leading-tight">{info.descripcion}</p>
               </button>
             )
           })}
         </div>
       </div>
 
+      {/* Contacto global (solo gestores centrales) */}
+      {canManageGlobal && (
+        <label className="flex items-center gap-2 cursor-pointer select-none">
+          <Checkbox checked={esGlobal} onCheckedChange={(v) => setEsGlobal(Boolean(v))} />
+          <Globe className="h-3.5 w-3.5 text-muted-foreground" />
+          <span className="text-sm text-muted-foreground">Contacto global (todas las delegaciones)</span>
+        </label>
+      )}
+
       {/* Identidad */}
       <div className="space-y-3 rounded-xl border border-border/40 bg-card/40 p-4">
-        <div className="flex items-end gap-3">
-          <div className="space-y-1.5">
-            <Label>Emoji</Label>
-            <EmojiPickerButton value={emoji} onChange={setEmoji} size="md" />
-          </div>
-          <div className="flex-1 space-y-1.5">
-            <Label htmlFor="contacto-nombre">Nombre *</Label>
+        <div className="space-y-1.5">
+          <Label htmlFor="contacto-nombre">Nombre *</Label>
+          <div className="flex items-center gap-1.5">
             <Input
               id="contacto-nombre"
               value={nombre}
@@ -202,12 +207,11 @@ export function ContactoForm({
               placeholder={tipo === "proveedor" ? "Mercadona, Luz García SL…" : tipo === "persona_mcm" ? "Juan Pérez" : "Familia López"}
               required
               autoFocus
+              className="flex-1"
             />
+            <EmojiPickerButton value={emoji} onChange={setEmoji} size="sm" />
+            <ColorPicker value={color} onChange={setColor} className="h-8 w-8" />
           </div>
-        </div>
-        <div className="space-y-1.5">
-          <Label>Color</Label>
-          <ColorPicker value={color} onChange={setColor} />
         </div>
         <div className="space-y-1.5">
           <Label htmlFor="contacto-id-fiscal">CIF / NIF / DNI</Label>
@@ -218,25 +222,37 @@ export function ContactoForm({
             placeholder="B12345678 · 12345678X"
           />
         </div>
-
-        {canManageGlobal && (
-          <label className="flex items-start gap-2 rounded-lg border border-border/40 bg-background/60 p-3 cursor-pointer">
-            <Checkbox checked={esGlobal} onCheckedChange={(v) => setEsGlobal(Boolean(v))} />
-            <div className="flex-1">
-              <div className="flex items-center gap-2 text-sm font-medium">
-                <Globe className="h-3.5 w-3.5" />
-                Contacto global
-              </div>
-              <p className="text-[11px] text-muted-foreground mt-0.5">
-                Compartido por todas las delegaciones. Solo los gestores centrales pueden crearlos o editarlos.
-              </p>
-            </div>
-          </label>
-        )}
       </div>
 
       {/* Contacto */}
       <div className="space-y-3 rounded-xl border border-border/40 bg-card/40 p-4">
+        <div className="space-y-1.5">
+          <Label htmlFor="contacto-iban">IBAN</Label>
+          <div className="flex gap-2">
+            <Input
+              id="contacto-iban"
+              value={iban}
+              onChange={(e) => setIban(e.target.value)}
+              onBlur={() => setIban(formatearIban(iban))}
+              placeholder="ES91 2100 0418 4502 0005 1332"
+              className={cn(!ibanValido && "border-red-500 focus-visible:ring-red-500/30")}
+            />
+            {ibanNormalizado && (
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                onClick={() => copy(ibanNormalizado)}
+                title="Copiar IBAN"
+              >
+                <Copy className={cn("h-4 w-4", isCopied(ibanNormalizado) && "text-green-600")} />
+              </Button>
+            )}
+          </div>
+          {iban && !ibanValido && (
+            <p className="text-[11px] text-red-600">El dígito de control no cuadra. Revísalo o déjalo vacío.</p>
+          )}
+        </div>
         <div className="space-y-1.5">
           <Label htmlFor="contacto-email">Email</Label>
           <div className="flex gap-2">
@@ -270,33 +286,6 @@ export function ContactoForm({
               </Button>
             )}
           </div>
-        </div>
-        <div className="space-y-1.5">
-          <Label htmlFor="contacto-iban">IBAN</Label>
-          <div className="flex gap-2">
-            <Input
-              id="contacto-iban"
-              value={iban}
-              onChange={(e) => setIban(e.target.value)}
-              onBlur={() => setIban(formatearIban(iban))}
-              placeholder="ES91 2100 0418 4502 0005 1332"
-              className={cn(!ibanValido && "border-red-500 focus-visible:ring-red-500/30")}
-            />
-            {ibanNormalizado && (
-              <Button
-                type="button"
-                variant="outline"
-                size="icon"
-                onClick={() => copy(ibanNormalizado)}
-                title="Copiar IBAN"
-              >
-                <Copy className={cn("h-4 w-4", isCopied(ibanNormalizado) && "text-green-600")} />
-              </Button>
-            )}
-          </div>
-          {iban && !ibanValido && (
-            <p className="text-[11px] text-red-600">El dígito de control no cuadra. Revísalo o déjalo vacío.</p>
-          )}
         </div>
       </div>
 

--- a/components/contactos/contacto-selector.tsx
+++ b/components/contactos/contacto-selector.tsx
@@ -74,7 +74,11 @@ export function ContactoSelector({
           role="combobox"
           aria-expanded={open}
           disabled={disabled || loading}
-          className={cn("w-full justify-between font-normal", !selected && "text-muted-foreground", className)}
+          className={cn(
+            "w-full justify-between font-normal bg-background border-border hover:bg-muted/50 h-9",
+            !selected && "text-muted-foreground",
+            className,
+          )}
         >
           <span className="flex items-center gap-2 truncate">
             {selected ? (
@@ -101,7 +105,7 @@ export function ContactoSelector({
           <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
+      <PopoverContent className="w-[--radix-popover-trigger-width] p-0 z-[80]" align="start">
         <Command>
           <CommandInput
             placeholder="Buscar contacto…"

--- a/components/contactos/contacto-selector.tsx
+++ b/components/contactos/contacto-selector.tsx
@@ -1,0 +1,193 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import { Check, ChevronsUpDown, Plus, Users, X } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@/components/ui/command"
+import { cn } from "@/lib/utils"
+import { CONTACTO_TIPO_INFO, CONTACTO_TIPO_ORDER } from "@/lib/utils/contacto-tipos"
+import type { ContactoConCategoriaPredeterminada, ContactoTipo } from "@/lib/types/database"
+
+interface ContactoSelectorProps {
+  contactos: ContactoConCategoriaPredeterminada[]
+  value?: string | null
+  onChange: (contactoId: string | null) => void
+  onCreateNew?: (initialNombre: string) => void
+  placeholder?: string
+  disabled?: boolean
+  loading?: boolean
+  className?: string
+}
+
+export function ContactoSelector({
+  contactos,
+  value,
+  onChange,
+  onCreateNew,
+  placeholder = "Sin contacto",
+  disabled,
+  loading,
+  className,
+}: ContactoSelectorProps) {
+  const [open, setOpen] = useState(false)
+  const [search, setSearch] = useState("")
+
+  const selected = useMemo(
+    () => (value ? contactos.find((c) => c.id === value) ?? null : null),
+    [value, contactos],
+  )
+
+  const grouped = useMemo(() => {
+    const result: Record<ContactoTipo, ContactoConCategoriaPredeterminada[]> = {
+      proveedor: [],
+      persona_mcm: [],
+      destinatario_mcm: [],
+    }
+    for (const c of contactos) {
+      if (c.archivado) continue
+      result[c.tipo].push(c)
+    }
+    return result
+  }, [contactos])
+
+  const trimmedSearch = search.trim()
+  const hasExactMatch = useMemo(
+    () => contactos.some((c) => c.nombre.toLowerCase() === trimmedSearch.toLowerCase()),
+    [contactos, trimmedSearch],
+  )
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          disabled={disabled || loading}
+          className={cn("w-full justify-between font-normal", !selected && "text-muted-foreground", className)}
+        >
+          <span className="flex items-center gap-2 truncate">
+            {selected ? (
+              <>
+                <span aria-hidden>{selected.emoji ?? CONTACTO_TIPO_INFO[selected.tipo].emoji}</span>
+                <span className="truncate">{selected.nombre}</span>
+                <span
+                  className={cn(
+                    "rounded-full px-1.5 py-0.5 text-[10px] uppercase tracking-wide",
+                    CONTACTO_TIPO_INFO[selected.tipo].bgClass,
+                    CONTACTO_TIPO_INFO[selected.tipo].textClass,
+                  )}
+                >
+                  {CONTACTO_TIPO_INFO[selected.tipo].shortLabel}
+                </span>
+              </>
+            ) : (
+              <>
+                <Users className="h-3.5 w-3.5" />
+                <span>{placeholder}</span>
+              </>
+            )}
+          </span>
+          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
+        <Command>
+          <CommandInput
+            placeholder="Buscar contacto…"
+            value={search}
+            onValueChange={setSearch}
+          />
+          <CommandList>
+            <CommandEmpty>Sin resultados.</CommandEmpty>
+
+            {value && (
+              <CommandGroup>
+                <CommandItem
+                  value="__limpiar__"
+                  onSelect={() => {
+                    onChange(null)
+                    setOpen(false)
+                  }}
+                >
+                  <X className="mr-2 h-4 w-4 text-muted-foreground" />
+                  Quitar contacto
+                </CommandItem>
+              </CommandGroup>
+            )}
+
+            {CONTACTO_TIPO_ORDER.map((tipo) => {
+              const items = grouped[tipo]
+              if (items.length === 0) return null
+              const info = CONTACTO_TIPO_INFO[tipo]
+              return (
+                <CommandGroup key={tipo} heading={`${info.emoji} ${info.label}`}>
+                  {items.map((c) => {
+                    const isSelected = c.id === value
+                    const searchValue = `${c.nombre} ${c.email ?? ""} ${c.identificador_fiscal ?? ""} ${c.iban ?? ""}`
+                    return (
+                      <CommandItem
+                        key={c.id}
+                        value={`${c.id}__${searchValue}`}
+                        onSelect={() => {
+                          onChange(c.id)
+                          setOpen(false)
+                        }}
+                      >
+                        <span className="mr-2">{c.emoji ?? info.emoji}</span>
+                        <div className="flex-1 truncate">
+                          <div className="truncate font-medium">{c.nombre}</div>
+                          {(c.email || c.identificador_fiscal) && (
+                            <div className="truncate text-[11px] text-muted-foreground">
+                              {c.identificador_fiscal ?? c.email}
+                            </div>
+                          )}
+                        </div>
+                        {c.es_global && (
+                          <span className="ml-2 rounded-full bg-muted px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">
+                            Global
+                          </span>
+                        )}
+                        <Check className={cn("ml-2 h-4 w-4", isSelected ? "opacity-100" : "opacity-0")} />
+                      </CommandItem>
+                    )
+                  })}
+                </CommandGroup>
+              )
+            })}
+
+            {onCreateNew && (
+              <>
+                <CommandSeparator />
+                <CommandGroup>
+                  <CommandItem
+                    value={`__crear__${trimmedSearch}`}
+                    onSelect={() => {
+                      onCreateNew(trimmedSearch)
+                      setOpen(false)
+                    }}
+                  >
+                    <Plus className="mr-2 h-4 w-4" />
+                    {trimmedSearch && !hasExactMatch
+                      ? `Crear contacto "${trimmedSearch}"`
+                      : "Crear nuevo contacto…"}
+                  </CommandItem>
+                </CommandGroup>
+              </>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/components/contactos/contacto-tipo-badge.tsx
+++ b/components/contactos/contacto-tipo-badge.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import { cn } from "@/lib/utils"
+import { getContactoTipoInfo } from "@/lib/utils/contacto-tipos"
+import type { ContactoTipo } from "@/lib/types/database"
+
+interface ContactoTipoBadgeProps {
+  tipo: ContactoTipo
+  size?: "sm" | "md"
+  short?: boolean
+  className?: string
+}
+
+export function ContactoTipoBadge({ tipo, size = "md", short = false, className }: ContactoTipoBadgeProps) {
+  const info = getContactoTipoInfo(tipo)
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full border font-medium",
+        info.bgClass,
+        info.textClass,
+        info.borderClass,
+        size === "sm" ? "px-1.5 py-0.5 text-[10px]" : "px-2 py-0.5 text-xs",
+        className,
+      )}
+    >
+      <span aria-hidden>{info.emoji}</span>
+      <span>{short ? info.shortLabel : info.label}</span>
+    </span>
+  )
+}

--- a/components/contactos/contactos-manager.tsx
+++ b/components/contactos/contactos-manager.tsx
@@ -1,0 +1,424 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import {
+  Archive,
+  ArchiveRestore,
+  Copy,
+  Edit3,
+  Globe,
+  Loader2,
+  Plus,
+  Search,
+  Trash2,
+  Users,
+} from "lucide-react"
+import { toast } from "sonner"
+import { Card, CardContent } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { EmptyState } from "@/components/ui/empty-state"
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet"
+import { cn } from "@/lib/utils"
+import { useDelegationContext } from "@/contexts/delegation-context"
+import { useCategorias } from "@/hooks/use-categorias"
+import { useContactos } from "@/hooks/use-contactos"
+import { useDelegationRole } from "@/hooks/use-delegation-role"
+import useIsAdmin from "@/hooks/use-is-admin"
+import { useAuth } from "@/contexts/auth-context"
+import { useClipboard } from "@/hooks/use-clipboard"
+import { useDebouncedState } from "@/hooks/use-debounced-state"
+import { CONTACTO_TIPO_INFO, CONTACTO_TIPO_ORDER } from "@/lib/utils/contacto-tipos"
+import { formatearIban } from "@/lib/utils/iban"
+import type { ContactoConCategoriaPredeterminada, ContactoTipo } from "@/lib/types/database"
+import { ContactoForm, type ContactoFormSubmitPayload } from "./contacto-form"
+import { ContactoDetailSheet } from "./contacto-detail-sheet"
+import { ContactoTipoBadge } from "./contacto-tipo-badge"
+import { DeleteContactoDialog } from "./delete-contacto-dialog"
+
+type TabValue = "todos" | ContactoTipo
+
+export function ContactosManager() {
+  const { selectedDelegation } = useDelegationContext()
+  const { user } = useAuth()
+  const isAdmin = useIsAdmin()
+  const { role } = useDelegationRole(selectedDelegation)
+  const canEdit = role === "gestor_central" || role === "administrador" || isAdmin
+  const canManageGlobal = isAdmin
+
+  const [tab, setTab] = useState<TabValue>("todos")
+  const [incluirArchivados, setIncluirArchivados] = useState(false)
+  const { value: busquedaDebounced, immediateValue: busqueda, setValue: setBusqueda } = useDebouncedState("", 250)
+
+  const {
+    contactos,
+    loading,
+    error,
+    counts,
+    createContacto,
+    updateContacto,
+    deleteContacto,
+    archiveContacto,
+  } = useContactos(selectedDelegation, {
+    busqueda: busquedaDebounced || undefined,
+    incluirArchivados,
+  })
+
+  const { categorias } = useCategorias(selectedDelegation, { includeGlobal: true, includeInactive: false })
+
+  const [formOpen, setFormOpen] = useState(false)
+  const [editing, setEditing] = useState<ContactoConCategoriaPredeterminada | null>(null)
+  const [detailId, setDetailId] = useState<string | null>(null)
+  const [detailOpen, setDetailOpen] = useState(false)
+  const [deleting, setDeleting] = useState<ContactoConCategoriaPredeterminada | null>(null)
+
+  const filtered = useMemo(() => {
+    if (tab === "todos") return contactos
+    return contactos.filter((c) => c.tipo === tab)
+  }, [contactos, tab])
+
+  const handleSubmitForm = async (payload: ContactoFormSubmitPayload) => {
+    if (editing) {
+      if (!payload.update) return
+      await updateContacto(editing.id, payload.update)
+      return undefined
+    }
+    if (!payload.insert) return
+    return await createContacto({ ...payload.insert, creado_por: user?.id ?? null })
+  }
+
+  const openCreate = (tipo?: ContactoTipo) => {
+    setEditing(null)
+    setFormOpen(true)
+    if (tipo) setTab(tipo)
+  }
+  const openEdit = (c: ContactoConCategoriaPredeterminada) => {
+    setEditing(c)
+    setFormOpen(true)
+    setDetailOpen(false)
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div className="space-y-2">
+          <div className="flex items-center gap-3">
+            <div className="h-10 w-2 rounded-full bg-gradient-to-b from-primary via-primary/70 to-primary/40 shadow-lg shadow-primary/30" />
+            <h1 className="text-3xl font-extrabold sm:text-4xl bg-gradient-to-r from-foreground via-foreground/90 to-foreground/70 bg-clip-text">
+              Contactos
+            </h1>
+          </div>
+          <p className="ml-5 max-w-2xl pl-4 text-sm text-muted-foreground">
+            Tu agenda para los movimientos: proveedores, personas MCM (socios, voluntarios) y destinatarios. Guarda IBAN, teléfono y notas, y vincúlalos a los movimientos.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setIncluirArchivados((v) => !v)}
+            className={cn(incluirArchivados && "bg-amber-100/40 dark:bg-amber-950/30")}
+          >
+            <Archive className="mr-1.5 h-3.5 w-3.5" />
+            {incluirArchivados ? "Ocultar archivados" : "Ver archivados"}
+          </Button>
+          {canEdit && (
+            <Button onClick={() => openCreate()}>
+              <Plus className="mr-1.5 h-4 w-4" /> Nuevo contacto
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {/* Tipo tabs */}
+      <Tabs value={tab} onValueChange={(v) => setTab(v as TabValue)}>
+        <TabsList className="w-full max-w-2xl grid grid-cols-4">
+          <TabsTrigger value="todos">
+            Todos
+            {counts.total > 0 && <span className="ml-1.5 text-[10px] text-muted-foreground">{counts.total}</span>}
+          </TabsTrigger>
+          {CONTACTO_TIPO_ORDER.map((t) => {
+            const info = CONTACTO_TIPO_INFO[t]
+            const n = counts[t]
+            return (
+              <TabsTrigger key={t} value={t}>
+                <span className="mr-1">{info.emoji}</span>
+                <span className="hidden sm:inline">{info.shortLabel}</span>
+                {n > 0 && <span className="ml-1.5 text-[10px] text-muted-foreground">{n}</span>}
+              </TabsTrigger>
+            )
+          })}
+        </TabsList>
+      </Tabs>
+
+      {/* Buscador */}
+      <div className="relative max-w-xl">
+        <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          value={busqueda}
+          onChange={(e) => setBusqueda(e.target.value)}
+          placeholder="Buscar por nombre, email, teléfono, CIF/NIF o IBAN…"
+          className="pl-9"
+        />
+      </div>
+
+      {/* Lista */}
+      {loading && contactos.length === 0 ? (
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" /> Cargando contactos…
+        </div>
+      ) : error ? (
+        <EmptyState title="No se pudieron cargar los contactos" description={error} />
+      ) : filtered.length === 0 ? (
+        <EmptyState
+          icon={<Users className="h-6 w-6" />}
+          title={tab === "todos" ? "Aún no hay contactos" : "Sin contactos de este tipo"}
+          description={
+            tab === "todos"
+              ? "Crea tu primer contacto para vincularlo a los movimientos y tener su IBAN y datos a mano."
+              : `Crea el primer contacto de tipo "${CONTACTO_TIPO_INFO[tab as ContactoTipo].label}".`
+          }
+        >
+          {canEdit && (
+            <Button onClick={() => openCreate(tab === "todos" ? undefined : (tab as ContactoTipo))}>
+              <Plus className="mr-1.5 h-4 w-4" /> Crear contacto
+            </Button>
+          )}
+        </EmptyState>
+      ) : (
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
+          {filtered.map((c) => (
+            <ContactoCard
+              key={c.id}
+              contacto={c}
+              canEdit={canEdit && (!c.es_global || canManageGlobal)}
+              onOpen={() => {
+                setDetailId(c.id)
+                setDetailOpen(true)
+              }}
+              onEdit={() => openEdit(c)}
+              onDelete={() => setDeleting(c)}
+              onArchive={() => archiveContacto(c.id, !c.archivado)}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Form sheet */}
+      <Sheet open={formOpen} onOpenChange={setFormOpen}>
+        <SheetContent side="right" className="w-full sm:max-w-xl overflow-y-auto">
+          <SheetHeader className="mb-2">
+            <SheetTitle>{editing ? "Editar contacto" : "Nuevo contacto"}</SheetTitle>
+          </SheetHeader>
+          <ContactoForm
+            delegacionId={selectedDelegation}
+            contacto={editing}
+            categorias={categorias}
+            canManageGlobal={canManageGlobal}
+            defaultTipo={tab === "todos" ? "proveedor" : (tab as ContactoTipo)}
+            onSubmit={handleSubmitForm}
+            onCancel={() => setFormOpen(false)}
+            onSaved={() => setFormOpen(false)}
+          />
+        </SheetContent>
+      </Sheet>
+
+      {/* Detail */}
+      <ContactoDetailSheet
+        contactoId={detailId}
+        open={detailOpen}
+        onOpenChange={setDetailOpen}
+        canEdit={canEdit}
+        onEdit={(c) => openEdit(c)}
+        onArchive={(c) => archiveContacto(c.id, !c.archivado).then(() => toast.success(c.archivado ? "Desarchivado" : "Archivado"))}
+        onDelete={(c) => {
+          setDetailOpen(false)
+          setDeleting(c)
+        }}
+      />
+
+      {/* Delete dialog */}
+      <DeleteContactoDialog
+        contacto={deleting}
+        open={Boolean(deleting)}
+        onOpenChange={(open) => !open && setDeleting(null)}
+        onDelete={async (id) => {
+          await deleteContacto(id)
+          setDeleting(null)
+        }}
+        onArchive={async (id) => {
+          await archiveContacto(id, true)
+          setDeleting(null)
+        }}
+      />
+    </div>
+  )
+}
+
+function ContactoCard({
+  contacto,
+  canEdit,
+  onOpen,
+  onEdit,
+  onDelete,
+  onArchive,
+}: {
+  contacto: ContactoConCategoriaPredeterminada
+  canEdit: boolean
+  onOpen: () => void
+  onEdit: () => void
+  onDelete: () => void
+  onArchive: () => void
+}) {
+  const info = CONTACTO_TIPO_INFO[contacto.tipo]
+  const { copy, isCopied } = useClipboard()
+
+  const handleCopy = async (e: React.MouseEvent, value: string | null | undefined, label: string) => {
+    e.stopPropagation()
+    if (!value) return
+    const ok = await copy(value)
+    if (ok) toast.success(`${label} copiado`)
+  }
+
+  return (
+    <Card
+      className={cn(
+        "cursor-pointer transition-all hover:shadow-md hover:-translate-y-0.5",
+        contacto.archivado && "opacity-60",
+      )}
+      onClick={onOpen}
+    >
+      <CardContent className="p-4 space-y-3">
+        <div className="flex items-start gap-3">
+          <div
+            className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl text-xl shadow-sm"
+            style={{ backgroundColor: contacto.color ?? info.color }}
+            aria-hidden
+          >
+            {contacto.emoji ?? info.emoji}
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="truncate font-semibold">{contacto.nombre}</div>
+            <div className="mt-0.5 flex flex-wrap items-center gap-1">
+              <ContactoTipoBadge tipo={contacto.tipo} size="sm" short />
+              {contacto.es_global && (
+                <span className="inline-flex items-center gap-1 rounded-full bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+                  <Globe className="h-2.5 w-2.5" /> Global
+                </span>
+              )}
+              {contacto.archivado && (
+                <span className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-1.5 py-0.5 text-[10px] text-amber-700 dark:bg-amber-950/40 dark:text-amber-300">
+                  <Archive className="h-2.5 w-2.5" /> Archivado
+                </span>
+              )}
+            </div>
+            {contacto.identificador_fiscal && (
+              <div className="mt-0.5 truncate text-[11px] text-muted-foreground">{contacto.identificador_fiscal}</div>
+            )}
+          </div>
+        </div>
+
+        <div className="space-y-1 text-xs">
+          {contacto.iban && (
+            <CopyChip
+              label="IBAN"
+              value={formatearIban(contacto.iban)}
+              copyValue={contacto.iban}
+              copied={isCopied(contacto.iban)}
+              onCopy={(e) => handleCopy(e, contacto.iban, "IBAN")}
+              mono
+            />
+          )}
+          {contacto.email && (
+            <CopyChip
+              label="Email"
+              value={contacto.email}
+              copied={isCopied(contacto.email)}
+              onCopy={(e) => handleCopy(e, contacto.email, "Email")}
+            />
+          )}
+          {contacto.telefono && (
+            <CopyChip
+              label="Tel"
+              value={contacto.telefono}
+              copied={isCopied(contacto.telefono)}
+              onCopy={(e) => handleCopy(e, contacto.telefono, "Teléfono")}
+            />
+          )}
+        </div>
+
+        {canEdit && (
+          <div className="flex justify-end gap-1 pt-1">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 px-2"
+              onClick={(e) => {
+                e.stopPropagation()
+                onEdit()
+              }}
+            >
+              <Edit3 className="h-3.5 w-3.5" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 px-2"
+              onClick={(e) => {
+                e.stopPropagation()
+                onArchive()
+              }}
+              title={contacto.archivado ? "Desarchivar" : "Archivar"}
+            >
+              {contacto.archivado ? <ArchiveRestore className="h-3.5 w-3.5" /> : <Archive className="h-3.5 w-3.5" />}
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 px-2 text-destructive hover:text-destructive"
+              onClick={(e) => {
+                e.stopPropagation()
+                onDelete()
+              }}
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function CopyChip({
+  label,
+  value,
+  copyValue,
+  copied,
+  onCopy,
+  mono,
+}: {
+  label: string
+  value: string
+  copyValue?: string
+  copied: boolean
+  onCopy: (e: React.MouseEvent) => void
+  mono?: boolean
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onCopy}
+      className={cn(
+        "flex w-full items-center gap-2 rounded-md border border-transparent bg-muted/40 px-2 py-1 text-left transition-colors hover:border-border/40 hover:bg-muted",
+        copied && "bg-green-50 border-green-200 dark:bg-green-950/30 dark:border-green-900",
+      )}
+    >
+      <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">{label}</span>
+      <span className={cn("flex-1 truncate", mono && "font-mono")}>{value}</span>
+      <Copy className={cn("h-3 w-3 shrink-0", copied ? "text-green-600" : "text-muted-foreground")} />
+    </button>
+  )
+}

--- a/components/contactos/delete-contacto-dialog.tsx
+++ b/components/contactos/delete-contacto-dialog.tsx
@@ -1,0 +1,101 @@
+"use client"
+
+import { useState } from "react"
+import { toast } from "sonner"
+import { AlertTriangle, Archive } from "lucide-react"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import type { Contacto } from "@/lib/types/database"
+
+interface DeleteContactoDialogProps {
+  contacto: Contacto | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onDelete: (id: string) => Promise<void>
+  onArchive?: (id: string) => Promise<void>
+}
+
+export function DeleteContactoDialog({ contacto, open, onOpenChange, onDelete, onArchive }: DeleteContactoDialogProps) {
+  const [busy, setBusy] = useState(false)
+
+  if (!contacto) return null
+
+  const handleDelete = async () => {
+    setBusy(true)
+    try {
+      await onDelete(contacto.id)
+      toast.success("Contacto eliminado")
+      onOpenChange(false)
+    } catch (err) {
+      toast.error("No se pudo eliminar: " + (err instanceof Error ? err.message : "error desconocido"))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleArchive = async () => {
+    if (!onArchive) return
+    setBusy(true)
+    try {
+      await onArchive(contacto.id)
+      toast.success("Contacto archivado")
+      onOpenChange(false)
+    } catch (err) {
+      toast.error("No se pudo archivar: " + (err instanceof Error ? err.message : "error desconocido"))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => !busy && onOpenChange(v)}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <AlertTriangle className="h-5 w-5 text-amber-500" />
+            Eliminar contacto
+          </DialogTitle>
+          <DialogDescription>
+            Esta acción no se puede deshacer. Los movimientos vinculados se mantienen pero pierden el contacto.
+          </DialogDescription>
+        </DialogHeader>
+
+        <Alert>
+          <AlertDescription>
+            <span className="font-semibold">{contacto.emoji ?? "👤"} {contacto.nombre}</span>
+          </AlertDescription>
+        </Alert>
+
+        {onArchive && !contacto.archivado && (
+          <Alert className="border-amber-300/50 bg-amber-50/60 dark:bg-amber-950/30">
+            <AlertDescription className="text-xs">
+              💡 Si quieres conservar el histórico, puedes <strong>archivarlo</strong> en lugar de borrarlo. Dejará de aparecer en listas pero seguirá disponible en los movimientos antiguos.
+            </AlertDescription>
+          </Alert>
+        )}
+
+        <DialogFooter className="gap-2 sm:gap-2">
+          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={busy}>
+            Cancelar
+          </Button>
+          {onArchive && !contacto.archivado && (
+            <Button variant="outline" onClick={handleArchive} disabled={busy}>
+              <Archive className="mr-2 h-4 w-4" /> Archivar
+            </Button>
+          )}
+          <Button variant="destructive" onClick={handleDelete} disabled={busy}>
+            {busy ? "Procesando…" : "Eliminar definitivamente"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -88,8 +88,8 @@ function SidebarContent({ className, collapsed = false, counts, countsLoading }:
       name: "Contactos",
       href: "/contactos",
       icon: Users,
-      count: null,
-      enabled: false,
+      count: getCountBadge(counts.contactos),
+      enabled: true,
     },
     ...(isAdmin
       ? [

--- a/components/transactions/transaction-create-panel.tsx
+++ b/components/transactions/transaction-create-panel.tsx
@@ -18,11 +18,18 @@ import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sh
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { CategorySelector } from "./category-selector"
 import { BankAvatar } from "@/components/bank-avatar"
-import type { Movimiento, Cuenta, Categoria } from "@/lib/types/database"
+import { ContactoSelector } from "@/components/contactos/contacto-selector"
+import { ContactoForm } from "@/components/contactos/contacto-form"
+import { CONTACTO_TIPO_INFO } from "@/lib/utils/contacto-tipos"
+import type { Contacto, ContactoConCategoriaPredeterminada, Movimiento, Cuenta, Categoria } from "@/lib/types/database"
 
 interface TransactionCreatePanelProps {
   accounts: Cuenta[]
   categories: Categoria[]
+  contactos?: ContactoConCategoriaPredeterminada[]
+  delegacionId?: string | null
+  canManageGlobalContact?: boolean
+  onCreateContacto?: (payload: Parameters<NonNullable<React.ComponentProps<typeof ContactoForm>["onSubmit"]>>[0]) => Promise<Contacto | void>
   open: boolean
   onOpenChange: (open: boolean) => void
   onCreate: (data: Partial<Movimiento>) => Promise<void>
@@ -31,6 +38,10 @@ interface TransactionCreatePanelProps {
 export function TransactionCreatePanel({
   accounts,
   categories,
+  contactos = [],
+  delegacionId,
+  canManageGlobalContact,
+  onCreateContacto,
   open,
   onOpenChange,
   onCreate,
@@ -41,12 +52,14 @@ export function TransactionCreatePanel({
     fecha: format(new Date(), "yyyy-MM-dd"),
     descripcion: "",
     categoria_id: "",
-    contraparte: "",
+    contacto_id: null,
     cuenta_id: "",
   })
   const [dateOpen, setDateOpen] = useState(false)
   const [isCreating, setIsCreating] = useState(false)
   const [dateInput, setDateInput] = useState(() => formatIsoDateToInput(format(new Date(), "yyyy-MM-dd")))
+  const [contactoCreateOpen, setContactoCreateOpen] = useState(false)
+  const [contactoInitialNombre, setContactoInitialNombre] = useState("")
 
   const isFormValid = 
     formData.concepto?.trim() && 
@@ -69,9 +82,9 @@ export function TransactionCreatePanel({
         ...formData,
         // Ensure nullable UUIDs are not sent as empty strings
         categoria_id: formData.categoria_id || null,
+        contacto_id: formData.contacto_id || null,
         concepto: formData.concepto?.trim(),
         descripcion: formData.descripcion?.trim() || "",
-        contraparte: formData.contraparte?.trim() || "",
       })
       // Reset form
       const initialDate = format(new Date(), "yyyy-MM-dd")
@@ -81,7 +94,7 @@ export function TransactionCreatePanel({
         fecha: initialDate,
         descripcion: "",
         categoria_id: "",
-        contraparte: "",
+        contacto_id: null,
         cuenta_id: "",
       })
       setDateInput(formatIsoDateToInput(initialDate))
@@ -103,7 +116,7 @@ export function TransactionCreatePanel({
       fecha: initialDate,
       descripcion: "",
       categoria_id: "",
-      contraparte: "",
+      contacto_id: null,
       cuenta_id: "",
     })
     setDateInput(formatIsoDateToInput(initialDate))
@@ -354,12 +367,43 @@ export function TransactionCreatePanel({
           {/* Contact */}
           <div className="space-y-3">
             <Label className="text-sm font-medium text-muted-foreground">CONTACTO</Label>
-            <Input
-              value={formData.contraparte || ""}
-              onChange={(e) => setFormData({ ...formData, contraparte: e.target.value })}
-              placeholder="Proveedor, cliente u otros (sin uso todavía)"
-              className="bg-muted/30"
+            <ContactoSelector
+              contactos={contactos}
+              value={formData.contacto_id ?? null}
+              onChange={(contactoId) => {
+                setFormData((prev) => {
+                  const next: Partial<Movimiento> = { ...prev, contacto_id: contactoId }
+                  if (contactoId && !prev.categoria_id) {
+                    const c = contactos.find((x) => x.id === contactoId)
+                    if (c?.categoria_id_predeterminada) {
+                      next.categoria_id = c.categoria_id_predeterminada
+                    }
+                  }
+                  return next
+                })
+              }}
+              onCreateNew={
+                onCreateContacto
+                  ? (initialNombre) => {
+                      setContactoInitialNombre(initialNombre)
+                      setContactoCreateOpen(true)
+                    }
+                  : undefined
+              }
+              placeholder="Sin contacto"
             />
+            {formData.contacto_id && (() => {
+              const c = contactos.find((x) => x.id === formData.contacto_id)
+              if (!c) return null
+              return (
+                <p className="text-[11px] text-muted-foreground">
+                  Tipo: <span className="font-medium">{CONTACTO_TIPO_INFO[c.tipo].label}</span>
+                  {c.categoria_id_predeterminada && !formData.categoria_id && (
+                    <span> · Te sugerimos su categoría por defecto</span>
+                  )}
+                </p>
+              )
+            })()}
           </div>
         </div>
 
@@ -397,6 +441,32 @@ export function TransactionCreatePanel({
         {/* Spacer for mobile fixed buttons */}
         <div className="h-20 sm:hidden"></div>
       </SheetContent>
+
+      {onCreateContacto && (
+        <Sheet open={contactoCreateOpen} onOpenChange={setContactoCreateOpen}>
+          <SheetContent side="right" className="w-full sm:max-w-xl overflow-y-auto z-[70]">
+            <SheetHeader className="mb-2">
+              <SheetTitle>Nuevo contacto</SheetTitle>
+            </SheetHeader>
+            <ContactoForm
+              delegacionId={delegacionId ?? null}
+              contacto={null}
+              categorias={categories as any}
+              canManageGlobal={Boolean(canManageGlobalContact)}
+              defaultNombre={contactoInitialNombre}
+              onSubmit={async (payload) => {
+                const created = (await onCreateContacto(payload)) as Contacto | void
+                if (created?.id) {
+                  setFormData((prev) => ({ ...prev, contacto_id: created.id }))
+                }
+                return created
+              }}
+              onCancel={() => setContactoCreateOpen(false)}
+              onSaved={() => setContactoCreateOpen(false)}
+            />
+          </SheetContent>
+        </Sheet>
+      )}
     </Sheet>
   )
 }

--- a/components/transactions/transaction-create-panel.tsx
+++ b/components/transactions/transaction-create-panel.tsx
@@ -366,7 +366,7 @@ export function TransactionCreatePanel({
 
           {/* Contact */}
           <div className="space-y-3">
-            <Label className="text-sm font-medium text-muted-foreground">CONTACTO</Label>
+            <Label className="text-sm font-medium text-muted-foreground">CONTACTO <span className="text-[10px] font-normal normal-case">(opcional)</span></Label>
             <ContactoSelector
               contactos={contactos}
               value={formData.contacto_id ?? null}

--- a/components/transactions/transaction-detail.tsx
+++ b/components/transactions/transaction-detail.tsx
@@ -22,13 +22,20 @@ import { TabWithCounter } from "./tab-with-counter"
 import { formatCurrency } from "@/lib/utils/format"
 import { formatIsoDateToInput, maskDateInput, parseDateInputToIso } from "@/lib/utils/date-input"
 import { TransactionFiles } from "./transaction-files"
-import type { Movimiento, Cuenta, Categoria } from "@/lib/types/database"
+import type { Movimiento, MovimientoConRelaciones, Cuenta, Categoria, Contacto, ContactoConCategoriaPredeterminada } from "@/lib/types/database"
 import { LoadingSpinner } from "@/components/ui/loading-spinner"
+import { ContactoSelector } from "@/components/contactos/contacto-selector"
+import { ContactoForm } from "@/components/contactos/contacto-form"
+import { CONTACTO_TIPO_INFO } from "@/lib/utils/contacto-tipos"
 
 interface TransactionDetailProps {
-  movement: Movimiento | null
+  movement: MovimientoConRelaciones | null
   accounts: Cuenta[]
   categories: Categoria[]
+  contactos?: ContactoConCategoriaPredeterminada[]
+  delegacionId?: string | null
+  canManageGlobalContact?: boolean
+  onCreateContacto?: (payload: Parameters<NonNullable<React.ComponentProps<typeof ContactoForm>["onSubmit"]>>[0]) => Promise<Contacto | void>
   open: boolean
   onOpenChange: (open: boolean) => void
   onUpdate: (movementId: string, patch: Partial<Movimiento>) => Promise<void>
@@ -42,12 +49,18 @@ export function TransactionDetail({
   movement,
   accounts,
   categories,
+  contactos = [],
+  delegacionId,
+  canManageGlobalContact,
+  onCreateContacto,
   open,
   onOpenChange,
   onUpdate,
   onBack,
   initialTab = "datos",
 }: TransactionDetailProps) {
+  const [contactoCreateOpen, setContactoCreateOpen] = useState(false)
+  const [contactoInitialNombre, setContactoInitialNombre] = useState("")
   const [formData, setFormData] = useState<Partial<Movimiento>>({})
   const [formMovementId, setFormMovementId] = useState<string | null>(movement?.id ?? null)
   const [isInitialized, setIsInitialized] = useState(false)
@@ -72,7 +85,7 @@ export function TransactionDetail({
       concepto: movement.concepto,
       descripcion: movement.descripcion || "",
       categoria_id: movement.categoria_id,
-      contraparte: movement.contraparte || "",
+      contacto_id: movement.contacto_id ?? null,
     }
   }, [movement])
 
@@ -529,13 +542,40 @@ export function TransactionDetail({
                     <Label htmlFor="contacto" className="text-sm font-medium">
                       Contacto
                     </Label>
-                    <Input
-                      id="contacto"
-                      value={formData.contraparte || ""}
-                      onChange={(e) => setFormData((prev) => ({ ...prev, contraparte: e.target.value }))}
-                      placeholder="Nombre del contacto"
-                      className="h-9"
+                    <ContactoSelector
+                      contactos={contactos}
+                      value={formData.contacto_id ?? null}
+                      onChange={(contactoId) => {
+                        setFormData((prev) => {
+                          const next: Partial<Movimiento> = { ...prev, contacto_id: contactoId }
+                          // Auto-sugerir categoría predeterminada al elegir contacto si no había una
+                          if (contactoId && !prev.categoria_id) {
+                            const c = contactos.find((x) => x.id === contactoId)
+                            if (c?.categoria_id_predeterminada) {
+                              next.categoria_id = c.categoria_id_predeterminada
+                            }
+                          }
+                          return next
+                        })
+                      }}
+                      onCreateNew={
+                        onCreateContacto
+                          ? (initialNombre) => {
+                              setContactoInitialNombre(initialNombre)
+                              setContactoCreateOpen(true)
+                            }
+                          : undefined
+                      }
+                      placeholder="Sin contacto vinculado"
                     />
+                    {movement?.contacto && (
+                      <p className="text-[11px] text-muted-foreground">
+                        Tipo:{" "}
+                        <span className="font-medium">
+                          {CONTACTO_TIPO_INFO[movement.contacto.tipo].label}
+                        </span>
+                      </p>
+                    )}
                   </div>
 
                   <div className="space-y-2">
@@ -597,6 +637,32 @@ export function TransactionDetail({
           </>
         )}
       </SheetContent>
+
+      {onCreateContacto && (
+        <Sheet open={contactoCreateOpen} onOpenChange={setContactoCreateOpen}>
+          <SheetContent side="right" className="w-full sm:max-w-xl overflow-y-auto z-[70]">
+            <SheetHeader className="mb-2">
+              <SheetTitle>Nuevo contacto</SheetTitle>
+            </SheetHeader>
+            <ContactoForm
+              delegacionId={delegacionId ?? null}
+              contacto={null}
+              categorias={categories as any}
+              canManageGlobal={Boolean(canManageGlobalContact)}
+              defaultNombre={contactoInitialNombre}
+              onSubmit={async (payload) => {
+                const created = (await onCreateContacto(payload)) as Contacto | void
+                if (created?.id) {
+                  setFormData((prev) => ({ ...prev, contacto_id: created.id }))
+                }
+                return created
+              }}
+              onCancel={() => setContactoCreateOpen(false)}
+              onSaved={() => setContactoCreateOpen(false)}
+            />
+          </SheetContent>
+        </Sheet>
+      )}
     </Sheet>
   )
 }

--- a/components/transactions/transaction-detail.tsx
+++ b/components/transactions/transaction-detail.tsx
@@ -539,8 +539,9 @@ export function TransactionDetail({
                   </div>
 
                   <div className="space-y-2">
-                    <Label htmlFor="contacto" className="text-sm font-medium">
+                    <Label htmlFor="contacto" className="text-sm font-medium flex items-center gap-1.5">
                       Contacto
+                      <span className="text-[11px] font-normal text-muted-foreground">(opcional)</span>
                     </Label>
                     <ContactoSelector
                       contactos={contactos}

--- a/components/transactions/transaction-filters.tsx
+++ b/components/transactions/transaction-filters.tsx
@@ -4,7 +4,6 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { Separator } from "@/components/ui/separator"
 import { Badge } from "@/components/ui/badge"
 import { CategorySelector } from "./category-selector"
 import { AmountRangeFilter } from "./amount-range-filter"
@@ -52,22 +51,22 @@ export function TransactionFiltersComponent({
   })
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
       {hasActiveFilters && (
-        <div className="bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-blue-950/20 dark:to-indigo-950/20 p-4 rounded-lg border border-blue-200 dark:border-blue-800">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <div className="h-2 w-2 bg-blue-500 rounded-full animate-pulse"></div>
-              <span className="text-sm font-medium text-blue-700 dark:text-blue-300">Filtros activos</span>
+        <div className="bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-blue-950/20 dark:to-indigo-950/20 p-2.5 rounded-lg border border-blue-200 dark:border-blue-800">
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex items-center gap-2 min-w-0">
+              <div className="h-2 w-2 bg-blue-500 rounded-full animate-pulse shrink-0"></div>
+              <span className="text-xs font-medium text-blue-700 dark:text-blue-300 truncate">Filtros activos</span>
             </div>
             <Button
               variant="outline"
               size="sm"
               onClick={onClearFilters}
-              className="bg-white/80 hover:bg-white border-blue-300 text-blue-700 hover:text-blue-800 dark:bg-blue-950/50 dark:text-blue-300 dark:hover:bg-blue-950/70"
+              className="h-7 px-2 text-xs bg-white/80 hover:bg-white border-blue-300 text-blue-700 hover:text-blue-800 dark:bg-blue-950/50 dark:text-blue-300 dark:hover:bg-blue-950/70"
             >
-              <X className="mr-2 h-4 w-4" />
-              Quitar filtros
+              <X className="mr-1 h-3.5 w-3.5" />
+              Quitar
             </Button>
           </div>
         </div>
@@ -99,10 +98,18 @@ export function TransactionFiltersComponent({
         )}
       </Button>
 
-      <Separator className="bg-border" />
+      <div className="space-y-2">
+        <Label className="text-xs font-semibold text-foreground uppercase tracking-wide">Buscar</Label>
+        <Input
+          placeholder="Concepto, descripción, contacto…"
+          value={filters.search || ""}
+          onChange={(e) => updateFilter("search", e.target.value || undefined)}
+          className="h-9 bg-background border-border focus:border-primary focus:ring-1 focus:ring-primary/20"
+        />
+      </div>
 
-      <div className="space-y-3">
-        <Label className="text-sm font-semibold text-foreground">Categorías</Label>
+      <div className="space-y-2">
+        <Label className="text-xs font-semibold text-foreground uppercase tracking-wide">Categorías</Label>
         <CategorySelector
           categories={categories}
           selectedCategories={filters.categoryIds || []}
@@ -110,83 +117,51 @@ export function TransactionFiltersComponent({
             updateFilter("categoryIds", categoryIds.length > 0 ? categoryIds : undefined)
           }
           allowMultiple={true}
-          placeholder="Seleccionar categorías..."
+          placeholder="Todas las categorías"
         />
       </div>
-
-      <Separator className="bg-border" />
-
-      <div className="space-y-3">
-        <Label className="text-sm font-semibold text-foreground">Buscar transacciones</Label>
-        <div className="relative">
-          <Input
-            placeholder="Buscar en concepto o descripción..."
-            value={filters.search || ""}
-            onChange={(e) => updateFilter("search", e.target.value || undefined)}
-            className="bg-background border-border focus:border-primary focus:ring-1 focus:ring-primary/20"
-          />
-        </div>
-      </div>
-
-      <Separator className="bg-border" />
 
       {accounts.length > 0 && (
-        <>
-          <div className="space-y-3">
-            <Label className="text-sm font-semibold text-foreground">Cuenta</Label>
-            <Select
-              value={filters.accountId || "all"}
-              onValueChange={(value) => updateFilter("accountId", value === "all" ? undefined : value)}
-            >
-              <SelectTrigger className="bg-background border-border focus:border-primary">
-                <SelectValue placeholder="Todas las cuentas" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">Todas las cuentas</SelectItem>
-                {accounts.map((account) => (
-                  <SelectItem key={account.id} value={account.id}>
-                    <div className="flex items-center gap-2">
-                      {account.tipo === "caja" ? (
-                        <PiggyBank className="h-4 w-4 text-amber-600" />
-                      ) : (
-                        <Building2 className="h-4 w-4 text-blue-600" />
-                      )}
-                      <span>{account.nombre}</span>
-                      {account.banco_nombre && (
-                        <span className="text-xs text-muted-foreground">({account.banco_nombre})</span>
-                      )}
-                    </div>
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-          <Separator className="bg-border" />
-        </>
+        <div className="space-y-2">
+          <Label className="text-xs font-semibold text-foreground uppercase tracking-wide">Cuenta</Label>
+          <Select
+            value={filters.accountId || "all"}
+            onValueChange={(value) => updateFilter("accountId", value === "all" ? undefined : value)}
+          >
+            <SelectTrigger className="h-9 bg-background border-border focus:border-primary">
+              <SelectValue placeholder="Todas las cuentas" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">Todas las cuentas</SelectItem>
+              {accounts.map((account) => (
+                <SelectItem key={account.id} value={account.id}>
+                  <div className="flex items-center gap-2">
+                    {account.tipo === "caja" ? (
+                      <PiggyBank className="h-4 w-4 text-amber-600" />
+                    ) : (
+                      <Building2 className="h-4 w-4 text-blue-600" />
+                    )}
+                    <span>{account.nombre}</span>
+                    {account.banco_nombre && (
+                      <span className="text-xs text-muted-foreground">({account.banco_nombre})</span>
+                    )}
+                  </div>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
       )}
 
-      <div className="space-y-3">
-        <Label className="text-sm font-semibold text-foreground">Importe</Label>
-        <AmountRangeFilter
-          amountFrom={filters.amountFrom}
-          amountTo={filters.amountTo}
-          onAmountRangeChange={(amountFrom, amountTo) => {
-            onFiltersChange({ ...filters, amountFrom, amountTo })
-          }}
-        />
-      </div>
-
-      <Separator className="bg-border" />
-
-      <div className="space-y-3">
-        <Label className="text-sm font-semibold text-foreground">Contactos</Label>
+      <div className="space-y-2">
+        <Label className="text-xs font-semibold text-foreground uppercase tracking-wide">Contactos</Label>
         <ContactoSelector
           contactos={contactos}
           value={filters.contactoIds?.[0] ?? null}
           onChange={(id) => updateFilter("contactoIds", id ? [id] : undefined)}
           placeholder="Cualquier contacto"
         />
-        <div className="flex flex-wrap gap-1.5">
+        <div className="flex flex-wrap gap-1">
           {CONTACTO_TIPO_ORDER.map((t) => {
             const info = CONTACTO_TIPO_INFO[t]
             const active = (filters.contactoTipos ?? []).includes(t)
@@ -196,7 +171,7 @@ export function TransactionFiltersComponent({
                 type="button"
                 onClick={() => toggleContactoTipo(t)}
                 className={cn(
-                  "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] transition-all",
+                  "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] transition-all",
                   active
                     ? `${info.bgClass} ${info.textClass} ${info.borderClass} shadow-sm`
                     : "border-border/40 bg-background/60 text-muted-foreground hover:bg-muted",
@@ -208,6 +183,17 @@ export function TransactionFiltersComponent({
             )
           })}
         </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label className="text-xs font-semibold text-foreground uppercase tracking-wide">Importe</Label>
+        <AmountRangeFilter
+          amountFrom={filters.amountFrom}
+          amountTo={filters.amountTo}
+          onAmountRangeChange={(amountFrom, amountTo) => {
+            onFiltersChange({ ...filters, amountFrom, amountTo })
+          }}
+        />
       </div>
     </div>
   )

--- a/components/transactions/transaction-filters.tsx
+++ b/components/transactions/transaction-filters.tsx
@@ -8,7 +8,10 @@ import { Separator } from "@/components/ui/separator"
 import { Badge } from "@/components/ui/badge"
 import { CategorySelector } from "./category-selector"
 import { AmountRangeFilter } from "./amount-range-filter"
-import type { Categoria, CuentaConDelegacion } from "@/lib/types/database"
+import { ContactoSelector } from "@/components/contactos/contacto-selector"
+import { CONTACTO_TIPO_INFO, CONTACTO_TIPO_ORDER } from "@/lib/utils/contacto-tipos"
+import { cn } from "@/lib/utils"
+import type { Categoria, ContactoConCategoriaPredeterminada, ContactoTipo, CuentaConDelegacion } from "@/lib/types/database"
 import type { TransactionFilters as Filters } from "./transaction-manager"
 
 interface TransactionFiltersProps {
@@ -17,6 +20,7 @@ interface TransactionFiltersProps {
   onClearFilters: () => void
   categories: Categoria[]
   accounts?: CuentaConDelegacion[]
+  contactos?: ContactoConCategoriaPredeterminada[]
   uncategorizedCount: number
 }
 
@@ -26,15 +30,22 @@ export function TransactionFiltersComponent({
   onClearFilters,
   categories,
   accounts = [],
+  contactos = [],
   uncategorizedCount,
 }: TransactionFiltersProps) {
   const updateFilter = (key: keyof Filters, value: any) => {
     onFiltersChange({ ...filters, [key]: value })
   }
 
+  const toggleContactoTipo = (tipo: ContactoTipo) => {
+    const current = filters.contactoTipos || []
+    const next = current.includes(tipo) ? current.filter((t) => t !== tipo) : [...current, tipo]
+    updateFilter("contactoTipos", next.length > 0 ? next : undefined)
+  }
+
   const hasActiveFilters = Object.entries(filters).some(([key, value]) => {
     if (key === "uncategorized" || key === "dateRange") return false
-    if (key === "categoryIds") {
+    if (key === "categoryIds" || key === "contactoIds" || key === "contactoTipos") {
       return Array.isArray(value) && value.length > 0
     }
     return value !== undefined && value !== "" && value !== false
@@ -163,6 +174,40 @@ export function TransactionFiltersComponent({
             onFiltersChange({ ...filters, amountFrom, amountTo })
           }}
         />
+      </div>
+
+      <Separator className="bg-border" />
+
+      <div className="space-y-3">
+        <Label className="text-sm font-semibold text-foreground">Contactos</Label>
+        <ContactoSelector
+          contactos={contactos}
+          value={filters.contactoIds?.[0] ?? null}
+          onChange={(id) => updateFilter("contactoIds", id ? [id] : undefined)}
+          placeholder="Cualquier contacto"
+        />
+        <div className="flex flex-wrap gap-1.5">
+          {CONTACTO_TIPO_ORDER.map((t) => {
+            const info = CONTACTO_TIPO_INFO[t]
+            const active = (filters.contactoTipos ?? []).includes(t)
+            return (
+              <button
+                key={t}
+                type="button"
+                onClick={() => toggleContactoTipo(t)}
+                className={cn(
+                  "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] transition-all",
+                  active
+                    ? `${info.bgClass} ${info.textClass} ${info.borderClass} shadow-sm`
+                    : "border-border/40 bg-background/60 text-muted-foreground hover:bg-muted",
+                )}
+              >
+                <span aria-hidden>{info.emoji}</span>
+                <span>{info.shortLabel}</span>
+              </button>
+            )
+          })}
+        </div>
       </div>
     </div>
   )

--- a/components/transactions/transaction-list-row.tsx
+++ b/components/transactions/transaction-list-row.tsx
@@ -12,6 +12,7 @@ import { LoadingSpinner } from "@/components/ui/loading-spinner"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { Check, Pencil } from "lucide-react"
+import { CONTACTO_TIPO_INFO } from "@/lib/utils/contacto-tipos"
 import type { Movimiento, MovimientoConRelaciones, Cuenta, Categoria } from "@/lib/types/database"
 
 interface TransactionListRowProps {
@@ -193,7 +194,7 @@ export const TransactionListRow = memo(function TransactionListRow({
                   </div>
                 )}
 
-                <div onClick={(e) => e.stopPropagation()}>
+                <div onClick={(e) => e.stopPropagation()} className="flex items-center gap-1.5 flex-wrap">
                   {isUpdating ? (
                     <div className="flex items-center gap-2">
                       <LoadingSpinner size="sm" />
@@ -207,6 +208,20 @@ export const TransactionListRow = memo(function TransactionListRow({
                       account={account}
                       onCategoryChange={(categoryId) => handleCategoryChange(categoryId)}
                     />
+                  )}
+                  {movement.contacto && (
+                    <span
+                      className={cn(
+                        "inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5 text-[10px] font-medium",
+                        CONTACTO_TIPO_INFO[movement.contacto.tipo].bgClass,
+                        CONTACTO_TIPO_INFO[movement.contacto.tipo].textClass,
+                        CONTACTO_TIPO_INFO[movement.contacto.tipo].borderClass,
+                      )}
+                      title={`${CONTACTO_TIPO_INFO[movement.contacto.tipo].label}: ${movement.contacto.nombre}`}
+                    >
+                      <span aria-hidden>{movement.contacto.emoji ?? CONTACTO_TIPO_INFO[movement.contacto.tipo].emoji}</span>
+                      <span className="max-w-[120px] truncate">{movement.contacto.nombre}</span>
+                    </span>
                   )}
                 </div>
               </div>

--- a/components/transactions/transaction-manager.tsx
+++ b/components/transactions/transaction-manager.tsx
@@ -13,6 +13,9 @@ import { useDelegationContext } from "@/contexts/delegation-context"
 import { useMovimientos, applyAbsoluteAmountFilter } from "@/hooks/use-movimientos"
 import { useCategorias } from "@/hooks/use-categorias"
 import { useCuentas } from "@/hooks/use-cuentas"
+import { useContactos } from "@/hooks/use-contactos"
+import useIsAdminHook from "@/hooks/use-is-admin"
+import { useAuth as useCurrentUser } from "@/contexts/auth-context"
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
 import {
@@ -53,6 +56,8 @@ export interface TransactionFilters {
   dateTo?: string
   categoryIds?: string[]
   accountId?: string
+  contactoIds?: string[]
+  contactoTipos?: ("proveedor" | "persona_mcm" | "destinatario_mcm")[]
   search?: string
   amountFrom?: number
   amountTo?: number
@@ -111,6 +116,8 @@ export function TransactionManager() {
     fechaHasta: filters.dateTo,
     categoriaIds: filters.categoryIds,
     cuentaId: filters.accountId,
+    contactoIds: filters.contactoIds,
+    contactoTipos: filters.contactoTipos,
     busqueda: filters.search,
     amountFrom: filters.amountFrom,
     amountTo: filters.amountTo,
@@ -126,6 +133,9 @@ export function TransactionManager() {
 
   const { categorias: categories } = useCategorias(selectedDelegation)
   const { cuentas: accounts } = useCuentas(selectedDelegation)
+  const { contactos, createContacto: createContactoFn } = useContactos(selectedDelegation)
+  const isAdmin = useIsAdminHook()
+  const { user: currentUser } = useCurrentUser()
 
   useEffect(() => {
     if (movements.length === 0) {
@@ -459,7 +469,7 @@ export function TransactionManager() {
 
   const hasActiveFilters = Object.entries(filters).some(([key, value]) => {
     if (key === "dateFrom" || key === "dateTo") return false
-    if (key === "categoryIds") {
+    if (key === "categoryIds" || key === "contactoIds" || key === "contactoTipos") {
       return Array.isArray(value) && value.length > 0
     }
     return value !== undefined && value !== "" && value !== false
@@ -552,6 +562,7 @@ export function TransactionManager() {
               onClearFilters={clearFilters}
               categories={categories}
               accounts={accounts}
+              contactos={contactos}
               uncategorizedCount={uncategorizedCount}
             />
           </div>
@@ -786,6 +797,13 @@ export function TransactionManager() {
         movement={selectedMovementSnapshot}
         accounts={accounts as unknown as Cuenta[]}
         categories={categories as unknown as Categoria[]}
+        contactos={contactos}
+        delegacionId={selectedDelegation}
+        canManageGlobalContact={isAdmin}
+        onCreateContacto={async (payload) => {
+          if (!payload.insert) return
+          return await createContactoFn({ ...payload.insert, creado_por: currentUser?.id ?? null })
+        }}
         open={selectedMovementId !== null}
         onOpenChange={(open) => {
           if (!open) {
@@ -804,6 +822,13 @@ export function TransactionManager() {
       <TransactionCreatePanel
         accounts={accounts as unknown as Cuenta[]}
         categories={categories as unknown as Categoria[]}
+        contactos={contactos}
+        delegacionId={selectedDelegation}
+        canManageGlobalContact={isAdmin}
+        onCreateContacto={async (payload) => {
+          if (!payload.insert) return
+          return await createContactoFn({ ...payload.insert, creado_por: currentUser?.id ?? null })
+        }}
         open={createFormOpen}
         onOpenChange={setCreateFormOpen}
         onCreate={handleCreateMovement}

--- a/contexts/movimientos-cache-context.tsx
+++ b/contexts/movimientos-cache-context.tsx
@@ -14,6 +14,8 @@ interface MovimientosFilters {
   fechaHasta?: string
   categoriaIds?: string[]
   cuentaId?: string
+  contactoIds?: string[]
+  contactoTipos?: ("proveedor" | "persona_mcm" | "destinatario_mcm")[]
   busqueda?: string
   amountFrom?: number
   amountTo?: number
@@ -46,6 +48,8 @@ function serializeFilters(filters?: MovimientosFilters): string {
   const normalized = {
     ...filters,
     categoriaIds: filters.categoriaIds ? [...filters.categoriaIds].sort() : undefined,
+    contactoIds: filters.contactoIds ? [...filters.contactoIds].sort() : undefined,
+    contactoTipos: filters.contactoTipos ? [...filters.contactoTipos].sort() : undefined,
   }
   return JSON.stringify(normalized)
 }
@@ -111,6 +115,25 @@ export function MovimientosCacheProvider({ children }: { children: React.ReactNo
       // Create and store the request promise
       const requestPromise = (async () => {
         try {
+          // Resolve contacto IDs to filter by when filtering by name match or tipo
+          let contactoIdsExtra: string[] | null = null
+          if (filters?.busqueda || (filters?.contactoTipos && filters.contactoTipos.length > 0)) {
+            const term = filters.busqueda?.replace(/%/g, "\\%")
+            let contactoLookup = (supabase as any)
+              .from("contacto")
+              .select("id")
+              .or(`delegacion_id.eq.${delegacionId},es_global.is.true`)
+              .limit(500)
+            if (term) {
+              contactoLookup = contactoLookup.ilike("nombre", `%${term}%`)
+            }
+            if (filters.contactoTipos && filters.contactoTipos.length > 0) {
+              contactoLookup = contactoLookup.in("tipo", filters.contactoTipos)
+            }
+            const { data: matchedContactos } = await contactoLookup.abortSignal(ac.signal)
+            contactoIdsExtra = (matchedContactos ?? []).map((c: any) => c.id)
+          }
+
           // Build query
           // Optimized query: removed unnecessary delegacion JOIN (we already have delegacion_id)
           // and archivos JOIN (lazy loaded on demand)
@@ -132,6 +155,7 @@ export function MovimientosCacheProvider({ children }: { children: React.ReactNo
               notas,
               ignorado,
               categoria_id,
+              contacto_id,
               adjunto_principal_url,
               creado_por,
               creado_en,
@@ -154,6 +178,14 @@ export function MovimientosCacheProvider({ children }: { children: React.ReactNo
                 orden,
                 categoria_padre_id,
                 creado_en
+              ),
+              contacto:contacto_id (
+                id,
+                nombre,
+                tipo,
+                emoji,
+                color,
+                es_global
               )
             `,
               { count: "exact" }
@@ -177,9 +209,19 @@ export function MovimientosCacheProvider({ children }: { children: React.ReactNo
             if (filters.cuentaId) {
               query = query.eq("cuenta_id", filters.cuentaId)
             }
+            if (filters.contactoIds && filters.contactoIds.length > 0) {
+              query = query.in("contacto_id", filters.contactoIds)
+            }
+            if (filters.contactoTipos && filters.contactoTipos.length > 0) {
+              query = query.in("contacto_id", contactoIdsExtra && contactoIdsExtra.length > 0 ? contactoIdsExtra : ["00000000-0000-0000-0000-000000000000"])
+            }
             if (filters.busqueda) {
               const term = filters.busqueda.replace(/%/g, "\\%").replace(/,/g, "\\,")
-              query = query.or(`concepto.ilike.%${term}%,descripcion.ilike.%${term}%`)
+              const orParts = [`concepto.ilike.%${term}%`, `descripcion.ilike.%${term}%`]
+              if (contactoIdsExtra && contactoIdsExtra.length > 0) {
+                orParts.push(`contacto_id.in.(${contactoIdsExtra.join(",")})`)
+              }
+              query = query.or(orParts.join(","))
             }
             // Filter by absolute amount value (matches both positive and negative)
             query = applyAbsoluteAmountFilter(query, filters.amountFrom, filters.amountTo)

--- a/hooks/use-clipboard.ts
+++ b/hooks/use-clipboard.ts
@@ -1,0 +1,49 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+
+export function useClipboard(resetMs = 2000) {
+  const [copied, setCopied] = useState<string | null>(null)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const copy = useCallback(
+    async (value: string) => {
+      if (!value) return false
+      try {
+        if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+          await navigator.clipboard.writeText(value)
+        } else if (typeof document !== "undefined") {
+          const textarea = document.createElement("textarea")
+          textarea.value = value
+          textarea.style.position = "fixed"
+          textarea.style.left = "-999999px"
+          textarea.style.top = "-999999px"
+          document.body.appendChild(textarea)
+          textarea.focus()
+          textarea.select()
+          document.execCommand("copy")
+          document.body.removeChild(textarea)
+        } else {
+          return false
+        }
+
+        setCopied(value)
+        if (timerRef.current) clearTimeout(timerRef.current)
+        timerRef.current = setTimeout(() => setCopied(null), resetMs)
+        return true
+      } catch (error) {
+        console.error("useClipboard: error copying", error)
+        return false
+      }
+    },
+    [resetMs],
+  )
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current)
+    }
+  }, [])
+
+  return { copied, copy, isCopied: (value: string) => copied === value }
+}

--- a/hooks/use-contactos.ts
+++ b/hooks/use-contactos.ts
@@ -1,0 +1,197 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { DatabaseService } from "@/lib/services/database"
+import { registerAC, unregisterAC } from "@/lib/db/in-flight"
+import { useRevalidateOnFocusJitter } from "./use-app-status"
+import type {
+  Contacto,
+  ContactoConCategoriaPredeterminada,
+  ContactoInsert,
+  ContactoTipo,
+  ContactoUpdate,
+} from "@/lib/types/database"
+
+const QUERY_TIMEOUT_MS = 12000
+
+export interface UseContactosOptions {
+  tipo?: ContactoTipo
+  busqueda?: string
+  incluirArchivados?: boolean
+  incluirGlobales?: boolean
+}
+
+export function useContactos(delegacionId?: string | null, options: UseContactosOptions = {}) {
+  const [contactos, setContactos] = useState<ContactoConCategoriaPredeterminada[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const abortRef = useRef<AbortController | null>(null)
+  const contactosRef = useRef(contactos)
+  contactosRef.current = contactos
+
+  const incluirGlobales = options.incluirGlobales ?? true
+  const incluirArchivados = options.incluirArchivados ?? false
+  const tipo = options.tipo
+  const busqueda = options.busqueda?.trim() || undefined
+
+  const fetchContactos = useCallback(async () => {
+    if (abortRef.current) {
+      abortRef.current.abort()
+      unregisterAC(abortRef.current)
+    }
+
+    const ac = new AbortController()
+    abortRef.current = ac
+    registerAC(ac)
+
+    try {
+      if (!delegacionId && !incluirGlobales) {
+        setContactos([])
+        setLoading(false)
+        return
+      }
+
+      if (contactosRef.current.length === 0) {
+        setLoading(true)
+      }
+
+      const data = await Promise.race([
+        DatabaseService.getContactosByDelegacion(delegacionId, {
+          tipo,
+          busqueda,
+          incluirArchivados,
+          incluirGlobales,
+          signal: ac.signal,
+        }),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error(`contactos timeout after ${QUERY_TIMEOUT_MS}ms`)), QUERY_TIMEOUT_MS),
+        ),
+      ])
+
+      if (ac.signal.aborted) return
+      setContactos(data)
+      setError(null)
+    } catch (err) {
+      if (ac.signal.aborted) return
+      setError(err instanceof Error ? err.message : "Error desconocido")
+    } finally {
+      unregisterAC(ac)
+      if (!ac.signal.aborted) setLoading(false)
+    }
+  }, [delegacionId, tipo, busqueda, incluirArchivados, incluirGlobales])
+
+  const fetchRef = useRef(fetchContactos)
+  fetchRef.current = fetchContactos
+
+  useEffect(() => {
+    fetchRef.current()
+    return () => {
+      if (abortRef.current) {
+        abortRef.current.abort()
+        unregisterAC(abortRef.current)
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [delegacionId, tipo, busqueda, incluirArchivados, incluirGlobales])
+
+  useRevalidateOnFocusJitter(() => fetchRef.current(), { minMs: 80, maxMs: 200 })
+
+  const createContacto = useCallback(
+    async (payload: Omit<ContactoInsert, "creado_en" | "actualizado_en">) => {
+      const created = await DatabaseService.createContacto(payload)
+      await fetchRef.current()
+      return created
+    },
+    [],
+  )
+
+  const updateContacto = useCallback(async (id: string, updates: ContactoUpdate) => {
+    await DatabaseService.updateContacto(id, updates)
+    setContactos((prev) =>
+      prev.map((c) => (c.id === id ? ({ ...c, ...updates } as ContactoConCategoriaPredeterminada) : c)),
+    )
+  }, [])
+
+  const deleteContacto = useCallback(async (id: string) => {
+    await DatabaseService.deleteContacto(id)
+    setContactos((prev) => prev.filter((c) => c.id !== id))
+  }, [])
+
+  const archiveContacto = useCallback(async (id: string, archivado: boolean) => {
+    await DatabaseService.archiveContacto(id, archivado)
+    setContactos((prev) => prev.map((c) => (c.id === id ? { ...c, archivado } : c)))
+  }, [])
+
+  const counts = useMemo(() => {
+    const base = { proveedor: 0, persona_mcm: 0, destinatario_mcm: 0, total: 0 }
+    for (const c of contactos) {
+      if (c.archivado) continue
+      base[c.tipo] += 1
+      base.total += 1
+    }
+    return base
+  }, [contactos])
+
+  return {
+    contactos,
+    loading,
+    error,
+    counts,
+    refetch: fetchContactos,
+    createContacto,
+    updateContacto,
+    deleteContacto,
+    archiveContacto,
+  }
+}
+
+export type UseContactosReturn = ReturnType<typeof useContactos>
+
+// Hook ligero para el detalle de un contacto (información + movimientos vinculados)
+export function useContactoDetalle(contactoId: string | null) {
+  const [contacto, setContacto] = useState<ContactoConCategoriaPredeterminada | null>(null)
+  const [movimientos, setMovimientos] = useState<Awaited<ReturnType<typeof DatabaseService.getMovimientosByContacto>>>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchDetalle = useCallback(async () => {
+    if (!contactoId) {
+      setContacto(null)
+      setMovimientos([])
+      return
+    }
+    setLoading(true)
+    setError(null)
+    try {
+      const [c, m] = await Promise.all([
+        DatabaseService.getContactoById(contactoId),
+        DatabaseService.getMovimientosByContacto(contactoId, { limite: 200 }),
+      ])
+      setContacto(c)
+      setMovimientos(m)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Error al cargar el contacto")
+    } finally {
+      setLoading(false)
+    }
+  }, [contactoId])
+
+  useEffect(() => {
+    fetchDetalle()
+  }, [fetchDetalle])
+
+  const totales = useMemo(() => {
+    let ingresos = 0
+    let gastos = 0
+    for (const m of movimientos) {
+      if (m.importe >= 0) ingresos += m.importe
+      else gastos += m.importe
+    }
+    return { ingresos, gastos, neto: ingresos + gastos, total: movimientos.length }
+  }, [movimientos])
+
+  return { contacto, movimientos, totales, loading, error, refetch: fetchDetalle }
+}
+
+export type UseContactoDetalleReturn = ReturnType<typeof useContactoDetalle>
+export type { Contacto, ContactoConCategoriaPredeterminada }

--- a/hooks/use-delegation-counts.ts
+++ b/hooks/use-delegation-counts.ts
@@ -10,12 +10,14 @@ export interface DelegationCounts {
   movimientos: number | null
   categorias: number | null
   cuentas: number | null
+  contactos: number | null
 }
 
 const INITIAL_COUNTS: DelegationCounts = {
   movimientos: null,
   categorias: null,
   cuentas: null,
+  contactos: null,
 }
 
 const QUERY_TIMEOUT_MS = 10000
@@ -54,7 +56,7 @@ export function useDelegationCounts() {
     const organizacionId = delegation?.organizacion_id ?? null
 
     try {
-      const [movimientosRes, cuentasRes, categoriasRes] = await Promise.all([
+      const [movimientosRes, cuentasRes, categoriasRes, contactosRes] = await Promise.all([
         runQuery<{ count: number | null }>({
           label: "count-movimientos",
           table: "movimiento",
@@ -96,6 +98,20 @@ export function useDelegationCounts() {
               },
             })
           : Promise.resolve({ data: { count: null }, error: null }),
+        runQuery<{ count: number | null }>({
+          label: "count-contactos",
+          table: "contacto",
+          timeoutMs: QUERY_TIMEOUT_MS,
+          build: async (signal) => {
+            const { count, error } = await supabase
+              .from("contacto")
+              .select("id", { head: true, count: "exact" })
+              .or(`delegacion_id.eq.${delegationId},es_global.is.true`)
+              .eq("archivado", false)
+              .abortSignal(signal)
+            return { data: { count: typeof count === "number" ? count : 0 }, error }
+          },
+        }),
       ])
 
       if (requestRef.current !== fetchId) return
@@ -109,18 +125,21 @@ export function useDelegationCounts() {
             : categoriasRes.error
               ? null
               : categoriasRes.data?.count ?? 0,
+        contactos: contactosRes.error ? null : contactosRes.data?.count ?? 0,
       }
 
       const hasError =
         Boolean(movimientosRes.error) ||
         Boolean(cuentasRes.error) ||
-        (organizacionId !== null && Boolean(categoriasRes.error))
+        (organizacionId !== null && Boolean(categoriasRes.error)) ||
+        Boolean(contactosRes.error)
 
       if (hasError) {
         console.warn("⚠️ useDelegationCounts: error loading counts", {
           movimientosError: movimientosRes.error,
           cuentasError: cuentasRes.error,
           categoriasError: categoriasRes.error,
+          contactosError: contactosRes.error,
         })
         setError("No se pudieron cargar todos los totales")
       } else {

--- a/hooks/use-movimientos.ts
+++ b/hooks/use-movimientos.ts
@@ -11,6 +11,8 @@ interface MovimientosFilters {
   fechaHasta?: string
   categoriaIds?: string[]
   cuentaId?: string
+  contactoIds?: string[]
+  contactoTipos?: ("proveedor" | "persona_mcm" | "destinatario_mcm")[]
   busqueda?: string
   amountFrom?: number
   amountTo?: number
@@ -75,6 +77,8 @@ export function useMovimientos(
     const normalized = {
       ...filters,
       categoriaIds: filters.categoriaIds ? [...filters.categoriaIds].sort() : undefined,
+      contactoIds: filters.contactoIds ? [...filters.contactoIds].sort() : undefined,
+      contactoTipos: filters.contactoTipos ? [...filters.contactoTipos].sort() : undefined,
     }
     try {
       return JSON.stringify(normalized)
@@ -91,6 +95,8 @@ export function useMovimientos(
       return {
         ...parsed,
         categoriaIds: parsed.categoriaIds ? [...parsed.categoriaIds] : undefined,
+        contactoIds: parsed.contactoIds ? [...parsed.contactoIds] : undefined,
+        contactoTipos: parsed.contactoTipos ? [...parsed.contactoTipos] : undefined,
       }
     } catch (error) {
       console.warn("No se pudieron deserializar los filtros de movimientos", error)
@@ -146,6 +152,25 @@ export function useMovimientos(
         }
         setError(null)
 
+        // Resolve contacto IDs to filter by when filtering by name match or tipo
+        let contactoIdsExtra: string[] | null = null
+        if (memoizedFilters?.busqueda || (memoizedFilters?.contactoTipos && memoizedFilters.contactoTipos.length > 0)) {
+          const term = memoizedFilters.busqueda?.replace(/%/g, "\\%")
+          let contactoLookup = supabase
+            .from("contacto")
+            .select("id")
+            .or(`delegacion_id.eq.${delegacionId},es_global.is.true`)
+            .limit(500)
+          if (term) {
+            contactoLookup = contactoLookup.ilike("nombre", `%${term}%`)
+          }
+          if (memoizedFilters.contactoTipos && memoizedFilters.contactoTipos.length > 0) {
+            contactoLookup = contactoLookup.in("tipo", memoizedFilters.contactoTipos)
+          }
+          const { data: matchedContactos } = await contactoLookup.abortSignal(abortController.signal)
+          contactoIdsExtra = (matchedContactos ?? []).map((c: any) => c.id)
+        }
+
         // Optimized query: removed delegacion JOIN and archivos JOIN
         let query = supabase
           .from("movimiento")
@@ -165,6 +190,7 @@ export function useMovimientos(
             notas,
             ignorado,
             categoria_id,
+            contacto_id,
             adjunto_principal_url,
             creado_por,
             creado_en,
@@ -187,6 +213,14 @@ export function useMovimientos(
               orden,
               categoria_padre_id,
               creado_en
+            ),
+            contacto:contacto_id (
+              id,
+              nombre,
+              tipo,
+              emoji,
+              color,
+              es_global
             )
           `,
             { count: "exact" }
@@ -210,9 +244,20 @@ export function useMovimientos(
           if (memoizedFilters.cuentaId) {
             query = query.eq("cuenta_id", memoizedFilters.cuentaId)
           }
+          if (memoizedFilters.contactoIds && memoizedFilters.contactoIds.length > 0) {
+            query = query.in("contacto_id", memoizedFilters.contactoIds)
+          }
+          if (memoizedFilters.contactoTipos && memoizedFilters.contactoTipos.length > 0) {
+            // Restringe a movimientos cuyo contacto coincide con uno de los tipos
+            query = query.in("contacto_id", contactoIdsExtra && contactoIdsExtra.length > 0 ? contactoIdsExtra : ["00000000-0000-0000-0000-000000000000"])
+          }
           if (memoizedFilters.busqueda) {
             const term = memoizedFilters.busqueda.replace(/%/g, "\\%").replace(/,/g, "\\,")
-            query = query.or(`concepto.ilike.%${term}%,descripcion.ilike.%${term}%`)
+            const orParts = [`concepto.ilike.%${term}%`, `descripcion.ilike.%${term}%`]
+            if (contactoIdsExtra && contactoIdsExtra.length > 0) {
+              orParts.push(`contacto_id.in.(${contactoIdsExtra.join(",")})`)
+            }
+            query = query.or(orParts.join(","))
           }
           // Filter by absolute amount value so -150 matches range [100, 300]
           query = applyAbsoluteAmountFilter(query, memoizedFilters.amountFrom, memoizedFilters.amountTo)
@@ -334,6 +379,7 @@ export function useMovimientos(
       const payload: any = {
         ...data,
         categoria_id: (data as any)?.categoria_id || null,
+        contacto_id: (data as any)?.contacto_id || null,
         creado_por: user.id,
       }
 
@@ -356,6 +402,7 @@ export function useMovimientos(
           notas,
           ignorado,
           categoria_id,
+          contacto_id,
           adjunto_principal_url,
           creado_por,
           creado_en,
@@ -389,6 +436,14 @@ export function useMovimientos(
             creado_en,
             es_global
           ),
+          contacto:contacto_id (
+            id,
+            nombre,
+            tipo,
+            emoji,
+            color,
+            es_global
+          ),
           archivos:movimiento_archivo!movimiento_id (
             id,
             nombre_original,
@@ -420,7 +475,7 @@ export function useMovimientos(
   const updateMovimiento = async (movimientoId: string, patch: Partial<MovimientoConRelaciones>) => {
     try {
       // Strip relation fields — only send flat DB columns to .update()
-      const { cuenta, categoria, archivos, ...dbFields } = patch
+      const { cuenta, categoria, contacto, archivos, ...dbFields } = patch
       const { error } = await (supabase as any)
         .from("movimiento")
         .update(dbFields)

--- a/lib/services/database.ts
+++ b/lib/services/database.ts
@@ -4,8 +4,14 @@ import type {
   CategoryBreakdownRow,
   CategoriaConOrdenEfectivo,
   CategoriaOrdenDelegacion,
+  Contacto,
+  ContactoConCategoriaPredeterminada,
+  ContactoInsert,
+  ContactoTipo,
+  ContactoUpdate,
   FinancialSummary,
   MonthlyTrendRow,
+  MovimientoConRelaciones,
 } from "@/lib/types/database"
 
 type CategoriaWithOverrides = Categoria & {
@@ -213,6 +219,172 @@ export class DatabaseService {
       .match({ delegacion_id: delegacionId, categoria_id: categoriaId })
 
     if (error) throw error
+  }
+
+  // ---------------------------------------------------------------------------
+  // Contacto operations (client-side)
+  // ---------------------------------------------------------------------------
+
+  static async getContactosByDelegacion(
+    delegacionId?: string | null,
+    options: {
+      tipo?: ContactoTipo
+      busqueda?: string
+      incluirArchivados?: boolean
+      incluirGlobales?: boolean
+      signal?: AbortSignal
+    } = {},
+  ): Promise<ContactoConCategoriaPredeterminada[]> {
+    const supabase = this.getClient() as any
+    const incluirGlobales = options.incluirGlobales ?? true
+
+    if (!delegacionId && !incluirGlobales) return []
+
+    let query = supabase
+      .from("contacto")
+      .select(`
+        *,
+        categoria_predeterminada:categoria_id_predeterminada (
+          id,
+          nombre,
+          emoji,
+          color
+        )
+      `)
+      .order("archivado", { ascending: true })
+      .order("nombre", { ascending: true })
+
+    if (delegacionId) {
+      query = incluirGlobales
+        ? query.or(`delegacion_id.eq.${delegacionId},es_global.is.true`)
+        : query.eq("delegacion_id", delegacionId)
+    } else if (incluirGlobales) {
+      query = query.eq("es_global", true)
+    }
+
+    if (options.tipo) {
+      query = query.eq("tipo", options.tipo)
+    }
+
+    if (!options.incluirArchivados) {
+      query = query.eq("archivado", false)
+    }
+
+    if (options.busqueda) {
+      const term = options.busqueda.replace(/%/g, "\\%").replace(/,/g, "\\,")
+      query = query.or(
+        `nombre.ilike.%${term}%,email.ilike.%${term}%,telefono.ilike.%${term}%,identificador_fiscal.ilike.%${term}%,iban.ilike.%${term}%`,
+      )
+    }
+
+    if (options.signal) {
+      query = query.abortSignal(options.signal)
+    }
+
+    const { data, error } = await query
+    if (error) throw error
+    return (data ?? []) as ContactoConCategoriaPredeterminada[]
+  }
+
+  static async getContactoById(id: string): Promise<ContactoConCategoriaPredeterminada | null> {
+    const supabase = this.getClient() as any
+    const { data, error } = await supabase
+      .from("contacto")
+      .select(`
+        *,
+        categoria_predeterminada:categoria_id_predeterminada (
+          id,
+          nombre,
+          emoji,
+          color
+        )
+      `)
+      .eq("id", id)
+      .maybeSingle()
+    if (error) throw error
+    return (data ?? null) as ContactoConCategoriaPredeterminada | null
+  }
+
+  static async createContacto(
+    contacto: Omit<ContactoInsert, "creado_en" | "actualizado_en">,
+  ): Promise<Contacto> {
+    const supabase = this.getClient() as any
+    const { data, error } = await supabase.from("contacto").insert(contacto).select().single()
+    if (error) throw error
+    return data as Contacto
+  }
+
+  static async updateContacto(id: string, updates: ContactoUpdate): Promise<void> {
+    const supabase = this.getClient() as any
+    const { error } = await supabase.from("contacto").update(updates).eq("id", id)
+    if (error) throw error
+  }
+
+  static async deleteContacto(id: string): Promise<void> {
+    const supabase = this.getClient() as any
+    const { error } = await supabase.from("contacto").delete().eq("id", id)
+    if (error) throw error
+  }
+
+  static async archiveContacto(id: string, archivado: boolean): Promise<void> {
+    await this.updateContacto(id, { archivado })
+  }
+
+  static async getMovimientosByContacto(
+    contactoId: string,
+    options: { limite?: number; signal?: AbortSignal } = {},
+  ): Promise<MovimientoConRelaciones[]> {
+    const supabase = this.getClient() as any
+    const limite = options.limite ?? 100
+
+    let query = supabase
+      .from("movimiento")
+      .select(`
+        id,
+        delegacion_id,
+        cuenta_id,
+        fecha,
+        concepto,
+        descripcion,
+        importe,
+        notas,
+        ignorado,
+        categoria_id,
+        contacto_id,
+        creado_en,
+        cuenta:cuenta_id (
+          id,
+          delegacion_id,
+          nombre,
+          tipo,
+          origen,
+          banco_nombre,
+          color
+        ),
+        categoria:categoria_id (
+          id,
+          nombre,
+          color,
+          tipo,
+          emoji,
+          orden,
+          categoria_padre_id,
+          creado_en
+        )
+      `)
+      .eq("contacto_id", contactoId)
+      .eq("ignorado", false)
+      .order("fecha", { ascending: false })
+      .order("creado_en", { ascending: false })
+      .limit(limite)
+
+    if (options.signal) {
+      query = query.abortSignal(options.signal)
+    }
+
+    const { data, error } = await query
+    if (error) throw error
+    return (data ?? []) as MovimientoConRelaciones[]
   }
 
   // ---------------------------------------------------------------------------

--- a/lib/types/database.ts
+++ b/lib/types/database.ts
@@ -125,6 +125,7 @@ export type Database = {
           notas: string | null
           ignorado: boolean
           categoria_id: string | null
+          contacto_id: string | null
           adjunto_principal_url: string | null
           creado_por: string
           creado_en: string
@@ -150,6 +151,7 @@ export type Database = {
           notas?: string | null
           ignorado?: boolean
           categoria_id?: string | null
+          contacto_id?: string | null
           adjunto_principal_url?: string | null
           creado_por: string
           creado_en?: string
@@ -175,6 +177,7 @@ export type Database = {
           notas?: string | null
           ignorado?: boolean
           categoria_id?: string | null
+          contacto_id?: string | null
           adjunto_principal_url?: string | null
           creado_por?: string
           creado_en?: string
@@ -184,6 +187,74 @@ export type Database = {
           booking_date?: string | null
           value_date?: string | null
           origen_sync?: "manual" | "import_excel" | "enablebanking" | null
+        }
+      }
+      contacto: {
+        Row: {
+          id: string
+          delegacion_id: string | null
+          es_global: boolean
+          tipo: "proveedor" | "persona_mcm" | "destinatario_mcm"
+          nombre: string
+          emoji: string | null
+          color: string | null
+          identificador_fiscal: string | null
+          iban: string | null
+          email: string | null
+          telefono: string | null
+          direccion: string | null
+          ciudad: string | null
+          codigo_postal: string | null
+          categoria_id_predeterminada: string | null
+          notas: string | null
+          archivado: boolean
+          creado_por: string | null
+          creado_en: string
+          actualizado_en: string
+        }
+        Insert: {
+          id?: string
+          delegacion_id?: string | null
+          es_global?: boolean
+          tipo: "proveedor" | "persona_mcm" | "destinatario_mcm"
+          nombre: string
+          emoji?: string | null
+          color?: string | null
+          identificador_fiscal?: string | null
+          iban?: string | null
+          email?: string | null
+          telefono?: string | null
+          direccion?: string | null
+          ciudad?: string | null
+          codigo_postal?: string | null
+          categoria_id_predeterminada?: string | null
+          notas?: string | null
+          archivado?: boolean
+          creado_por?: string | null
+          creado_en?: string
+          actualizado_en?: string
+        }
+        Update: {
+          id?: string
+          delegacion_id?: string | null
+          es_global?: boolean
+          tipo?: "proveedor" | "persona_mcm" | "destinatario_mcm"
+          nombre?: string
+          emoji?: string | null
+          color?: string | null
+          identificador_fiscal?: string | null
+          iban?: string | null
+          email?: string | null
+          telefono?: string | null
+          direccion?: string | null
+          ciudad?: string | null
+          codigo_postal?: string | null
+          categoria_id_predeterminada?: string | null
+          notas?: string | null
+          archivado?: boolean
+          creado_por?: string | null
+          creado_en?: string
+          actualizado_en?: string
         }
       }
       categoria: {
@@ -599,6 +670,16 @@ export type PropuestaMejoraComentario = Database["public"]["Tables"]["propuesta_
 export type PropuestaMejoraVoto = Database["public"]["Tables"]["propuesta_mejora_voto"]["Row"]
 export type BancoConexion = Database["public"]["Tables"]["banco_conexion"]["Row"]
 export type BancoSyncLog = Database["public"]["Tables"]["banco_sync_log"]["Row"]
+export type Contacto = Database["public"]["Tables"]["contacto"]["Row"]
+export type ContactoInsert = Database["public"]["Tables"]["contacto"]["Insert"]
+export type ContactoUpdate = Database["public"]["Tables"]["contacto"]["Update"]
+export type ContactoTipo = Contacto["tipo"]
+
+export const CONTACTO_TIPOS: readonly ContactoTipo[] = ["proveedor", "persona_mcm", "destinatario_mcm"] as const
+
+export type ContactoConCategoriaPredeterminada = Contacto & {
+  categoria_predeterminada?: Pick<Categoria, "id" | "nombre" | "emoji" | "color"> | null
+}
 
 export type BancoSyncLogStep = {
   t: string
@@ -611,6 +692,7 @@ export type BancoSyncLogStep = {
 export type MovimientoConRelaciones = Movimiento & {
   cuenta: Cuenta
   categoria?: Categoria
+  contacto?: Pick<Contacto, "id" | "nombre" | "tipo" | "emoji" | "color" | "es_global"> | null
   archivos?: MovimientoArchivo[] // Lazy loaded - not included in default queries
 }
 

--- a/lib/utils/contacto-tipos.ts
+++ b/lib/utils/contacto-tipos.ts
@@ -1,0 +1,63 @@
+import type { ContactoTipo } from "@/lib/types/database"
+
+export interface ContactoTipoInfo {
+  value: ContactoTipo
+  label: string
+  shortLabel: string
+  descripcion: string
+  emoji: string
+  color: string
+  bgClass: string
+  textClass: string
+  borderClass: string
+}
+
+export const CONTACTO_TIPO_INFO: Record<ContactoTipo, ContactoTipoInfo> = {
+  proveedor: {
+    value: "proveedor",
+    label: "Proveedor",
+    shortLabel: "Proveedor",
+    descripcion: "Empresa o autónomo que nos vende o factura.",
+    emoji: "🏢",
+    color: "#3B82F6",
+    bgClass: "bg-blue-100 dark:bg-blue-950/40",
+    textClass: "text-blue-700 dark:text-blue-300",
+    borderClass: "border-blue-200 dark:border-blue-900",
+  },
+  persona_mcm: {
+    value: "persona_mcm",
+    label: "Persona MCM",
+    shortLabel: "Persona",
+    descripcion: "Socio, voluntario, monitor, miembro de equipo. Candidato a reembolsos.",
+    emoji: "🧑",
+    color: "#10B981",
+    bgClass: "bg-emerald-100 dark:bg-emerald-950/40",
+    textClass: "text-emerald-700 dark:text-emerald-300",
+    borderClass: "border-emerald-200 dark:border-emerald-900",
+  },
+  destinatario_mcm: {
+    value: "destinatario_mcm",
+    label: "Destinatario MCM",
+    shortLabel: "Destinatario",
+    descripcion: "Destinatario final de nuestras actividades o su familia. Suele ser origen de ingresos.",
+    emoji: "🎯",
+    color: "#F59E0B",
+    bgClass: "bg-amber-100 dark:bg-amber-950/40",
+    textClass: "text-amber-700 dark:text-amber-300",
+    borderClass: "border-amber-200 dark:border-amber-900",
+  },
+}
+
+export const CONTACTO_TIPO_ORDER: ContactoTipo[] = ["proveedor", "persona_mcm", "destinatario_mcm"]
+
+export function getContactoTipoInfo(tipo: ContactoTipo): ContactoTipoInfo {
+  return CONTACTO_TIPO_INFO[tipo]
+}
+
+export function getDefaultEmoji(tipo: ContactoTipo): string {
+  return CONTACTO_TIPO_INFO[tipo].emoji
+}
+
+export function getDefaultColor(tipo: ContactoTipo): string {
+  return CONTACTO_TIPO_INFO[tipo].color
+}

--- a/lib/utils/iban.ts
+++ b/lib/utils/iban.ts
@@ -1,0 +1,42 @@
+// Utilidades mínimas para IBAN: limpiar, formatear y validar mod-97.
+
+export function normalizarIban(value: string | null | undefined): string {
+  if (!value) return ""
+  return value.replace(/\s+/g, "").toUpperCase()
+}
+
+export function formatearIban(value: string | null | undefined): string {
+  const clean = normalizarIban(value)
+  if (!clean) return ""
+  return clean.match(/.{1,4}/g)?.join(" ") ?? clean
+}
+
+// Valida con el algoritmo mod-97 (estándar ISO 13616).
+// Devuelve true si parece un IBAN válido o si está vacío (campo opcional).
+export function validarIban(value: string | null | undefined): boolean {
+  const iban = normalizarIban(value)
+  if (!iban) return true
+  if (iban.length < 15 || iban.length > 34) return false
+  if (!/^[A-Z]{2}[0-9]{2}[A-Z0-9]+$/.test(iban)) return false
+
+  // Mover los 4 primeros caracteres al final y reemplazar letras por números (A=10..Z=35)
+  const rearranged = iban.slice(4) + iban.slice(0, 4)
+  let numeric = ""
+  for (const char of rearranged) {
+    const code = char.charCodeAt(0)
+    if (code >= 48 && code <= 57) {
+      numeric += char
+    } else if (code >= 65 && code <= 90) {
+      numeric += (code - 55).toString()
+    } else {
+      return false
+    }
+  }
+
+  // Mod 97 sobre cadena larga
+  let remainder = 0
+  for (let i = 0; i < numeric.length; i++) {
+    remainder = (remainder * 10 + Number(numeric[i])) % 97
+  }
+  return remainder === 1
+}

--- a/scripts/040_create_contacto.sql
+++ b/scripts/040_create_contacto.sql
@@ -1,0 +1,132 @@
+-- Crear tabla de contactos: directorio reutilizable por delegación con 3 tipos:
+--   - proveedor: empresa o autónomo que nos factura
+--   - persona_mcm: socio, voluntario, monitor, miembro de equipo (reembolsable)
+--   - destinatario_mcm: destinatario final de actividades o su familia (origen de ingresos)
+-- Incluye soporte para contactos globales (compartidos por toda la organización),
+-- solo creables por usuarios con rol gestor_central.
+
+CREATE TABLE IF NOT EXISTS public.contacto (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    delegacion_id UUID REFERENCES public.delegacion(id) ON DELETE CASCADE,
+    es_global BOOLEAN NOT NULL DEFAULT false,
+    tipo TEXT NOT NULL CHECK (tipo IN ('proveedor', 'persona_mcm', 'destinatario_mcm')),
+    nombre TEXT NOT NULL,
+    emoji TEXT,
+    color TEXT,
+    identificador_fiscal TEXT,
+    iban TEXT,
+    email TEXT,
+    telefono TEXT,
+    direccion TEXT,
+    ciudad TEXT,
+    codigo_postal TEXT,
+    categoria_id_predeterminada UUID REFERENCES public.categoria(id) ON DELETE SET NULL,
+    notas TEXT,
+    archivado BOOLEAN NOT NULL DEFAULT false,
+    creado_por UUID,
+    creado_en TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now()),
+    actualizado_en TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now()),
+
+    -- Un contacto es global (sin delegación) o de delegación (con delegación), pero no ambos
+    CONSTRAINT contacto_scope_chk CHECK (
+        (es_global = true AND delegacion_id IS NULL)
+        OR (es_global = false AND delegacion_id IS NOT NULL)
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_contacto_delegacion_tipo ON public.contacto(delegacion_id, tipo);
+CREATE INDEX IF NOT EXISTS idx_contacto_delegacion_archivado_nombre ON public.contacto(delegacion_id, archivado, nombre);
+CREATE INDEX IF NOT EXISTS idx_contacto_es_global ON public.contacto(es_global) WHERE es_global = true;
+CREATE INDEX IF NOT EXISTS idx_contacto_categoria_pred ON public.contacto(categoria_id_predeterminada) WHERE categoria_id_predeterminada IS NOT NULL;
+
+-- Trigger BEFORE UPDATE para mantener actualizado_en
+CREATE OR REPLACE FUNCTION public.set_contacto_actualizado_en()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.actualizado_en = timezone('utc', now());
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_contacto_actualizado_en ON public.contacto;
+CREATE TRIGGER trg_contacto_actualizado_en
+    BEFORE UPDATE ON public.contacto
+    FOR EACH ROW
+    EXECUTE FUNCTION public.set_contacto_actualizado_en();
+
+-- RLS
+ALTER TABLE public.contacto ENABLE ROW LEVEL SECURITY;
+
+-- SELECT: contactos de mis delegaciones o globales (visibles a cualquier usuario autenticado con membresía)
+CREATE POLICY "Users can view contactos in their delegations or globals" ON public.contacto
+    FOR SELECT
+    USING (
+        es_global = true
+        OR EXISTS (
+            SELECT 1 FROM public.membresia mb
+            WHERE mb.delegacion_id = contacto.delegacion_id
+              AND mb.usuario_id = auth.uid()
+        )
+    );
+
+-- INSERT: contactos de delegación si soy miembro; globales solo si soy gestor_central en alguna delegación
+CREATE POLICY "Users can insert contactos in their delegations" ON public.contacto
+    FOR INSERT
+    WITH CHECK (
+        (es_global = false AND EXISTS (
+            SELECT 1 FROM public.membresia mb
+            WHERE mb.delegacion_id = contacto.delegacion_id
+              AND mb.usuario_id = auth.uid()
+        ))
+        OR (es_global = true AND EXISTS (
+            SELECT 1 FROM public.membresia mb
+            WHERE mb.usuario_id = auth.uid()
+              AND mb.rol = 'gestor_central'
+        ))
+    );
+
+-- UPDATE: mismas reglas
+CREATE POLICY "Users can update contactos in their delegations" ON public.contacto
+    FOR UPDATE
+    USING (
+        (es_global = false AND EXISTS (
+            SELECT 1 FROM public.membresia mb
+            WHERE mb.delegacion_id = contacto.delegacion_id
+              AND mb.usuario_id = auth.uid()
+        ))
+        OR (es_global = true AND EXISTS (
+            SELECT 1 FROM public.membresia mb
+            WHERE mb.usuario_id = auth.uid()
+              AND mb.rol = 'gestor_central'
+        ))
+    );
+
+-- DELETE: mismas reglas
+CREATE POLICY "Users can delete contactos in their delegations" ON public.contacto
+    FOR DELETE
+    USING (
+        (es_global = false AND EXISTS (
+            SELECT 1 FROM public.membresia mb
+            WHERE mb.delegacion_id = contacto.delegacion_id
+              AND mb.usuario_id = auth.uid()
+        ))
+        OR (es_global = true AND EXISTS (
+            SELECT 1 FROM public.membresia mb
+            WHERE mb.usuario_id = auth.uid()
+              AND mb.rol = 'gestor_central'
+        ))
+    );
+
+-- Añadir vínculo opcional desde movimiento a contacto
+ALTER TABLE public.movimiento
+    ADD COLUMN IF NOT EXISTS contacto_id UUID REFERENCES public.contacto(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_movimiento_contacto_id
+    ON public.movimiento(contacto_id)
+    WHERE contacto_id IS NOT NULL;
+
+COMMENT ON TABLE public.contacto IS 'Directorio de contactos: proveedores, personas MCM (reembolsables) y destinatarios MCM (origen de ingresos).';
+COMMENT ON COLUMN public.contacto.es_global IS 'Si true, contacto global visible y editable por gestores centrales. Si false, scope por delegacion_id.';
+COMMENT ON COLUMN public.contacto.tipo IS 'proveedor | persona_mcm | destinatario_mcm';
+COMMENT ON COLUMN public.contacto.categoria_id_predeterminada IS 'Categoría sugerida al crear un movimiento vinculado a este contacto.';
+COMMENT ON COLUMN public.movimiento.contacto_id IS 'Contacto opcional vinculado al movimiento (sustituye al texto libre contraparte).';


### PR DESCRIPTION
- Tabla contacto (proveedor / persona_mcm / destinatario_mcm) con RLS y
  soporte de contactos globales solo gestionables por gestor_central.
- Columna movimiento.contacto_id (FK opcional, ON DELETE SET NULL).
- Página /contactos con tabs por tipo, búsqueda, archivado, copia rápida
  de IBAN/email/teléfono, formulario completo (emoji+color+CIF+IBAN
  validado mod-97+dirección+categoría predeterminada+notas) y panel
  lateral con histórico de movimientos vinculados y totales.
- Selector de contacto en crear/editar movimiento con búsqueda, creación
  inline en sheet anidado y autocompletado de la categoría sugerida.
- Filtros por contacto y por tipo en el panel de movimientos, badge en
  filas, búsqueda global que también encuentra por nombre de contacto.
- Hook useClipboard reutilizable y refresco de contadores del sidebar.