### PR TITLE
feat(cuentas): IBAN con espacios en bloques de 4 y matching normalizado en Enable Banking

### DIFF
--- a/app/api/bank-sync/callback/route.ts
+++ b/app/api/bank-sync/callback/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server"
 import { createAdminClient } from "@/lib/supabase/admin"
 import { enableBanking, EnableBankingError } from "@/lib/enable-banking/client"
+import { normalizarIban } from "@/lib/utils/iban"
 
 export const runtime = "nodejs"
 
@@ -67,11 +68,14 @@ export async function GET(request: Request) {
       return NextResponse.redirect(`${redirectBase}?bank_sync_error=cuenta_no_encontrada`)
     }
 
+    // Comparamos IBANs normalizados (sin espacios, mayúsculas) para que dé
+    // igual si el usuario lo escribió en bloques de 4.
+    const cuentaIban = normalizarIban(cuenta.iban)
     let match = session.accounts.find(
       (a) =>
-        cuenta.iban &&
-        (a.account_id.iban === cuenta.iban ||
-          a.all_account_ids?.some((id) => id.iban === cuenta.iban)),
+        cuentaIban &&
+        (normalizarIban(a.account_id.iban) === cuentaIban ||
+          a.all_account_ids?.some((id) => normalizarIban(id.iban) === cuentaIban)),
     )
     if (!match && session.accounts.length === 1) {
       match = session.accounts[0]
@@ -99,7 +103,7 @@ export async function GET(request: Request) {
         sync_enabled: true,
         origen: "conectada",
         // Si la cuenta no tenía IBAN, lo copiamos del account de EB
-        iban: cuenta.iban || match.account_id.iban || null,
+        iban: cuentaIban || normalizarIban(match.account_id.iban) || null,
       })
       .eq("id", cuentaId)
 

--- a/components/cuentas/cuenta-edit-form.tsx
+++ b/components/cuentas/cuenta-edit-form.tsx
@@ -12,6 +12,7 @@ import { Textarea } from "@/components/ui/textarea"
 import { Card, CardContent } from "@/components/ui/card"
 import { ColorPicker } from "@/components/ui/color-picker"
 import type { Cuenta } from "@/lib/types/database"
+import { formatearIban, normalizarIban } from "@/lib/utils/iban"
 
 interface CuentaEditFormProps {
   cuenta: Cuenta
@@ -25,7 +26,7 @@ export function CuentaEditForm({ cuenta, onSave, onCancel }: CuentaEditFormProps
     tipo: cuenta.tipo || "banco",
     origen: cuenta.origen || "manual",
     banco_nombre: cuenta.banco_nombre || "",
-    iban: cuenta.iban || "",
+    iban: formatearIban(cuenta.iban),
     color: cuenta.color || "#4ECDC4",
     personas_autorizadas: cuenta.personas_autorizadas || "",
     descripcion: cuenta.descripcion || "",
@@ -66,7 +67,7 @@ export function CuentaEditForm({ cuenta, onSave, onCancel }: CuentaEditFormProps
         tipo: formData.tipo as "banco" | "caja",
         origen: formData.origen as "manual" | "conectada",
         banco_nombre: formData.tipo === "banco" ? formData.banco_nombre.trim() : null,
-        iban: formData.tipo === "banco" ? formData.iban.trim() : null,
+        iban: formData.tipo === "banco" ? normalizarIban(formData.iban) || null : null,
         color: formData.color,
         personas_autorizadas: formData.personas_autorizadas,
         descripcion: formData.descripcion.trim() || null,
@@ -183,6 +184,7 @@ export function CuentaEditForm({ cuenta, onSave, onCancel }: CuentaEditFormProps
             id="iban"
             value={formData.iban}
             onChange={(e) => setFormData({ ...formData, iban: e.target.value })}
+            onBlur={() => setFormData((prev) => ({ ...prev, iban: formatearIban(prev.iban) }))}
             placeholder="ES91 2100 0418 4502 0005 1332"
           />
         </div>

--- a/components/cuentas/cuentas-manager.tsx
+++ b/components/cuentas/cuentas-manager.tsx
@@ -19,6 +19,7 @@ import { useCuentas } from "@/hooks/use-cuentas"
 import { useDelegationContext } from "@/contexts/delegation-context"
 import { supabase } from "@/lib/supabase/client"
 import { formatCurrency } from "@/lib/utils/format"
+import { formatearIban } from "@/lib/utils/iban"
 import { toast } from "sonner"
 
 export function CuentasManager() {
@@ -670,7 +671,7 @@ export function CuentasManager() {
                         {cuenta.tipo === "banco" && cuenta.iban && (
                           <div className="flex items-center gap-2 flex-wrap">
                             <code className="text-xs sm:text-sm text-muted-foreground font-mono bg-muted px-2 sm:px-3 py-1 sm:py-1.5 rounded-md border break-all inline-block">
-                              {cuenta.iban}
+                              {formatearIban(cuenta.iban)}
                             </code>
                             <Popover>
                               <PopoverTrigger asChild>


### PR DESCRIPTION
- El callback de Enable Banking compara IBANs normalizados (sin espacios,
  mayúsculas), así el linkado funciona aunque el usuario escriba el IBAN
  en bloques de 4.
- El formulario de cuentas formatea el IBAN en bloques de 4 al salir del
  campo y lo guarda normalizado, igual que el formulario de contactos.
- La tarjeta de cuenta muestra el IBAN formateado en bloques de 4.

https://claude.ai/code/session_019f74ZkZjBLfwSrMXLTTf3y