### PR TITLE
fix(categorias): visibilidad por delegación (no desactivación global)

### DIFF
--- a/components/categories/category-list.tsx
+++ b/components/categories/category-list.tsx
@@ -252,9 +252,39 @@ export function CategoryList() {
 
   const handleToggleActive = async (category: CategoriaConOrdenEfectivo) => {
     try {
-      // Solo categorías LOCALES se activan/desactivan. Las globales tienen
-      // visibilidad de alcance global (siempre activas); para quitarlas se eliminan.
-      if (canToggleCategoryActive(category)) {
+      // Caso 1: Ocultar/Mostrar una categoría GLOBAL en ESTA delegación
+      // (override de visibilidad por delegación; tesorero o gestor central).
+      if (canHideGlobalCategory(category)) {
+        if (!selectedDelegation) {
+          alert("Selecciona una delegación para gestionar la visibilidad")
+          return
+        }
+
+        const nextActive = !category.esta_activa_efectiva
+
+        if (!nextActive) {
+          // Ocultar la categoría global en esta delegación
+          await DatabaseService.setDelegacionCategoryVisibility(
+            selectedDelegation,
+            category.id,
+            false,
+            category.orden_override ?? category.orden,
+          )
+        } else if (category.orden_override === null && category.has_override) {
+          // Si solo tenía override de visibilidad (sin orden propio), se elimina
+          await DatabaseService.clearDelegacionCategoryOrder(selectedDelegation, category.id)
+        } else {
+          // Mostrar de nuevo la categoría global en esta delegación
+          await DatabaseService.setDelegacionCategoryVisibility(
+            selectedDelegation,
+            category.id,
+            true,
+            category.orden_override ?? category.orden,
+          )
+        }
+      }
+      // Caso 2: Activar/Desactivar una categoría LOCAL (tesorero de su delegación)
+      else if (canToggleCategoryActive(category)) {
         await updateCategoria(category.id, { esta_activa: !category.esta_activa })
       }
 

--- a/lib/services/database.ts
+++ b/lib/services/database.ts
@@ -52,11 +52,15 @@ function mapCategorias(
         ? overrideOrdenRaw
         : null
     const orden_efectivo = orden_override ?? orden_base
-    // La visibilidad de las categorías es de ALCANCE GLOBAL: no se aplican
-    // overrides de visibilidad por delegación. Se conservan los campos por
-    // compatibilidad de tipos, pero esta_activa_efectiva = categoria.esta_activa.
-    const esta_activa_override = null
-    const esta_activa_efectiva = categoria.esta_activa
+    // Visibilidad POR DELEGACIÓN: si existe override para esta delegación, manda;
+    // si no, se usa el esta_activa de la categoría (las globales no tienen
+    // desactivación global, así que su base es siempre activa).
+    const esta_activa_override =
+      override && typeof override.esta_activa === "boolean"
+        ? override.esta_activa
+        : null
+    const esta_activa_efectiva =
+      esta_activa_override !== null ? esta_activa_override : categoria.esta_activa
 
     return {
       ...categoria,
@@ -177,6 +181,35 @@ export class DatabaseService {
         categoria_id: categoriaId,
         orden,
         esta_activa: true,
+      } as any)
+
+      if (insertError) throw insertError
+    }
+  }
+
+  static async setDelegacionCategoryVisibility(
+    delegacionId: string,
+    categoriaId: string,
+    estaActiva: boolean,
+    ordenFallback: number,
+  ): Promise<void> {
+    const supabase = this.getClient() as any
+    const now = new Date().toISOString()
+
+    const { data, error } = await supabase
+      .from("categoria_orden_delegacion")
+      .update({ esta_activa: estaActiva, actualizado_en: now } as any)
+      .match({ delegacion_id: delegacionId, categoria_id: categoriaId })
+      .select("categoria_id")
+
+    if (error) throw error
+
+    if (!data || data.length === 0) {
+      const { error: insertError } = await supabase.from("categoria_orden_delegacion").insert({
+        delegacion_id: delegacionId,
+        categoria_id: categoriaId,
+        orden: ordenFallback,
+        esta_activa: estaActiva,
       } as any)
 
       if (insertError) throw insertError

--- a/lib/services/server-database.ts
+++ b/lib/services/server-database.ts
@@ -42,9 +42,14 @@ function mapCategorias(
         ? overrideOrdenRaw
         : null
     const orden_efectivo = orden_override ?? orden_base
-    // Visibilidad de ALCANCE GLOBAL: sin overrides de visibilidad por delegación.
-    const esta_activa_override = null
-    const esta_activa_efectiva = categoria.esta_activa
+    // Visibilidad POR DELEGACIÓN: el override de la delegación manda; si no hay,
+    // se usa el esta_activa de la categoría.
+    const esta_activa_override =
+      override && typeof override.esta_activa === "boolean"
+        ? override.esta_activa
+        : null
+    const esta_activa_efectiva =
+      esta_activa_override !== null ? esta_activa_override : categoria.esta_activa
 
     return {
       ...categoria,
@@ -246,6 +251,35 @@ export class ServerDatabaseService {
         categoria_id: categoriaId,
         orden,
         esta_activa: true,
+      } as any)
+
+      if (insertError) throw insertError
+    }
+  }
+
+  static async setDelegacionCategoryVisibility(
+    delegacionId: string,
+    categoriaId: string,
+    estaActiva: boolean,
+    ordenFallback: number,
+  ): Promise<void> {
+    const supabase = this.getServerClient()
+    const now = new Date().toISOString()
+
+    const { data, error } = await supabase
+      .from("categoria_orden_delegacion")
+      .update({ esta_activa: estaActiva, actualizado_en: now } as any)
+      .match({ delegacion_id: delegacionId, categoria_id: categoriaId })
+      .select("categoria_id")
+
+    if (error) throw error
+
+    if (!data || data.length === 0) {
+      const { error: insertError } = await supabase.from("categoria_orden_delegacion").insert({
+        delegacion_id: delegacionId,
+        categoria_id: categoriaId,
+        orden: ordenFallback,
+        esta_activa: estaActiva,
       } as any)
 
       if (insertError) throw insertError

--- a/lib/utils/category-permissions.test.ts
+++ b/lib/utils/category-permissions.test.ts
@@ -81,9 +81,14 @@ describe("canToggleCategoryActive", () => {
 })
 
 describe("canHideGlobalCategory", () => {
-  it("nadie oculta globales por delegación: la visibilidad es global", () => {
-    expect(canHideGlobalCategory(tesorero, cat({ es_global: true }))).toBe(false)
-    expect(canHideGlobalCategory(gestor, cat({ es_global: true }))).toBe(false)
+  it("tesorero y gestor pueden ocultar globales en la delegación seleccionada", () => {
+    expect(canHideGlobalCategory(tesorero, cat({ es_global: true }))).toBe(true)
+    expect(canHideGlobalCategory(gestor, cat({ es_global: true }))).toBe(true)
+  })
+
+  it("no aplica a categorías locales ni sin delegación seleccionada", () => {
+    expect(canHideGlobalCategory(tesorero, cat({ es_global: false }))).toBe(false)
+    expect(canHideGlobalCategory(sinDelegacion, cat({ es_global: true }))).toBe(false)
   })
 })
 

--- a/lib/utils/category-permissions.ts
+++ b/lib/utils/category-permissions.ts
@@ -39,11 +39,12 @@ export function canDeleteCategory(
 }
 
 /**
- * Puede ACTIVAR/DESACTIVAR una categoría (cambiar esta_activa).
- * - Las categorías GLOBALES no se activan/desactivan: su visibilidad es global y
- *   están siempre activas. Si una global ya no se quiere, se elimina (el archivado
- *   de actividades será una funcionalidad aparte en el futuro).
- * - Tesorero: solo sus categorías locales.
+ * Puede ACTIVAR/DESACTIVAR una categoría LOCAL (cambiar su esta_activa).
+ * - Las categorías GLOBALES no tienen desactivación global: una global no se puede
+ *   ocultar "para todos" (si sobra, se borra). Su visibilidad se gestiona por
+ *   delegación con canHideGlobalCategory.
+ * - Las categorías locales pertenecen a una delegación, así que su esta_activa ya
+ *   es de hecho por delegación: las activa/desactiva el tesorero de esa delegación.
  */
 export function canToggleCategoryActive(
   ctx: CategoryPermissionContext,
@@ -56,18 +57,18 @@ export function canToggleCategoryActive(
 }
 
 /**
- * (Desactivado) Ocultar/mostrar una categoría global por delegación.
- *
- * El modelo es de ALCANCE GLOBAL: no hay overrides de visibilidad por delegación.
- * Las categorías globales están activas para todas las delegaciones. Se conserva
- * la función (devolviendo siempre false) para no romper los componentes que la
- * referencian, pero ya no expone ningún control en la interfaz.
+ * Puede OCULTAR/MOSTRAR una categoría global en la delegación seleccionada
+ * (override de visibilidad POR DELEGACIÓN, no global).
+ * - Solo aplica a categorías globales y con una delegación seleccionada.
+ * - Lo pueden hacer tanto el tesorero (en su delegación) como el gestor central
+ *   (que desactiva una global para UNA delegación concreta, nunca a nivel global).
  */
 export function canHideGlobalCategory(
-  _ctx: CategoryPermissionContext,
-  _category: CategoriaConOrdenEfectivo
+  ctx: CategoryPermissionContext,
+  category: CategoriaConOrdenEfectivo
 ): boolean {
-  return false
+  if (!ctx.selectedDelegation) return false
+  return category.es_global
 }
 
 /** Reordenar está permitido siempre. */


### PR DESCRIPTION
## Contexto

La PR #151 simplificó la visibilidad de categorías a "alcance global", pero esa dirección era incorrecta. El modelo correcto:

- **Ocultar/mostrar una categoría es POR DELEGACIÓN.** La gracia es que cada delegación desactive lo que no usa. El **gestor central** también puede desactivar una global, pero **para una delegación concreta**, nunca a nivel global.
- **Lo que NO debe existir es la desactivación GLOBAL** de una categoría global: si una global sobra, se borra (no se oculta para todos).
- La **ordenación por delegación** se mantiene como estaba.

## Cambios

- Restaura los overrides de visibilidad por delegación (`categoria_orden_delegacion.esta_activa`):
  - `mapCategorias` (cliente y servidor) vuelve a aplicar el override: `esta_activa_efectiva = override ?? categoria.esta_activa`.
  - Restaurado `setDelegacionCategoryVisibility` en `DatabaseService` y `ServerDatabaseService`.
  - Restaurada la rama de ocultar/mostrar por delegación en `handleToggleActive`.
- `canHideGlobalCategory`: ahora devuelve `true` para categorías globales con una delegación seleccionada, **tanto para tesorero como para gestor central**.
- `canToggleCategoryActive`: se mantiene `false` para globales (no hay desactivación global); las locales las gestiona el tesorero de su delegación.
- Se conserva la salvaguarda del árbol: un padre oculto en una delegación no esconde sus subcategorías visibles (se muestra atenuado).
- Tests de permisos actualizados.

No requiere migraciones: todas las categorías globales ya están activas a nivel base y no hay overrides de visibilidad en `false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01876i5Gi89xqPuqujuBcxNj)_