### PR TITLE
Add account migration option when deleting accounts

### DIFF
--- a/app/api/bank-sync/auth/route.ts
+++ b/app/api/bank-sync/auth/route.ts
@@ -12,6 +12,13 @@ const Body = z.object({
   aspsp_country: z.string().length(2),
   psu_type: z.enum(["personal", "business"]).default("business"),
   valid_days: z.number().int().min(1).max(180).default(90),
+  // Fecha ISO "yyyy-mm-dd" desde la que traer movimientos en la primera sync.
+  // null/omitido = todo el histórico que permita el banco.
+  sync_desde_fecha: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/)
+    .nullable()
+    .optional(),
 })
 
 /**
@@ -55,6 +62,13 @@ export async function POST(request: Request) {
   if (!membresia || !["gestor_central", "tesorero"].includes(membresia.rol)) {
     return NextResponse.json({ error: "Sin permisos para conectar esta cuenta" }, { status: 403 })
   }
+
+  // 1.b Persistir la fecha de inicio elegida (o limpiarla para "todo el histórico").
+  // syncCuenta la respeta sin fallback en la primera sincronización.
+  await admin
+    .from("cuenta")
+    .update({ sync_desde_fecha: body.data.sync_desde_fecha ?? null })
+    .eq("id", cuenta.id)
 
   // 2. Crear banco_conexion pendiente
   const validUntil = new Date(Date.now() + body.data.valid_days * 24 * 60 * 60 * 1000)

--- a/components/cuentas/cuenta-connect-dialog.tsx
+++ b/components/cuentas/cuenta-connect-dialog.tsx
@@ -14,6 +14,7 @@ import {
 import { Label } from "@/components/ui/label"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Input } from "@/components/ui/input"
+import { DateField } from "@/components/ui/date-field"
 
 type Aspsp = {
   name: string
@@ -40,6 +41,8 @@ export function CuentaConnectDialog({ open, onOpenChange, cuentaId, cuentaNombre
   const [aspspName, setAspspName] = useState<string>("")
   const [psuType, setPsuType] = useState<"personal" | "business">("business")
   const [validDays, setValidDays] = useState(90)
+  const [historyMode, setHistoryMode] = useState<"all" | "from">("all")
+  const [syncDesdeFecha, setSyncDesdeFecha] = useState<string | null>(null)
   const [connecting, setConnecting] = useState(false)
 
   useEffect(() => {
@@ -61,6 +64,10 @@ export function CuentaConnectDialog({ open, onOpenChange, cuentaId, cuentaNombre
 
   const connect = async () => {
     if (!aspspName) return
+    if (historyMode === "from" && !syncDesdeFecha) {
+      setError("Indica la fecha desde la que quieres traer los movimientos.")
+      return
+    }
     setConnecting(true)
     setError(null)
     try {
@@ -73,6 +80,7 @@ export function CuentaConnectDialog({ open, onOpenChange, cuentaId, cuentaNombre
           aspsp_country: country,
           psu_type: psuType,
           valid_days: Math.min(validDays, maxDaysAllowed),
+          sync_desde_fecha: historyMode === "from" ? syncDesdeFecha : null,
         }),
       })
       const body = await res.json()
@@ -170,6 +178,31 @@ export function CuentaConnectDialog({ open, onOpenChange, cuentaId, cuentaNombre
             <p className="text-xs text-muted-foreground">
               Máximo permitido por este banco: {maxDaysAllowed} días. Al vencer tendrás que renovar.
             </p>
+          </div>
+
+          <div className="space-y-2">
+            <Label>Movimientos a importar</Label>
+            <Select value={historyMode} onValueChange={(v) => setHistoryMode(v as "all" | "from")}>
+              <SelectTrigger><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">Todos los disponibles</SelectItem>
+                <SelectItem value="from">Desde una fecha concreta</SelectItem>
+              </SelectContent>
+            </Select>
+            {historyMode === "from" ? (
+              <>
+                <DateField value={syncDesdeFecha} onChange={setSyncDesdeFecha} />
+                <p className="text-xs text-muted-foreground">
+                  Se importarán los movimientos desde esta fecha. Si el banco no conserva tanto histórico,
+                  rechazará la petición; en ese caso elige una fecha más reciente o importa lo anterior desde Excel.
+                </p>
+              </>
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                Intentaremos traer todo el histórico que permita el banco (hasta 2 años). Por PSD2, muchos
+                bancos limitan a los últimos 90 días.
+              </p>
+            )}
           </div>
 
           {error && (

--- a/components/cuentas/cuentas-manager.tsx
+++ b/components/cuentas/cuentas-manager.tsx
@@ -269,15 +269,36 @@ export function CuentasManager() {
     }
   }
 
-  const handleDeleteCuenta = async (cuentaId: string) => {
+  const handleDeleteCuenta = async (cuentaId: string, opts: { migrateToCuentaId?: string } = {}) => {
 
     // Marcar como en proceso de eliminación
     setOperationState(cuentaId, 'deleting')
 
-    // Aplicar eliminación optimista inmediatamente
-    removeCuenta(cuentaId)
-
     try {
+      // 1. Si se pide migrar, reasignar primero los movimientos a la cuenta destino.
+      //    Los movimientos manuales tienen external_id NULL, así que no colisionan con
+      //    el índice único (cuenta_id, external_id). Si la cuenta destino tuviera el
+      //    mismo movimiento bancario, el UPDATE fallaría y avisamos sin borrar nada.
+      if (opts.migrateToCuentaId) {
+        const { error: migrateError } = await (supabase as any)
+          .from("movimiento")
+          .update({ cuenta_id: opts.migrateToCuentaId })
+          .eq("cuenta_id", cuentaId)
+
+        if (migrateError) {
+          console.error("handleDeleteCuenta: Error migrating movements", migrateError)
+          setOperationState(cuentaId, null)
+          toast.error("No se pudieron migrar los movimientos", {
+            description:
+              "Puede que la cuenta destino ya tenga algún movimiento idéntico. No se ha eliminado nada.",
+          })
+          return
+        }
+      }
+
+      // 2. Eliminación optimista de la cuenta en la UI.
+      removeCuenta(cuentaId)
+
       const { error } = await (supabase as any).from("cuenta").delete().eq("id", cuentaId)
       if (error) {
         console.error("handleDeleteCuenta: Error deleting account", error)
@@ -287,6 +308,10 @@ export function CuentasManager() {
       }
       // No necesitamos limpiar el estado aquí porque la cuenta ya no existe
       setDeletingCuenta(null)
+      if (opts.migrateToCuentaId) {
+        await forceRefresh() // refrescar saldos de la cuenta destino
+        toast.success("Movimientos migrados y cuenta eliminada")
+      }
     } catch (error) {
       console.error("handleDeleteCuenta: Error in try-catch", error)
       // Limpiar estado en caso de error
@@ -881,7 +906,8 @@ export function CuentasManager() {
       {deletingCuenta && (
         <DeleteAccountDialog
           cuenta={deletingCuenta}
-          onConfirm={() => handleDeleteCuenta(deletingCuenta.id)}
+          otherCuentas={cuentas.filter((c) => c.id !== deletingCuenta.id)}
+          onConfirm={(opts) => handleDeleteCuenta(deletingCuenta.id, opts)}
           onCancel={() => setDeletingCuenta(null)}
         />
       )}

--- a/components/cuentas/delete-account-dialog.tsx
+++ b/components/cuentas/delete-account-dialog.tsx
@@ -1,38 +1,48 @@
 "use client"
 
 import { useState } from "react"
-import { AlertTriangle, Trash2 } from "lucide-react"
+import { AlertTriangle, Trash2, ArrowRightLeft } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Alert, AlertDescription } from "@/components/ui/alert"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import type { Cuenta } from "@/lib/types/database"
 
 interface DeleteAccountDialogProps {
   cuenta: Cuenta
-  onConfirm: () => void
+  /** Otras cuentas de la misma delegación a las que se podrían migrar los movimientos. */
+  otherCuentas: Cuenta[]
+  /** Si migrateToCuentaId viene, primero se reasignan los movimientos y luego se borra la cuenta. */
+  onConfirm: (opts: { migrateToCuentaId?: string }) => void | Promise<void>
   onCancel: () => void
 }
 
