### PR TITLE
feat(api): API externa de solo lectura para consultar movimientos

### DIFF
--- a/app/api/v1/movimientos/[id]/archivos/route.ts
+++ b/app/api/v1/movimientos/[id]/archivos/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from "next/server"
+import { createAdminClient } from "@/lib/supabase/admin"
+import { verifyApiKey } from "@/lib/api/external-auth"
+import {
+  getMovimientoRaw,
+  getArchivosRaw,
+  serializeArchivo,
+} from "@/lib/api/movimientos-public"
+
+export const runtime = "nodejs"
+
+/**
+ * GET /api/v1/movimientos/{id}/archivos
+ *
+ * API externa: devuelve únicamente los archivos adjuntos de un movimiento, con
+ * su URL pública de descarga. Pensado para flujos que solo necesitan los
+ * ficheros (p.ej. descargar facturas desde Google Apps Script).
+ *
+ * Autenticación: cabecera `Authorization: Bearer <clave>` o `x-api-key: <clave>`.
+ */
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = verifyApiKey(request)
+  if (!auth.ok) {
+    return NextResponse.json({ ok: false, error: auth.error }, { status: auth.status })
+  }
+
+  const { id } = await params
+  if (!id) {
+    return NextResponse.json({ ok: false, error: "Falta el ID del movimiento." }, { status: 400 })
+  }
+
+  try {
+    const admin = createAdminClient()
+
+    // Verificamos que el movimiento exista para distinguir "sin archivos" de
+    // "movimiento inexistente".
+    const movimiento = await getMovimientoRaw(admin, id)
+    if (!movimiento) {
+      return NextResponse.json(
+        { ok: false, error: "Movimiento no encontrado." },
+        { status: 404 },
+      )
+    }
+
+    const archivosRaw = await getArchivosRaw(admin, id)
+    const archivos = archivosRaw.map(serializeArchivo)
+
+    return NextResponse.json({
+      ok: true,
+      movimiento_id: id,
+      total: archivos.length,
+      archivos,
+    })
+  } catch (err) {
+    return NextResponse.json(
+      { ok: false, error: err instanceof Error ? err.message : String(err) },
+      { status: 500 },
+    )
+  }
+}

--- a/app/api/v1/movimientos/[id]/route.ts
+++ b/app/api/v1/movimientos/[id]/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from "next/server"
+import { createAdminClient } from "@/lib/supabase/admin"
+import { verifyApiKey } from "@/lib/api/external-auth"
+import {
+  getMovimientoRaw,
+  getArchivosRaw,
+  serializeArchivo,
+  serializeMovimiento,
+} from "@/lib/api/movimientos-public"
+
+export const runtime = "nodejs"
+
+/**
+ * GET /api/v1/movimientos/{id}
+ *
+ * API externa (Google Apps Script u otras apps internas). Devuelve un movimiento
+ * por su ID, con sus relaciones (cuenta, categoría, delegación, contacto) y la
+ * lista de archivos adjuntos embebida.
+ *
+ * Autenticación: cabecera `Authorization: Bearer <clave>` o `x-api-key: <clave>`.
+ * El ID es único en toda la base de datos, así que no hace falta indicar la
+ * delegación.
+ */
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = verifyApiKey(request)
+  if (!auth.ok) {
+    return NextResponse.json({ ok: false, error: auth.error }, { status: auth.status })
+  }
+
+  const { id } = await params
+  if (!id) {
+    return NextResponse.json({ ok: false, error: "Falta el ID del movimiento." }, { status: 400 })
+  }
+
+  try {
+    const admin = createAdminClient()
+    const movimiento = await getMovimientoRaw(admin, id)
+    if (!movimiento) {
+      return NextResponse.json(
+        { ok: false, error: "Movimiento no encontrado." },
+        { status: 404 },
+      )
+    }
+
+    const archivosRaw = await getArchivosRaw(admin, id)
+    const archivos = archivosRaw.map(serializeArchivo)
+
+    return NextResponse.json({
+      ok: true,
+      movimiento: serializeMovimiento(movimiento, archivos),
+    })
+  } catch (err) {
+    return NextResponse.json(
+      { ok: false, error: err instanceof Error ? err.message : String(err) },
+      { status: 500 },
+    )
+  }
+}

