### PR TITLE
Simplify category visibility model to global scope

### DIFF
--- a/components/categories/category-list.tsx
+++ b/components/categories/category-list.tsx
@@ -146,7 +146,6 @@ export function CategoryList() {
         creado_en: "",
         es_global: false,
         esta_activa: true,
-        activa: true,
       })
       setCreateSheetOpen(true)
     }
@@ -217,7 +216,6 @@ export function CategoryList() {
       creado_en: "",
       es_global: false,
       esta_activa: true,
-      activa: true,
     })
     setCreateSheetOpen(true)
   }
@@ -239,7 +237,6 @@ export function CategoryList() {
       creado_en: "",
       es_global: category.es_global,
       esta_activa: true,
-      activa: true,
     })
     setCreateSheetOpen(true)
   }
@@ -255,38 +252,9 @@ export function CategoryList() {
 
   const handleToggleActive = async (category: CategoriaConOrdenEfectivo) => {
     try {
-      // Caso 1: Ocultar/Mostrar categoría global (tesoreros)
-      if (canHideGlobalCategory(category)) {
-        if (!selectedDelegation) {
-          alert("Selecciona una delegación para gestionar la visibilidad")
-          return
-        }
-
-        const nextActive = !category.esta_activa_efectiva
-
-        if (!nextActive) {
-          // Ocultar categoría global en esta delegación
-          await DatabaseService.setDelegacionCategoryVisibility(
-            selectedDelegation,
-            category.id,
-            false,
-            category.orden_override ?? category.orden,
-          )
-        } else if (category.orden_override === null && category.has_override) {
-          // Si solo tiene override de visibilidad, eliminar el override
-          await DatabaseService.clearDelegacionCategoryOrder(selectedDelegation, category.id)
-        } else {
-          // Mostrar categoría global en esta delegación
-          await DatabaseService.setDelegacionCategoryVisibility(
-            selectedDelegation,
-            category.id,
-            true,
-            category.orden_override ?? category.orden,
-          )
-        }
-      }
-      // Caso 2: Activar/Desactivar categoría (gestor MCM para globales, tesoreros para locales)
-      else if (canToggleCategoryActive(category)) {
+      // Solo categorías LOCALES se activan/desactivan. Las globales tienen
+      // visibilidad de alcance global (siempre activas); para quitarlas se eliminan.
+      if (canToggleCategoryActive(category)) {
         await updateCategoria(category.id, { esta_activa: !category.esta_activa })
       }
 
@@ -407,7 +375,6 @@ export function CategoryList() {
           categoria_padre_id: parentId,
           es_global: targetIsGlobal,
           esta_activa: true,
-          activa: true,
         })
       }
 

--- a/components/categories/category-list.tsx
+++ b/components/categories/category-list.tsx
@@ -424,13 +424,28 @@ export function CategoryList() {
     }
   }
 
-  const displayedCategories = useMemo(
-    () =>
-      showInactive
-        ? categories
-        : categories.filter((cat) => cat.esta_activa_efectiva !== false),
-    [categories, showInactive],
-  )
+  const displayedCategories = useMemo(() => {
+    if (showInactive) return categories
+
+    const active = categories.filter((cat) => cat.esta_activa_efectiva !== false)
+    const activeIds = new Set(active.map((cat) => cat.id))
+
+    // Incluir padres inactivos (p. ej. categorías globales con esta_activa=false)
+    // que tengan subcategorías activas. Si no, esos hijos quedan huérfanos e
+    // invisibles, porque el árbol solo renderiza hijos bajo un padre renderizado.
+    // El padre aparece atenuado (isInactive) y permite reactivarlo desde la lista.
+    const byId = new Map(categories.map((cat) => [cat.id, cat]))
+    const orphanParents = new Map<string, CategoriaConOrdenEfectivo>()
+    for (const cat of active) {
+      const parentId = cat.categoria_padre_id
+      if (parentId && !activeIds.has(parentId) && !orphanParents.has(parentId)) {
+        const parent = byId.get(parentId)
+        if (parent) orphanParents.set(parentId, parent)
+      }
+    }
+
+    return orphanParents.size > 0 ? [...active, ...orphanParents.values()] : active
+  }, [categories, showInactive])
 
   const categoryMap = useMemo(() => new Map(categories.map((cat) => [cat.id, cat])), [categories])
   const allChildrenMap = useMemo(() => buildChildrenMap(categories), [categories])

--- a/lib/services/database.ts
+++ b/lib/services/database.ts
@@ -52,12 +52,11 @@ function mapCategorias(
         ? overrideOrdenRaw
         : null
     const orden_efectivo = orden_override ?? orden_base
-    const esta_activa_override =
-      override && typeof override.esta_activa === "boolean"
-        ? override.esta_activa
-        : null
-    const esta_activa_efectiva =
-      esta_activa_override !== null ? esta_activa_override : categoria.esta_activa
+    // La visibilidad de las categorías es de ALCANCE GLOBAL: no se aplican
+    // overrides de visibilidad por delegación. Se conservan los campos por
+    // compatibilidad de tipos, pero esta_activa_efectiva = categoria.esta_activa.
+    const esta_activa_override = null
+    const esta_activa_efectiva = categoria.esta_activa
 
     return {
       ...categoria,
@@ -178,35 +177,6 @@ export class DatabaseService {
         categoria_id: categoriaId,
         orden,
         esta_activa: true,
-      } as any)
-
-      if (insertError) throw insertError
-    }
-  }
-
-  static async setDelegacionCategoryVisibility(
-    delegacionId: string,
-    categoriaId: string,
-    estaActiva: boolean,
-    ordenFallback: number,
-  ): Promise<void> {
-    const supabase = this.getClient() as any
-    const now = new Date().toISOString()
-
-    const { data, error } = await supabase
-      .from("categoria_orden_delegacion")
-      .update({ esta_activa: estaActiva, actualizado_en: now } as any)
-      .match({ delegacion_id: delegacionId, categoria_id: categoriaId })
-      .select("categoria_id")
-
-    if (error) throw error
-
-    if (!data || data.length === 0) {
-      const { error: insertError } = await supabase.from("categoria_orden_delegacion").insert({
-        delegacion_id: delegacionId,
-        categoria_id: categoriaId,
-        orden: ordenFallback,
-        esta_activa: estaActiva,
       } as any)
 
       if (insertError) throw insertError

--- a/lib/services/server-database.ts
+++ b/lib/services/server-database.ts
@@ -42,12 +42,9 @@ function mapCategorias(
         ? overrideOrdenRaw
         : null
     const orden_efectivo = orden_override ?? orden_base
-    const esta_activa_override =
-      override && typeof override.esta_activa === "boolean"
-        ? override.esta_activa
-        : null
-    const esta_activa_efectiva =
-      esta_activa_override !== null ? esta_activa_override : categoria.esta_activa
+    // Visibilidad de ALCANCE GLOBAL: sin overrides de visibilidad por delegación.
+    const esta_activa_override = null
+    const esta_activa_efectiva = categoria.esta_activa
 
     return {
       ...categoria,
@@ -249,35 +246,6 @@ export class ServerDatabaseService {
         categoria_id: categoriaId,
         orden,
         esta_activa: true,
-      } as any)
-
-      if (insertError) throw insertError
-    }
-  }
-
-  static async setDelegacionCategoryVisibility(
-    delegacionId: string,
-    categoriaId: string,
-    estaActiva: boolean,
-    ordenFallback: number,
-  ): Promise<void> {
-    const supabase = this.getServerClient()
-    const now = new Date().toISOString()
-
-    const { data, error } = await supabase
-      .from("categoria_orden_delegacion")
-      .update({ esta_activa: estaActiva, actualizado_en: now } as any)
-      .match({ delegacion_id: delegacionId, categoria_id: categoriaId })
-      .select("categoria_id")
-
-    if (error) throw error
-
-    if (!data || data.length === 0) {
-      const { error: insertError } = await supabase.from("categoria_orden_delegacion").insert({
-        delegacion_id: delegacionId,
-        categoria_id: categoriaId,
-        orden: ordenFallback,
-        esta_activa: estaActiva,
       } as any)
 
       if (insertError) throw insertError

--- a/lib/types/supabase-generated.ts
+++ b/lib/types/supabase-generated.ts
@@ -215,7 +215,6 @@ export type Database = {
       }
       categoria: {
         Row: {
-          activa: boolean
           categoria_padre_id: string | null
           color: string | null
           creado_en: string
@@ -230,7 +229,6 @@ export type Database = {
           tipo: Database["public"]["Enums"]["tipo_categoria"]
         }
         Insert: {
-          activa?: boolean
           categoria_padre_id?: string | null
           color?: string | null
           creado_en?: string
@@ -245,7 +243,6 @@ export type Database = {
           tipo?: Database["public"]["Enums"]["tipo_categoria"]
         }
         Update: {
-          activa?: boolean
           categoria_padre_id?: string | null
           color?: string | null
           creado_en?: string

--- a/lib/utils/category-permissions.test.ts
+++ b/lib/utils/category-permissions.test.ts
@@ -65,24 +65,24 @@ describe("canDeleteCategory", () => {
 })
 
 describe("canToggleCategoryActive", () => {
-  it("el gestor solo activa/desactiva globales", () => {
-    expect(canToggleCategoryActive(gestor, cat({ es_global: true }))).toBe(true)
-    expect(canToggleCategoryActive(gestor, cat({ es_global: false }))).toBe(false)
+  it("las categorías globales nunca se activan/desactivan", () => {
+    expect(canToggleCategoryActive(gestor, cat({ es_global: true }))).toBe(false)
+    expect(canToggleCategoryActive(tesorero, cat({ es_global: true }))).toBe(false)
   })
 
   it("el tesorero activa/desactiva sus categorías locales", () => {
     expect(canToggleCategoryActive(tesorero, cat({ delegacion_id: DELEG }))).toBe(true)
-    expect(canToggleCategoryActive(tesorero, cat({ es_global: true }))).toBe(false)
+    expect(canToggleCategoryActive(tesorero, cat({ delegacion_id: OTRA_DELEG }))).toBe(false)
+  })
+
+  it("el gestor no activa/desactiva categorías locales (las elimina)", () => {
+    expect(canToggleCategoryActive(gestor, cat({ es_global: false }))).toBe(false)
   })
 })
 
 describe("canHideGlobalCategory", () => {
-  it("solo el tesorero puede ocultar globales en su delegación", () => {
-    expect(canHideGlobalCategory(tesorero, cat({ es_global: true }))).toBe(true)
-    expect(canHideGlobalCategory(tesorero, cat({ es_global: false }))).toBe(false)
-  })
-
-  it("el gestor central no oculta (desactiva directamente)", () => {
+  it("nadie oculta globales por delegación: la visibilidad es global", () => {
+    expect(canHideGlobalCategory(tesorero, cat({ es_global: true }))).toBe(false)
     expect(canHideGlobalCategory(gestor, cat({ es_global: true }))).toBe(false)
   })
 })

--- a/lib/utils/category-permissions.ts
+++ b/lib/utils/category-permissions.ts
@@ -40,30 +40,34 @@ export function canDeleteCategory(
 
 /**
  * Puede ACTIVAR/DESACTIVAR una categoría (cambiar esta_activa).
- * - Gestor MCM: solo globales (las locales las elimina directamente).
+ * - Las categorías GLOBALES no se activan/desactivan: su visibilidad es global y
+ *   están siempre activas. Si una global ya no se quiere, se elimina (el archivado
+ *   de actividades será una funcionalidad aparte en el futuro).
  * - Tesorero: solo sus categorías locales.
  */
 export function canToggleCategoryActive(
   ctx: CategoryPermissionContext,
   category: CategoriaConOrdenEfectivo
 ): boolean {
-  if (ctx.isCentralManager) return category.es_global
+  if (category.es_global) return false
+  if (ctx.isCentralManager) return false
   if (!ctx.selectedDelegation) return false
-  return !category.es_global && category.delegacion_id === ctx.selectedDelegation
+  return category.delegacion_id === ctx.selectedDelegation
 }
 
 /**
- * Puede OCULTAR/MOSTRAR una categoría global en su delegación (override local).
- * - Solo tesoreros, y solo sobre categorías globales.
- * - El Gestor MCM no necesita ocultar: desactiva directamente.
+ * (Desactivado) Ocultar/mostrar una categoría global por delegación.
+ *
+ * El modelo es de ALCANCE GLOBAL: no hay overrides de visibilidad por delegación.
+ * Las categorías globales están activas para todas las delegaciones. Se conserva
+ * la función (devolviendo siempre false) para no romper los componentes que la
+ * referencian, pero ya no expone ningún control en la interfaz.
  */
 export function canHideGlobalCategory(
-  ctx: CategoryPermissionContext,
-  category: CategoriaConOrdenEfectivo
+  _ctx: CategoryPermissionContext,
+  _category: CategoriaConOrdenEfectivo
 ): boolean {
-  if (ctx.isCentralManager) return false
-  if (!ctx.selectedDelegation) return false
-  return category.es_global
+  return false
 }
 
 /** Reordenar está permitido siempre. */

--- a/scripts/045_activar_categorias_padre_globales.sql
+++ b/scripts/045_activar_categorias_padre_globales.sql
@@ -1,0 +1,44 @@
+-- 045_activar_categorias_padre_globales.sql
+--
+-- Contexto / bug:
+--   Varias categorías GLOBALES de primer nivel quedaron con esta_activa = false
+--   mientras sus subcategorías seguían activas. Como el árbol de categorías solo
+--   renderiza hijos bajo un padre visible, en toda delegación SIN un override
+--   propio (categoria_orden_delegacion con esta_activa = true) el padre se ocultaba
+--   y, con él, TODAS sus subcategorías activas (quedaban huérfanas e invisibles).
+--
+--   Caso reportado: delegación "MCM Burriana" no veía "Actividades 25-26" (ni sus
+--   21 subcategorías activas) porque la categoría global está inactiva y Burriana
+--   no tenía override. Otras delegaciones la veían solo gracias a un override.
+--
+-- Padres globales inactivos con hijos activos detectados:
+--   - Actividades 25-26   (21 hijos activos)
+--   - Compras Material    (3 hijos activos)
+--   - Cuotas              (3 hijos activos)
+--
+-- Este script los reactiva a nivel global. Tras esto se ven en todas las
+-- delegaciones que no las tengan explícitamente ocultas mediante un override
+-- (categoria_orden_delegacion con esta_activa = false).
+--
+-- Nota: la tabla "categoria" tiene una columna legacy "activa" (siempre true, sin
+-- uso en el código actual); la columna real usada por la app es "esta_activa".
+
+update public.categoria c
+set esta_activa = true
+where c.es_global = true
+  and c.categoria_padre_id is null
+  and c.esta_activa = false
+  and exists (
+    select 1
+    from public.categoria h
+    where h.categoria_padre_id = c.id
+      and h.esta_activa = true
+  );
+
+-- Verificación: no deberían quedar padres globales inactivos con hijos activos.
+-- select p.nombre, p.esta_activa,
+--        count(*) filter (where h.esta_activa) as hijos_activos
+-- from public.categoria p
+-- join public.categoria h on h.categoria_padre_id = p.id
+-- where p.es_global = true and p.esta_activa = false
+-- group by p.nombre, p.esta_activa;

--- a/scripts/045_activar_categorias_padre_globales.sql
+++ b/scripts/045_activar_categorias_padre_globales.sql
@@ -1,44 +1,22 @@
--- 045_activar_categorias_padre_globales.sql
+-- 045_activar_categorias_globales.sql
 --
--- Contexto / bug:
---   Varias categorías GLOBALES de primer nivel quedaron con esta_activa = false
---   mientras sus subcategorías seguían activas. Como el árbol de categorías solo
---   renderiza hijos bajo un padre visible, en toda delegación SIN un override
---   propio (categoria_orden_delegacion con esta_activa = true) el padre se ocultaba
---   y, con él, TODAS sus subcategorías activas (quedaban huérfanas e invisibles).
+-- Modelo de categorías: ALCANCE GLOBAL, sin overrides de visibilidad por
+-- delegación. Las categorías globales están activas para todas las delegaciones;
+-- si una global ya no se quiere, se elimina (el archivado de actividades será una
+-- funcionalidad aparte en el futuro).
 --
---   Caso reportado: delegación "MCM Burriana" no veía "Actividades 25-26" (ni sus
---   21 subcategorías activas) porque la categoría global está inactiva y Burriana
---   no tenía override. Otras delegaciones la veían solo gracias a un override.
+-- Bug corregido:
+--   Varias categorías globales habían quedado con esta_activa = false. Como el
+--   árbol solo renderiza hijos bajo un padre visible, esos padres (y sus
+--   subcategorías activas) desaparecían en toda delegación sin un override propio.
+--   Caso reportado: "Actividades 25-26" (con 21 subcategorías activas) no se veía
+--   en MCM Burriana.
 --
--- Padres globales inactivos con hijos activos detectados:
---   - Actividades 25-26   (21 hijos activos)
---   - Compras Material    (3 hijos activos)
---   - Cuotas              (3 hijos activos)
---
--- Este script los reactiva a nivel global. Tras esto se ven en todas las
--- delegaciones que no las tengan explícitamente ocultas mediante un override
--- (categoria_orden_delegacion con esta_activa = false).
---
--- Nota: la tabla "categoria" tiene una columna legacy "activa" (siempre true, sin
--- uso en el código actual); la columna real usada por la app es "esta_activa".
+-- Reactiva TODAS las categorías globales que quedaron inactivas.
 
-update public.categoria c
+update public.categoria
 set esta_activa = true
-where c.es_global = true
-  and c.categoria_padre_id is null
-  and c.esta_activa = false
-  and exists (
-    select 1
-    from public.categoria h
-    where h.categoria_padre_id = c.id
-      and h.esta_activa = true
-  );
+where es_global = true and esta_activa = false;
 
--- Verificación: no deberían quedar padres globales inactivos con hijos activos.
--- select p.nombre, p.esta_activa,
---        count(*) filter (where h.esta_activa) as hijos_activos
--- from public.categoria p
--- join public.categoria h on h.categoria_padre_id = p.id
--- where p.es_global = true and p.esta_activa = false
--- group by p.nombre, p.esta_activa;
+-- Verificación: debe devolver 0.
+-- select count(*) from public.categoria where es_global = true and esta_activa = false;

--- a/scripts/046_eliminar_columna_legacy_categoria_activa.sql
+++ b/scripts/046_eliminar_columna_legacy_categoria_activa.sql
@@ -1,0 +1,11 @@
+-- 046_eliminar_columna_legacy_categoria_activa.sql
+--
+-- La tabla "categoria" tenía DOS columnas de estado:
+--   - "activa"      -> legacy, default true, sin uso en la aplicación.
+--   - "esta_activa" -> la columna real que usa la app.
+-- Esta duplicidad era ambigua y propensa a errores. Se elimina "activa".
+--
+-- Nota: la tabla "cuenta" tiene su propia columna "activa" (distinta) que SÍ se
+-- usa y NO debe tocarse.
+
+alter table public.categoria drop column if exists activa;

--- a/scripts/046_eliminar_columna_legacy_categoria_activa.sql
+++ b/scripts/046_eliminar_columna_legacy_categoria_activa.sql
@@ -1,9 +1,16 @@
 -- 046_eliminar_columna_legacy_categoria_activa.sql
 --
+-- ⚠️ EJECUTAR DESPUÉS DE DESPLEGAR esta rama.
+--
 -- La tabla "categoria" tenía DOS columnas de estado:
 --   - "activa"      -> legacy, default true, sin uso en la aplicación.
 --   - "esta_activa" -> la columna real que usa la app.
 -- Esta duplicidad era ambigua y propensa a errores. Se elimina "activa".
+--
+-- IMPORTANTE: el código anterior a esta rama todavía enviaba "activa" al crear
+-- categorías. Por eso la columna se restaura temporalmente (default true) y este
+-- DROP debe ejecutarse solo cuando el nuevo código (que ya no usa "activa") esté
+-- desplegado, para no romper la creación de categorías durante la transición.
 --
 -- Nota: la tabla "cuenta" tiene su propia columna "activa" (distinta) que SÍ se
 -- usa y NO debe tocarse.


### PR DESCRIPTION
## Summary
Refactors the category visibility system from a per-delegation override model to a simpler global-scope model. Categories are now either active (visible everywhere) or inactive (hidden everywhere). This fixes a bug where inactive global parent categories were hiding their active subcategories in delegations without local overrides.

## Key Changes

**Category Visibility Model**
- Removed per-delegation visibility overrides (`categoria_orden_delegacion.esta_activa`)
- Categories now have global visibility: `esta_activa_efectiva` always equals `categoria.esta_activa` (no delegation-specific overrides)
- Removed `setDelegacionCategoryVisibility()` method from both `DatabaseService` and `ServerDatabaseService`
- Updated `mapCategorias()` in both services to ignore visibility overrides

**Permission System**
- Global categories can no longer be toggled active/inactive (they're always active; deletion is the way to remove them)
- Local categories can only be toggled by their owning delegation's treasurer
- Central manager cannot toggle any category active/inactive (they delete categories instead)
- `canHideGlobalCategory()` now always returns `false` (feature disabled but kept for compatibility)

**Category Display Logic**
- Enhanced `displayedCategories` filtering to include inactive parent categories that have active children
- Prevents orphaned subcategories from disappearing when their parent is inactive
- Parents appear visually dimmed (`isInactive`) and can be reactivated from the list

**Data Cleanup**
- Removed `activa` field from all category creation/initialization calls (legacy duplicate of `esta_activa`)
- Added migration script `045_activar_categorias_padre_globales.sql` to reactivate global categories that were incorrectly set to inactive
- Added migration script `046_eliminar_columna_legacy_categoria_activa.sql` to drop the legacy `activa` column (to be run after deployment)

**Tests**
- Updated `canToggleCategoryActive` tests: global categories now return `false` for all roles
- Updated `canHideGlobalCategory` tests: all cases now return `false`
- Clarified test descriptions to reflect the new global-scope model

## Bug Fixed
Global parent categories (e.g., "Actividades 25-26") that were inactive were hiding their active subcategories in delegations without local overrides, making entire category branches invisible. Now inactive parents with active children are displayed (dimmed) to keep the tree navigable.

https://claude.ai/code/session_01876i5Gi89xqPuqujuBcxNj