-export function DeleteAccountDialog({ cuenta, onConfirm, onCancel }: DeleteAccountDialogProps) {
+type Mode = "delete" | "migrate"
+
+export function DeleteAccountDialog({ cuenta, otherCuentas, onConfirm, onCancel }: DeleteAccountDialogProps) {
   const [confirmationText, setConfirmationText] = useState("")
   const [isDeleting, setIsDeleting] = useState(false)
+  const [mode, setMode] = useState<Mode>("delete")
+  const [targetCuentaId, setTargetCuentaId] = useState<string>("")
+
+  const canMigrate = otherCuentas.length > 0
+  const isConfirmationValid = confirmationText === "ELIMINAR"
+  const isMigrateReady = mode !== "migrate" || !!targetCuentaId
+  const canConfirm = isConfirmationValid && isMigrateReady && !isDeleting
 
   const handleConfirm = async () => {
-    if (confirmationText !== "ELIMINAR") {
-      return
-    }
-
+    if (!canConfirm) return
     setIsDeleting(true)
     try {
-      await onConfirm()
+      await onConfirm(mode === "migrate" ? { migrateToCuentaId: targetCuentaId } : {})
     } finally {
       setIsDeleting(false)
     }
   }
 
-  const isConfirmationValid = confirmationText === "ELIMINAR"
+  const targetNombre = otherCuentas.find((c) => c.id === targetCuentaId)?.nombre
 
   return (
     <Dialog open={true} onOpenChange={onCancel}>
@@ -43,7 +53,7 @@ export function DeleteAccountDialog({ cuenta, onConfirm, onCancel }: DeleteAccou
             Eliminar Cuenta
           </DialogTitle>
           <DialogDescription>
-            Esta acción no se puede deshacer. Se eliminará permanentemente la cuenta y todas sus transacciones asociadas.
+            Esta acción no se puede deshacer. Elige qué hacer con los movimientos de la cuenta antes de eliminarla.
           </DialogDescription>
         </DialogHeader>
 
@@ -60,6 +70,50 @@ export function DeleteAccountDialog({ cuenta, onConfirm, onCancel }: DeleteAccou
               )}
             </AlertDescription>
           </Alert>
+
+          {/* Qué hacer con los movimientos */}
+          {canMigrate && (
+            <div className="space-y-2">
+              <Label>¿Qué hacemos con los movimientos?</Label>
+              <Select value={mode} onValueChange={(v) => setMode(v as Mode)}>
+                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="delete">Eliminarlos junto con la cuenta</SelectItem>
+                  <SelectItem value="migrate">Migrarlos a otra cuenta y luego eliminar esta</SelectItem>
+                </SelectContent>
+              </Select>
+
+              {mode === "migrate" && (
+                <div className="space-y-2 pt-1">
+                  <Label className="flex items-center gap-1.5 text-sm">
+                    <ArrowRightLeft className="h-3.5 w-3.5" />
+                    Cuenta destino
+                  </Label>
+                  <Select value={targetCuentaId} onValueChange={setTargetCuentaId}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Selecciona una cuenta…" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {otherCuentas.map((c) => (
+                        <SelectItem key={c.id} value={c.id}>
+                          {c.nombre}
+                          {c.tipo === "banco" && c.banco_nombre ? ` · ${c.banco_nombre}` : ""}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <Alert className="border-amber-200 bg-amber-50">
+                    <AlertTriangle className="h-4 w-4 text-amber-600" />
+                    <AlertDescription className="text-amber-800 text-xs">
+                      Los movimientos pasarán a <strong>{targetNombre || "la cuenta destino"}</strong>. Revisa
+                      después el <strong>saldo inicial</strong> de esa cuenta: si ya estaba sincronizada con el
+                      banco, puede quedar descuadrado y tendrás que ajustarlo a mano.
+                    </AlertDescription>
+                  </Alert>
+                </div>
+              )}
+            </div>
+          )}
 
           {/* Confirmation Text Input */}
           <div className="space-y-2">
@@ -83,10 +137,16 @@ export function DeleteAccountDialog({ cuenta, onConfirm, onCancel }: DeleteAccou
             <Button
               variant="destructive"
               onClick={handleConfirm}
-              disabled={!isConfirmationValid || isDeleting}
+              disabled={!canConfirm}
               className="flex-1"
             >
-              {isDeleting ? "Eliminando..." : "Eliminar Cuenta"}
+              {isDeleting
+                ? mode === "migrate"
+                  ? "Migrando…"
+                  : "Eliminando..."
+                : mode === "migrate"
+                  ? "Migrar y eliminar"
+                  : "Eliminar Cuenta"}
             </Button>
             <Button
               variant="outline"


### PR DESCRIPTION
## Summary
Adds the ability to migrate transactions to another account before deletion, preventing data loss when removing accounts. Users can now choose to either delete all transactions with the account or migrate them to a different account in the same delegation.

## Key Changes

### Delete Account Dialog (`components/cuentas/delete-account-dialog.tsx`)
- Added migration mode selection with two options: delete transactions or migrate them
- New `otherCuentas` prop to display available destination accounts
- Updated `onConfirm` callback to accept migration options (`{ migrateToCuentaId?: string }`)
- Added destination account selector with helpful warnings about potential balance discrepancies
- Dynamic button text reflects the selected action ("Migrar y eliminar" vs "Eliminar Cuenta")
- Enhanced validation to ensure destination account is selected when migration mode is active

### Accounts Manager (`components/cuentas/cuentas-manager.tsx`)
- Updated `handleDeleteCuenta` to accept migration options
- Implements two-step deletion process:
  1. If migrating: reassign all transactions to destination account via Supabase update
  2. Delete the account from the database
- Added error handling for migration conflicts (e.g., duplicate transactions in destination account)
- Triggers UI refresh of destination account balances after successful migration
- Shows appropriate success toast message for migration operations
- Passes filtered list of other accounts to the delete dialog

### Bank Connection Dialog (`components/cuentas/cuenta-connect-dialog.tsx`)
- Added history import mode selection: "all available" or "from a specific date"
- New `DateField` component for selecting sync start date
- Passes `sync_desde_fecha` to the bank sync API when user selects date-based import
- Added helpful guidance text explaining PSD2 limitations and fallback options

### Bank Sync API (`app/api/bank-sync/auth/route.ts`)
- Added `sync_desde_fecha` field to request schema (ISO date format: yyyy-mm-dd)
- Persists the selected sync start date to the `cuenta` table for use in subsequent synchronizations
- Allows null value for "import all available" mode

## Implementation Details

- Migration uses Supabase's `update().eq()` pattern to reassign transactions by `cuenta_id`
- Manual transactions (with `external_id: NULL`) don't conflict with the unique index, but duplicate bank transactions would cause the migration to fail safely
- Balance discrepancies are flagged in the UI warning since migrating transactions may desynchronize bank-synced accounts
- The deletion is optimistic (UI updates immediately) but only completes after successful database operations
- Date-based sync respects bank limitations; users are guided to choose more recent dates if the bank rejects historical requests

https://claude.ai/code/session_014ud1mGEUP9zdmNV7gpWqe1