--- a/app/api/v1/openapi.json/route.ts
+++ b/app/api/v1/openapi.json/route.ts
@@ -1,0 +1,249 @@
+import { NextResponse } from "next/server"
+
+export const runtime = "nodejs"
+
+/**
+ * GET /api/v1/openapi.json
+ *
+ * Especificación OpenAPI 3.1 de la API externa. Es la "fuente de verdad"
+ * legible por máquinas: la consumen tanto la página de documentación (Scalar)
+ * como agentes de IA y generadores de clientes.
+ *
+ * Pública (no contiene secretos). El servidor se calcula a partir del origen de
+ * la petición para que el "try it out" apunte al dominio correcto.
+ */
+export async function GET(request: Request) {
+  const url = new URL(request.url)
+  const origin = `${url.protocol}//${url.host}`
+
+  const spec = {
+    openapi: "3.1.0",
+    info: {
+      title: "MCM Bank API externa",
+      version: "1.0.0",
+      description:
+        "API de solo lectura para consultar movimientos de MCM Bank desde " +
+        "aplicaciones internas (p.ej. Google Apps Script). El ID de un " +
+        "movimiento es único en toda la base de datos, así que no hace falta " +
+        "indicar la delegación.\n\n" +
+        "**Autenticación:** envía la clave en la cabecera `Authorization: " +
+        "Bearer <clave>` o `x-api-key: <clave>`.",
+    },
+    servers: [{ url: origin, description: "Servidor actual" }],
+    tags: [{ name: "Movimientos", description: "Consulta de movimientos y sus archivos" }],
+    security: [{ apiKeyHeader: [] }, { bearerAuth: [] }],
+    paths: {
+      "/api/v1/movimientos/{id}": {
+        get: {
+          tags: ["Movimientos"],
+          summary: "Obtener un movimiento por su ID (datos + archivos)",
+          description:
+            "Devuelve el movimiento con sus relaciones (cuenta, categoría, " +
+            "delegación, contacto) y la lista de archivos adjuntos embebida.",
+          operationId: "getMovimiento",
+          parameters: [
+            {
+              name: "id",
+              in: "path",
+              required: true,
+              description: "ID (UUID) del movimiento.",
+              schema: { type: "string", format: "uuid" },
+            },
+          ],
+          responses: {
+            "200": {
+              description: "Movimiento encontrado.",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      ok: { type: "boolean", const: true },
+                      movimiento: { $ref: "#/components/schemas/Movimiento" },
+                    },
+                    required: ["ok", "movimiento"],
+                  },
+                },
+              },
+            },
+            "400": { $ref: "#/components/responses/Error" },
+            "401": { $ref: "#/components/responses/Error" },
+            "404": { $ref: "#/components/responses/Error" },
+            "500": { $ref: "#/components/responses/Error" },
+          },
+        },
+      },
+      "/api/v1/movimientos/{id}/archivos": {
+        get: {
+          tags: ["Movimientos"],
+          summary: "Obtener solo los archivos de un movimiento",
+          description:
+            "Devuelve únicamente los archivos adjuntos del movimiento, con su " +
+            "URL pública de descarga.",
+          operationId: "getMovimientoArchivos",
+          parameters: [
+            {
+              name: "id",
+              in: "path",
+              required: true,
+              description: "ID (UUID) del movimiento.",
+              schema: { type: "string", format: "uuid" },
+            },
+          ],
+          responses: {
+            "200": {
+              description: "Lista de archivos del movimiento.",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      ok: { type: "boolean", const: true },
+                      movimiento_id: { type: "string", format: "uuid" },
+                      total: { type: "integer" },
+                      archivos: {
+                        type: "array",
+                        items: { $ref: "#/components/schemas/Archivo" },
+                      },
+                    },
+                    required: ["ok", "movimiento_id", "total", "archivos"],
+                  },
+                },
+              },
+            },
+            "400": { $ref: "#/components/responses/Error" },
+            "401": { $ref: "#/components/responses/Error" },
+            "404": { $ref: "#/components/responses/Error" },
+            "500": { $ref: "#/components/responses/Error" },
+          },
+        },
+      },
+    },
+    components: {
+      securitySchemes: {
+        apiKeyHeader: {
+          type: "apiKey",
+          in: "header",
+          name: "x-api-key",
+          description: "Clave de API en la cabecera x-api-key.",
+        },
+        bearerAuth: {
+          type: "http",
+          scheme: "bearer",
+          description: "Clave de API como token Bearer en Authorization.",
+        },
+      },
+      responses: {
+        Error: {
+          description: "Error.",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  ok: { type: "boolean", const: false },
+                  error: { type: "string" },
+                },
+                required: ["ok", "error"],
+              },
+            },
+          },
+        },
+      },
+      schemas: {
+        Archivo: {
+          type: "object",
+          properties: {
+            id: { type: "string", format: "uuid" },
+            nombre_original: { type: "string" },
+            tipo_mime: { type: "string" },
+            tamano_bytes: { type: "integer" },
+            es_factura: { type: "boolean" },
+            descripcion: { type: ["string", "null"] },
+            bucket: { type: "string", examples: ["facturas", "documentos"] },
+            url: {
+              type: "string",
+              format: "uri",
+              description: "URL pública directa de descarga (sin autenticación).",
+            },
+            subido_en: { type: "string", format: "date-time" },
+          },
+          required: [
+            "id",
+            "nombre_original",
+            "tipo_mime",
+            "tamano_bytes",
+            "es_factura",
+            "bucket",
+            "url",
+            "subido_en",
+          ],
+        },
+        Movimiento: {
+          type: "object",
+          properties: {
+            id: { type: "string", format: "uuid" },
+            fecha: { type: "string", format: "date" },
+            concepto: { type: "string" },
+            descripcion: { type: ["string", "null"] },
+            contraparte: { type: ["string", "null"] },
+            importe: { type: "number", description: "Positivo = ingreso, negativo = gasto." },
+            tipo: { type: "string", enum: ["ingreso", "gasto"] },
+            metodo: { type: ["string", "null"] },
+            notas: { type: ["string", "null"] },
+            ignorado: { type: "boolean" },
+            booking_date: { type: ["string", "null"], format: "date" },
+            value_date: { type: ["string", "null"], format: "date" },
+            origen_sync: { type: ["string", "null"] },
+            creado_en: { type: "string", format: "date-time" },
+            cuenta: {
+              type: ["object", "null"],
+              properties: {
+                id: { type: "string", format: "uuid" },
+                nombre: { type: "string" },
+                tipo: { type: ["string", "null"] },
+                banco_nombre: { type: ["string", "null"] },
+                iban: { type: ["string", "null"] },
+              },
+            },
+            categoria: {
+              type: ["object", "null"],
+              properties: {
+                id: { type: "string", format: "uuid" },
+                nombre: { type: "string" },
+                tipo: { type: ["string", "null"] },
+                emoji: { type: ["string", "null"] },
+                color: { type: ["string", "null"] },
+              },
+            },
+            delegacion: {
+              type: ["object", "null"],
+              properties: {
+                id: { type: "string", format: "uuid" },
+                codigo: { type: ["string", "null"] },
+                nombre: { type: "string" },
+              },
+            },
+            contacto: {
+              type: ["object", "null"],
+              properties: {
+                id: { type: "string", format: "uuid" },
+                nombre: { type: "string" },
+                tipo: { type: ["string", "null"] },
+              },
+            },
+            archivos: {
+              type: "array",
+              items: { $ref: "#/components/schemas/Archivo" },
+            },
+          },
+          required: ["id", "fecha", "concepto", "importe", "tipo", "creado_en", "archivos"],
+        },
+      },
+    },
+  }
+
+  return NextResponse.json(spec, {
+    headers: { "Cache-Control": "public, max-age=300" },
+  })
+}

