### PR TITLE
fix(transacciones): el botón + del selector de categorías ahora crea y asigna

### DIFF
--- a/components/transactions/category-chip.tsx
+++ b/components/transactions/category-chip.tsx
@@ -96,7 +96,14 @@ export function CategoryChip({
               onClose={closeDialog}
               movement={movement}
               account={account}
-              onCreateCategory={onCreateCategory}
+              onCreateCategory={
+                onCreateCategory
+                  ? () => {
+                      closeDialog()
+                      onCreateCategory()
+                    }
+                  : undefined
+              }
             />
           </DialogContent>
         </Dialog>
@@ -132,7 +139,14 @@ export function CategoryChip({
             onClose={closeDialog}
             movement={movement}
             account={account}
-            onCreateCategory={onCreateCategory}
+            onCreateCategory={
+              onCreateCategory
+                ? () => {
+                    closeDialog()
+                    onCreateCategory()
+                  }
+                : undefined
+            }
           />
         </DialogContent>
       </Dialog>

--- a/components/transactions/category-quick-create-sheet.tsx
+++ b/components/transactions/category-quick-create-sheet.tsx
@@ -1,0 +1,108 @@
+"use client"
+
+import { useMemo } from "react"
+import { toast } from "sonner"
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet"
+import { CategoryEditForm } from "@/components/categories/category-edit-form"
+import { DatabaseService } from "@/lib/services/database"
+import type { Categoria } from "@/lib/types/database"
+
+interface CategoryQuickCreateSheetProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  organizacionId?: string | null
+  delegacionId?: string | null
+  canManageGlobal: boolean
+  categories: Categoria[]
+  onCreated: (category: Categoria) => void | Promise<void>
+}
+
+export function CategoryQuickCreateSheet({
+  open,
+  onOpenChange,
+  organizacionId,
+  delegacionId,
+  canManageGlobal,
+  categories,
+  onCreated,
+}: CategoryQuickCreateSheetProps) {
+  const draftCategory = useMemo<Categoria>(
+    () => ({
+      id: "",
+      organizacion_id: organizacionId || "",
+      delegacion_id: delegacionId || null,
+      nombre: "",
+      tipo: "mixto",
+      emoji: "📁",
+      color: "#4ECDC4",
+      orden: 0,
+      categoria_padre_id: null,
+      creado_en: "",
+      es_global: false,
+      esta_activa: true,
+      activa: true,
+    }),
+    [organizacionId, delegacionId],
+  )
+
+  const handleSave = async (patch: Partial<Categoria>) => {
+    if (!organizacionId) {
+      toast.error("No se ha podido determinar la organización")
+      return
+    }
+
+    const targetIsGlobal = !!patch.es_global
+
+    if (targetIsGlobal && !canManageGlobal) {
+      toast.error("Solo el gestor central puede crear categorías globales")
+      return
+    }
+
+    if (!targetIsGlobal && !delegacionId) {
+      toast.error("Selecciona una delegación para crear categorías locales")
+      return
+    }
+
+    const siblings = categories.filter(
+      (category) => !category.categoria_padre_id && category.es_global === targetIsGlobal,
+    )
+    const maxOrder = siblings.length > 0 ? Math.max(...siblings.map((category) => category.orden)) : 0
+
+    try {
+      const created = await DatabaseService.createCategoria({
+        organizacion_id: organizacionId,
+        delegacion_id: targetIsGlobal ? null : delegacionId!,
+        nombre: patch.nombre!,
+        tipo: "mixto",
+        emoji: patch.emoji || "📁",
+        color: patch.color || "#4ECDC4",
+        orden: maxOrder + 1,
+        categoria_padre_id: null,
+        es_global: targetIsGlobal,
+        esta_activa: true,
+        activa: true,
+      })
+
+      await onCreated(created)
+    } catch (error) {
+      console.error("Error creating category:", error)
+      toast.error("Error al crear la categoría")
+    }
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="w-full sm:w-[400px] sm:max-w-[540px] overflow-y-auto">
+        <SheetHeader>
+          <SheetTitle>Crear categoría</SheetTitle>
+        </SheetHeader>
+        <CategoryEditForm
+          category={draftCategory}
+          onSave={handleSave}
+          onCancel={() => onOpenChange(false)}
+          canManageGlobal={canManageGlobal}
+        />
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/components/transactions/transaction-detail.tsx
+++ b/components/transactions/transaction-detail.tsx
@@ -43,6 +43,7 @@ interface TransactionDetailProps {
   onUpdate: (movementId: string, patch: Partial<Movimiento>) => Promise<void>
   onBack?: () => void
   initialTab?: "datos" | "archivos"
+  onRequestCreateCategory?: (assign: (categoryId: string) => void | Promise<void>) => void
 }
 
 type HistoryChange = "date" | "amount"
@@ -60,6 +61,7 @@ export function TransactionDetail({
   onUpdate,
   onBack,
   initialTab = "datos",
+  onRequestCreateCategory,
 }: TransactionDetailProps) {
   const [contactoCreateOpen, setContactoCreateOpen] = useState(false)
   const [contactoInitialNombre, setContactoInitialNombre] = useState("")
@@ -423,6 +425,14 @@ export function TransactionDetail({
                       account={account}
                       onCategoryChange={(categoryId) =>
                         setFormData((prev) => ({ ...prev, categoria_id: categoryId }))
+                      }
+                      onCreateCategory={
+                        onRequestCreateCategory
+                          ? () =>
+                              onRequestCreateCategory((categoryId) =>
+                                setFormData((prev) => ({ ...prev, categoria_id: categoryId })),
+                              )
+                          : undefined
                       }
                     />
                   </div>

--- a/components/transactions/transaction-list-row.tsx
+++ b/components/transactions/transaction-list-row.tsx
@@ -26,6 +26,7 @@ interface TransactionListRowProps {
   isSelected: boolean
   selectionActive: boolean
   onSelectionChange: (selected: boolean, rangeFromAnchor?: boolean) => void
+  onRequestCreateCategory?: (assign: (categoryId: string) => void | Promise<void>) => void
 }
 
 export const TransactionListRow = memo(function TransactionListRow({
@@ -39,6 +40,7 @@ export const TransactionListRow = memo(function TransactionListRow({
   isSelected,
   selectionActive,
   onSelectionChange,
+  onRequestCreateCategory,
 }: TransactionListRowProps) {
   const [isUpdating, setIsUpdating] = useState(false)
   const [editing, setEditing] = useState(false)
@@ -210,6 +212,11 @@ export const TransactionListRow = memo(function TransactionListRow({
                       movement={movement}
                       account={account}
                       onCategoryChange={(categoryId) => handleCategoryChange(categoryId)}
+                      onCreateCategory={
+                        onRequestCreateCategory
+                          ? () => onRequestCreateCategory(handleCategoryChange)
+                          : undefined
+                      }
                     />
                   )}
                   {movement.contacto && (

--- a/components/transactions/transaction-list.tsx
+++ b/components/transactions/transaction-list.tsx
@@ -28,6 +28,7 @@ interface TransactionListProps {
   onOpenFiles?: (movement: MovimientoConRelaciones) => void
   selectedMovementIds: string[]
   onMovementSelectionChange: (movementId: string, selected: boolean, rangeFromAnchor?: boolean) => void
+  onRequestCreateCategory?: (assign: (categoryId: string) => void | Promise<void>) => void
 }
 
 export function TransactionList({
@@ -44,6 +45,7 @@ export function TransactionList({
   onOpenFiles,
   selectedMovementIds,
   onMovementSelectionChange,
+  onRequestCreateCategory,
 }: TransactionListProps) {
   const loadMoreRef = useRef<HTMLDivElement | null>(null)
 
@@ -139,6 +141,7 @@ export function TransactionList({
           onSelectionChange={(selected, rangeFromAnchor) =>
             onMovementSelectionChange(movement.id, selected, rangeFromAnchor)
           }
+          onRequestCreateCategory={onRequestCreateCategory}
         />
       ))}
       {hasMore && (

--- a/components/transactions/transaction-manager.tsx
+++ b/components/transactions/transaction-manager.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect, useMemo, useCallback } from "react"
+import { useState, useEffect, useMemo, useCallback, useRef } from "react"
 import { useSearchParams } from "next/navigation"
 import { TransactionFiltersComponent } from "./transaction-filters"
 import { TransactionList } from "./transaction-list"
@@ -8,6 +8,7 @@ import { TransactionDetail } from "./transaction-detail"
 import { TransactionCreatePanel } from "./transaction-create-panel"
 import { DateRangeFilter } from "./date-range-filter"
 import { CategoryMegaSelector } from "./category-mega-selector"
+import { CategoryQuickCreateSheet } from "./category-quick-create-sheet"
 import { supabase } from "@/lib/supabase/client"
 import { useDelegationContext } from "@/contexts/delegation-context"
 import { useIsMobile } from "@/hooks/use-is-mobile"
@@ -71,6 +72,7 @@ export function TransactionManager() {
     selectedDelegation,
     delegations,
     loading: delegationsLoading,
+    getCurrentDelegation,
   } = useDelegationContext()
 
   const [filters, setFilters] = useState<TransactionFilters>({})
@@ -133,7 +135,9 @@ export function TransactionManager() {
     }
   }, [error])
 
-  const { categorias: categories } = useCategorias(selectedDelegation)
+  const { categorias: categories, fetchCategorias } = useCategorias(selectedDelegation)
+  const [categoryCreateOpen, setCategoryCreateOpen] = useState(false)
+  const pendingCategoryAssignRef = useRef<((categoryId: string) => void | Promise<void>) | null>(null)
   const { cuentas: accounts } = useCuentas(selectedDelegation)
   const { contactos, createContacto: createContactoFn } = useContactos(selectedDelegation)
   const isAdmin = useIsAdminHook()
@@ -278,6 +282,22 @@ export function TransactionManager() {
     } finally {
       setBulkCategoryLoading(false)
     }
+  }
+
+  const requestCreateCategory = useCallback((assign: (categoryId: string) => void | Promise<void>) => {
+    pendingCategoryAssignRef.current = assign
+    setCategoryCreateOpen(true)
+  }, [])
+
+  const handleCategoryCreated = async (newCategory: Categoria) => {
+    await fetchCategorias()
+    const assign = pendingCategoryAssignRef.current
+    pendingCategoryAssignRef.current = null
+    setCategoryCreateOpen(false)
+    if (assign) {
+      await assign(newCategory.id)
+    }
+    toast.success(`Categoría "${newCategory.nombre}" creada y asignada`)
   }
 
   const handleBulkConceptSubmit = async () => {
@@ -822,6 +842,7 @@ export function TransactionManager() {
             onOpenFiles={(movement) => handleOpenFiles(movement as unknown as MovimientoConRelaciones)}
             selectedMovementIds={selectedMovementIds}
             onMovementSelectionChange={handleMovementSelectionChange}
+            onRequestCreateCategory={requestCreateCategory}
           />
         </div>
       </div>
@@ -849,6 +870,7 @@ export function TransactionManager() {
           await handleMovementUpdate(movementId, fullPatch)
         }}
         initialTab={detailInitialTab}
+        onRequestCreateCategory={requestCreateCategory}
       />
 
       {/* Create Transaction Panel */}
@@ -902,9 +924,28 @@ export function TransactionManager() {
             onSelect={handleBulkCategorySelect}
             onClose={() => setBulkCategoryOpen(false)}
             bulkSelectionLabel={`${selectionCount} transacciones seleccionadas`}
+            onCreateCategory={() => {
+              setBulkCategoryOpen(false)
+              requestCreateCategory(handleBulkCategorySelect)
+            }}
           />
         </DialogContent>
       </Dialog>
+
+      <CategoryQuickCreateSheet
+        open={categoryCreateOpen}
+        onOpenChange={(open) => {
+          setCategoryCreateOpen(open)
+          if (!open) {
+            pendingCategoryAssignRef.current = null
+          }
+        }}
+        organizacionId={getCurrentDelegation()?.organizacion_id}
+        delegacionId={selectedDelegation}
+        canManageGlobal={isAdmin}
+        categories={categories as unknown as Categoria[]}
+        onCreated={handleCategoryCreated}
+      />
 
       <Dialog
         open={bulkConceptOpen}


### PR DESCRIPTION
El botón "+" del modal de asignación de categoría no hacía nada porque
ningún caller pasaba onCreateCategory. Ahora abre la sidebar de creación
de categorías existente (reutilizando CategoryEditForm), y al guardar
crea la categoría, la asigna automáticamente al movimiento (o a la
selección en bloque) y muestra un toast de confirmación.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PNbeoTgshdoPrjMwRtt8kD