--- a/app/docs/api/route.ts
+++ b/app/docs/api/route.ts
@@ -1,0 +1,47 @@
+export const runtime = "nodejs"
+
+/**
+ * GET /docs/api
+ *
+ * Página de documentación interactiva de la API externa, renderizada con
+ * Scalar (cargado desde CDN). Apunta a la spec OpenAPI servida en
+ * /api/v1/openapi.json. Pública.
+ *
+ * Se devuelve como HTML directo (route handler) en lugar de página React para
+ * evitar conflictos de hidratación y de estilos globales con el widget de
+ * Scalar, que ocupa toda la página.
+ */
+export async function GET() {
+  const html = `<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>MCM Bank · API externa</title>
+    <link rel="icon" href="/favicon.ico" />
+    <style>
+      body { margin: 0; }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+    <script>
+      Scalar.createApiReference('#app', {
+        url: '/api/v1/openapi.json',
+        theme: 'default',
+        metaData: {
+          title: 'MCM Bank · API externa',
+        },
+      })
+    </script>
+  </body>
+</html>`
+
+  return new Response(html, {
+    headers: {
+      "Content-Type": "text/html; charset=utf-8",
+      "Cache-Control": "public, max-age=300",
+    },
+  })
+}

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -1,0 +1,67 @@
+export const runtime = "nodejs"
+
+/**
+ * GET /llms.txt
+ *
+ * Punto de entrada para agentes de IA (convención llms.txt). Markdown plano,
+ * público, que describe la API externa y enlaza a la spec OpenAPI y a la
+ * documentación interactiva, con URLs absolutas al dominio actual.
+ */
+export async function GET(request: Request) {
+  const url = new URL(request.url)
+  const origin = `${url.protocol}//${url.host}`
+
+  const body = `# MCM Bank — API externa
+
+> API de solo lectura para consultar movimientos (transacciones) de MCM Bank
+> desde aplicaciones internas como Google Apps Script. El ID de un movimiento es
+> único en toda la base de datos: no hace falta indicar la delegación.
+
+## Autenticación
+
+Todas las peticiones requieren una clave de API en una cabecera:
+
+- \`Authorization: Bearer <clave>\`  — o bien
+- \`x-api-key: <clave>\`
+
+La clave la configura el administrador del servidor (variable de entorno
+\`MCM_API_KEY\`, con respaldo en \`CRON_SECRET\`).
+
+## Recursos
+
+- Especificación OpenAPI 3.1 (fuente de verdad legible por máquinas): ${origin}/api/v1/openapi.json
+- Documentación interactiva (Scalar): ${origin}/docs/api
+
+## Endpoints
+
+### GET ${origin}/api/v1/movimientos/{id}
+Devuelve un movimiento por su ID con sus relaciones (cuenta, categoría,
+delegación, contacto) y la lista de archivos adjuntos embebida.
+
+### GET ${origin}/api/v1/movimientos/{id}/archivos
+Devuelve únicamente los archivos adjuntos del movimiento, con su URL pública de
+descarga directa (la descarga del fichero no requiere autenticación).
+
+## Ejemplo
+
+\`\`\`bash
+curl -H "x-api-key: TU_CLAVE" \\
+  ${origin}/api/v1/movimientos/00000000-0000-0000-0000-000000000000
+\`\`\`
+
+## Notas
+
+- El campo \`importe\` es positivo para ingresos y negativo para gastos; \`tipo\`
+  ('ingreso' | 'gasto') refleja ese signo.
+- Códigos de error: 400 (falta ID), 401 (clave inválida), 404 (no existe),
+  500 (error de servidor o API no configurada).
+- Formato de error: \`{ "ok": false, "error": "..." }\`.
+`
+
+  return new Response(body, {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "Cache-Control": "public, max-age=300",
+    },
+  })
+}

--- a/components/transactions/transaction-detail.tsx
+++ b/components/transactions/transaction-detail.tsx
@@ -5,7 +5,8 @@ import type React from "react"
 import { useState, useEffect, useMemo } from "react"
 import { format } from "date-fns"
 import { es } from "date-fns/locale"
-import { CalendarIcon, AlertTriangle, Check, Loader2, ArrowLeft } from "lucide-react"
+import { CalendarIcon, AlertTriangle, Check, Loader2, ArrowLeft, Copy } from "lucide-react"
+import { toast } from "sonner"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -592,6 +593,32 @@ export function TransactionDetail({
                       className="resize-none"
                     />
                   </div>
+
+                  {movement && (
+                    <div className="space-y-2 border-t pt-4">
+                      <Label className="text-xs font-medium text-muted-foreground">
+                        ID del movimiento (API)
+                      </Label>
+                      <div className="flex items-center gap-2">
+                        <code className="flex-1 truncate rounded-md bg-muted px-2 py-1.5 font-mono text-xs">
+                          {movement.id}
+                        </code>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          className="shrink-0"
+                          onClick={() => {
+                            navigator.clipboard.writeText(movement.id)
+                            toast.success("ID copiado al portapapeles")
+                          }}
+                        >
+                          <Copy className="h-3.5 w-3.5" />
+                          <span className="ml-1.5">Copiar</span>
+                        </Button>
+                      </div>
+                    </div>
+                  )}
                 </TabsContent>
                 <TabsContent value="archivos" className="space-y-6 mt-6" forceMount>
                   <TransactionFiles

--- a/docs/08-api-externa.md
+++ b/docs/08-api-externa.md
@@ -8,6 +8,17 @@ consultas desde fuera para recibir toda su información y sus archivos adjuntos.
 Como el ID es único en toda la base de datos, **no hace falta indicar la
 delegación**.
 
+## Documentación interactiva y recursos para agentes de IA
+
+| Recurso | URL | Para qué |
+|---------|-----|----------|
+| **Documentación interactiva** | `https://TU-DOMINIO/docs/api` | Página web (Scalar) con "try it out". |
+| **OpenAPI 3.1** | `https://TU-DOMINIO/api/v1/openapi.json` | Spec legible por máquinas (agentes IA, generadores de clientes). |
+| **llms.txt** | `https://TU-DOMINIO/llms.txt` | Punto de entrada estándar para agentes de IA. |
+
+Todos son públicos (no contienen secretos) y se sirven con URLs absolutas al
+dominio actual.
+
 ## Autenticación
 
 Todas las peticiones requieren una **clave secreta** que se envía en una

--- a/docs/08-api-externa.md
+++ b/docs/08-api-externa.md
@@ -1,0 +1,197 @@
+# API externa (consulta de movimientos)
+
+MCM Bank expone una pequeña API de solo lectura para consultar movimientos
+desde otras aplicaciones internas (por ejemplo, un **Google Apps Script**).
+
+La idea es simple: copias el **ID de un movimiento** desde la aplicación y lo
+consultas desde fuera para recibir toda su información y sus archivos adjuntos.
+Como el ID es único en toda la base de datos, **no hace falta indicar la
+delegación**.
+
+## Autenticación
+
+Todas las peticiones requieren una **clave secreta** que se envía en una
+cabecera. Se acepta cualquiera de estas dos formas:
+
+```
+Authorization: Bearer TU_CLAVE
+```
+
+o bien:
+
+```
+x-api-key: TU_CLAVE
+```
+
+La clave se configura en el servidor mediante variables de entorno:
+
+- `MCM_API_KEY` — variable dedicada (recomendada si quieres una clave separada).
+- Si no está definida, se reutiliza `CRON_SECRET` (el secreto que ya usa el cron
+  de sincronización bancaria).
+
+> Para rotar la clave, cambia el valor en las variables de entorno del proyecto
+> (Vercel) y vuelve a desplegar.
+
+## Cómo obtener el ID de un movimiento
+
+1. Abre **Transacciones** en la app.
+2. Haz clic en un movimiento para abrir su detalle.
+3. En la pestaña **Datos**, al final, verás **«ID del movimiento (API)»** con un
+   botón **Copiar**.
+
+## Endpoints
+
+Base: `https://TU-DOMINIO/api/v1`
+
+### 1. Movimiento completo (datos + archivos)
+
+```
+GET /api/v1/movimientos/{id}
+```
+
+Respuesta `200`:
+
+```json
+{
+  "ok": true,
+  "movimiento": {
+    "id": "9f1c...",
+    "fecha": "2026-05-21",
+    "concepto": "Compra material oficina",
+    "descripcion": null,
+    "contraparte": "PAPELERIA XYZ",
+    "importe": -42.5,
+    "tipo": "gasto",
+    "metodo": "tarjeta",
+    "notas": null,
+    "ignorado": false,
+    "booking_date": "2026-05-21",
+    "value_date": "2026-05-22",
+    "origen_sync": "enablebanking",
+    "creado_en": "2026-05-22T08:10:00.000Z",
+    "cuenta": {
+      "id": "...",
+      "nombre": "Cuenta principal",
+      "tipo": "banco",
+      "banco_nombre": "CaixaBank",
+      "iban": "ES12 ...."
+    },
+    "categoria": {
+      "id": "...",
+      "nombre": "Material oficina",
+      "tipo": "gasto",
+      "emoji": "📎",
+      "color": "blue"
+    },
+    "delegacion": { "id": "...", "codigo": "MAD", "nombre": "Madrid" },
+    "contacto": { "id": "...", "nombre": "Papelería XYZ", "tipo": "proveedor" },
+    "archivos": [
+      {
+        "id": "...",
+        "nombre_original": "factura.pdf",
+        "tipo_mime": "application/pdf",
+        "tamano_bytes": 102400,
+        "es_factura": true,
+        "descripcion": null,
+        "bucket": "facturas",
+        "url": "https://....supabase.co/storage/v1/object/public/facturas/...",
+        "subido_en": "2026-05-22T08:12:00.000Z"
+      }
+    ]
+  }
+}
+```
+
+### 2. Solo archivos de un movimiento
+
+```
+GET /api/v1/movimientos/{id}/archivos
+```
+
+Respuesta `200`:
+
+```json
+{
+  "ok": true,
+  "movimiento_id": "9f1c...",
+  "total": 1,
+  "archivos": [
+    {
+      "id": "...",
+      "nombre_original": "factura.pdf",
+      "tipo_mime": "application/pdf",
+      "tamano_bytes": 102400,
+      "es_factura": true,
+      "descripcion": null,
+      "bucket": "facturas",
+      "url": "https://....supabase.co/storage/v1/object/public/facturas/...",
+      "subido_en": "2026-05-22T08:12:00.000Z"
+    }
+  ]
+}
+```
+
+El campo `url` es una URL pública directa: puedes descargar el archivo con un
+`GET` normal (sin cabecera de autenticación).
+
+### Errores
+
+| Código | Significado |
+|--------|-------------|
+| `400` | Falta el ID del movimiento. |
+| `401` | Falta la clave o no es válida. |
+| `404` | El movimiento no existe. |
+| `500` | Error del servidor (o la API no está configurada). |
+
+Formato de error:
+
+```json
+{ "ok": false, "error": "Movimiento no encontrado." }
+```
+
+## Ejemplo con `curl`
+
+```bash
+curl -H "x-api-key: TU_CLAVE" \
+  https://TU-DOMINIO/api/v1/movimientos/9f1c0000-0000-0000-0000-000000000000
+```
+
+## Ejemplo con Google Apps Script
+
+```javascript
+const BASE = "https://TU-DOMINIO/api/v1";
+const API_KEY = "TU_CLAVE"; // mejor en PropertiesService
+
+/** Devuelve el movimiento completo (datos + archivos). */
+function getMovimiento(id) {
+  const res = UrlFetchApp.fetch(`${BASE}/movimientos/${id}`, {
+    method: "get",
+    headers: { "x-api-key": API_KEY },
+    muteHttpExceptions: true,
+  });
+  const body = JSON.parse(res.getContentText());
+  if (res.getResponseCode() !== 200 || !body.ok) {
+    throw new Error(body.error || "Error consultando el movimiento");
+  }
+  return body.movimiento;
+}
+
+/** Descarga la primera factura de un movimiento a una carpeta de Drive. */
+function descargarFacturas(id) {
+  const mov = getMovimiento(id);
+  mov.archivos.forEach((archivo) => {
+    const blob = UrlFetchApp.fetch(archivo.url).getBlob();
+    blob.setName(archivo.nombre_original);
+    DriveApp.createFile(blob);
+  });
+}
+
+function ejemplo() {
+  const mov = getMovimiento("9f1c0000-0000-0000-0000-000000000000");
+  Logger.log(`${mov.fecha} · ${mov.concepto} · ${mov.importe} €`);
+}
+```
+
+> Recomendación: guarda la clave con
+> `PropertiesService.getScriptProperties().getProperty("MCM_API_KEY")` en lugar
+> de escribirla directamente en el código.

--- a/lib/api/external-auth.ts
+++ b/lib/api/external-auth.ts
@@ -1,0 +1,73 @@
+/**
+ * Autenticación para la API externa (consumo desde Google Apps Script u otras
+ * aplicaciones internas).
+ *
+ * Estrategia deliberadamente simple: una clave secreta compartida que se envía
+ * en cada petición. Se acepta en dos formatos para comodidad del cliente:
+ *
+ *   - Cabecera `Authorization: Bearer <clave>`
+ *   - Cabecera `x-api-key: <clave>`
+ *
+ * La clave válida se lee de las variables de entorno. Se admite una variable
+ * dedicada `MCM_API_KEY` y, como respaldo, se reutiliza `CRON_SECRET` (que ya
+ * existe para el cron de sincronización bancaria). Esto permite empezar sin
+ * añadir variables nuevas y, más adelante, separar las claves si interesa.
+ */
+
+/**
+ * Devuelve la clave de API configurada, o `null` si no hay ninguna.
+ * El orden de preferencia es: `MCM_API_KEY` y luego `CRON_SECRET`.
+ */
+function getConfiguredApiKey(): string | null {
+  return process.env.MCM_API_KEY || process.env.CRON_SECRET || null
+}
+
+/**
+ * Extrae la clave enviada por el cliente desde las cabeceras de la petición.
+ */
+function extractRequestKey(request: Request): string | null {
+  const authHeader = request.headers.get("authorization") || ""
+  if (authHeader.toLowerCase().startsWith("bearer ")) {
+    return authHeader.slice(7).trim()
+  }
+  const apiKeyHeader = request.headers.get("x-api-key")
+  if (apiKeyHeader) {
+    return apiKeyHeader.trim()
+  }
+  return null
+}
+
+export type ApiAuthResult =
+  | { ok: true }
+  | { ok: false; status: 401 | 500; error: string }
+
+/**
+ * Verifica que la petición incluya una clave de API válida.
+ *
+ * - 500 si el servidor no tiene ninguna clave configurada (mala configuración).
+ * - 401 si falta la clave o no coincide.
+ * - `{ ok: true }` si la autenticación es correcta.
+ */
+export function verifyApiKey(request: Request): ApiAuthResult {
+  const configuredKey = getConfiguredApiKey()
+  if (!configuredKey) {
+    return {
+      ok: false,
+      status: 500,
+      error:
+        "La API externa no está configurada en el servidor (falta MCM_API_KEY o CRON_SECRET).",
+    }
+  }
+
+  const providedKey = extractRequestKey(request)
+  if (!providedKey || providedKey !== configuredKey) {
+    return {
+      ok: false,
+      status: 401,
+      error:
+        "No autorizado. Envía la clave en 'Authorization: Bearer <clave>' o en la cabecera 'x-api-key'.",
+    }
+  }
+
+  return { ok: true }
+}

--- a/lib/api/movimientos-public.ts
+++ b/lib/api/movimientos-public.ts
@@ -1,0 +1,212 @@
+/**
+ * Lógica de datos y serialización para la API externa de movimientos.
+ *
+ * Se separa de las rutas para que tanto el endpoint combinado
+ * (`/api/v1/movimientos/[id]`) como el de archivos
+ * (`/api/v1/movimientos/[id]/archivos`) compartan exactamente el mismo formato
+ * de salida.
+ *
+ * El acceso se hace con el cliente admin (service role), de modo que la consulta
+ * por ID es global y no depende de la delegación seleccionada ni de RLS: un ID
+ * de movimiento es único en toda la base de datos.
+ */
+import type { createAdminClient } from "@/lib/supabase/admin"
+
+type AdminClient = ReturnType<typeof createAdminClient>
+
+/** Forma pública de un archivo adjunto. */
+export interface ArchivoPublico {
+  id: string
+  nombre_original: string
+  tipo_mime: string
+  tamano_bytes: number
+  es_factura: boolean
+  descripcion: string | null
+  bucket: string
+  url: string
+  subido_en: string
+}
+
+/** Forma pública de un movimiento (sin campos internos sensibles). */
+export interface MovimientoPublico {
+  id: string
+  fecha: string
+  concepto: string
+  descripcion: string | null
+  contraparte: string | null
+  importe: number
+  tipo: "ingreso" | "gasto"
+  metodo: string | null
+  notas: string | null
+  ignorado: boolean
+  booking_date: string | null
+  value_date: string | null
+  origen_sync: string | null
+  creado_en: string
+  cuenta: {
+    id: string
+    nombre: string
+    tipo: string | null
+    banco_nombre: string | null
+    iban: string | null
+  } | null
+  categoria: {
+    id: string
+    nombre: string
+    tipo: string | null
+    emoji: string | null
+    color: string | null
+  } | null
+  delegacion: {
+    id: string
+    codigo: string | null
+    nombre: string
+  } | null
+  contacto: {
+    id: string
+    nombre: string
+    tipo: string | null
+  } | null
+  archivos: ArchivoPublico[]
+}
+
+const MOVIMIENTO_SELECT = `
+  id,
+  fecha,
+  concepto,
+  descripcion,
+  contraparte,
+  importe,
+  metodo,
+  notas,
+  ignorado,
+  booking_date,
+  value_date,
+  origen_sync,
+  creado_en,
+  cuenta:cuenta_id (
+    id,
+    nombre,
+    tipo,
+    banco_nombre,
+    iban
+  ),
+  categoria:categoria_id (
+    id,
+    nombre,
+    tipo,
+    emoji,
+    color
+  ),
+  delegacion:delegacion_id (
+    id,
+    codigo,
+    nombre
+  ),
+  contacto:contacto_id (
+    id,
+    nombre,
+    tipo
+  )
+`
+
+/**
+ * Obtiene un movimiento por su ID con sus relaciones (cuenta, categoría,
+ * delegación, contacto). Devuelve `null` si no existe.
+ */
+export async function getMovimientoRaw(admin: AdminClient, id: string) {
+  const { data, error } = await (admin as any)
+    .from("movimiento")
+    .select(MOVIMIENTO_SELECT)
+    .eq("id", id)
+    .maybeSingle()
+
+  if (error) throw error
+  return data ?? null
+}
+
+/**
+ * Obtiene los archivos adjuntos de un movimiento, ordenados por fecha de subida.
+ */
+export async function getArchivosRaw(admin: AdminClient, movimientoId: string) {
+  const { data, error } = await (admin as any)
+    .from("movimiento_archivo")
+    .select("*")
+    .eq("movimiento_id", movimientoId)
+    .order("subido_en", { ascending: true })
+
+  if (error) throw error
+  return (data ?? []) as any[]
+}
+
+/** Serializa una fila de `movimiento_archivo` al formato público. */
+export function serializeArchivo(row: any): ArchivoPublico {
+  return {
+    id: row.id,
+    nombre_original: row.nombre_original,
+    tipo_mime: row.tipo_mime,
+    // La columna en BD es `tamaño_bytes` (con ñ); se expone sin ñ para clientes.
+    tamano_bytes: row["tamaño_bytes"] ?? row.tamano_bytes ?? 0,
+    es_factura: !!row.es_factura,
+    descripcion: row.descripcion ?? null,
+    bucket: row.bucket,
+    url: row.url_publica,
+    subido_en: row.subido_en,
+  }
+}
+
+/** Serializa un movimiento (con relaciones ya embebidas) al formato público. */
+export function serializeMovimiento(
+  row: any,
+  archivos: ArchivoPublico[],
+): MovimientoPublico {
+  return {
+    id: row.id,
+    fecha: row.fecha,
+    concepto: row.concepto,
+    descripcion: row.descripcion ?? null,
+    contraparte: row.contraparte ?? null,
+    importe: row.importe,
+    tipo: Number(row.importe) >= 0 ? "ingreso" : "gasto",
+    metodo: row.metodo ?? null,
+    notas: row.notas ?? null,
+    ignorado: !!row.ignorado,
+    booking_date: row.booking_date ?? null,
+    value_date: row.value_date ?? null,
+    origen_sync: row.origen_sync ?? null,
+    creado_en: row.creado_en,
+    cuenta: row.cuenta
+      ? {
+          id: row.cuenta.id,
+          nombre: row.cuenta.nombre,
+          tipo: row.cuenta.tipo ?? null,
+          banco_nombre: row.cuenta.banco_nombre ?? null,
+          iban: row.cuenta.iban ?? null,
+        }
+      : null,
+    categoria: row.categoria
+      ? {
+          id: row.categoria.id,
+          nombre: row.categoria.nombre,
+          tipo: row.categoria.tipo ?? null,
+          emoji: row.categoria.emoji ?? null,
+          color: row.categoria.color ?? null,
+        }
+      : null,
+    delegacion: row.delegacion
+      ? {
+          id: row.delegacion.id,
+          codigo: row.delegacion.codigo ?? null,
+          nombre: row.delegacion.nombre,
+        }
+      : null,
+    contacto: row.contacto
+      ? {
+          id: row.contacto.id,
+          nombre: row.contacto.nombre,
+          tipo: row.contacto.tipo ?? null,
+        }
+      : null,
+    archivos,
+  }
+}


### PR DESCRIPTION
Añade endpoints v1 para consumir movimientos desde apps internas (Google
Apps Script):

- GET /api/v1/movimientos/{id}: datos + relaciones + archivos embebidos
- GET /api/v1/movimientos/{id}/archivos: solo archivos

Auth por clave compartida (MCM_API_KEY o, en su defecto, CRON_SECRET) vía
cabecera Authorization: Bearer o x-api-key. Acceso por ID global con cliente
admin (sin depender de delegación/RLS).

Muestra el ID del movimiento con botón de copiar en el detalle de
transacción y documenta la API en docs/08-api-externa.md.

https://claude.ai/code/session_01KPEEcoGqruwmtUJQT3KwrW