### PR TITLE
feat(cuentas): animación e indicador de conexión más visible

### DIFF
--- a/components/cuentas/cuentas-manager.tsx
+++ b/components/cuentas/cuentas-manager.tsx
@@ -329,9 +329,9 @@ export function CuentasManager() {
     if (!status) return "bg-gray-200"
     switch (status) {
       case "connected":
-        return "bg-green-500"
+        return "bg-emerald-500"
       case "disconnected":
-        return "bg-gray-400"
+        return "bg-slate-300 dark:bg-slate-500"
       default:
         return "bg-gray-200"
     }
@@ -563,10 +563,13 @@ export function CuentasManager() {
 
                           {/* Connection Status Badge */}
                           {connectionStatus && (
-                            <div
-                              className={`absolute -top-1 -right-1 h-4 w-4 sm:h-5 sm:w-5 rounded-full ${getConnectionBadgeColor(connectionStatus)} border-2 sm:border-3 border-white dark:border-gray-800 shadow-sm`}
-                            >
-                              <div className="h-full w-full rounded-full bg-current opacity-80" />
+                            <div className="absolute -top-1 -right-1 h-4 w-4 sm:h-5 sm:w-5">
+                              {connectionStatus === "connected" && (
+                                <span className="absolute inset-0 rounded-full bg-emerald-400 opacity-75 animate-ping" />
+                              )}
+                              <div
+                                className={`relative h-full w-full rounded-full ${getConnectionBadgeColor(connectionStatus)} border-2 sm:border-3 border-white dark:border-gray-800 ${connectionStatus === "connected" ? "shadow-[0_0_6px_2px_rgba(16,185,129,0.7)]" : "shadow-sm"}`}
+                              />
                             </div>
                           )}
 


### PR DESCRIPTION
## Resumen
- El punto de estado "conectada" en las tarjetas de cuenta ahora tiene una animación de pulso (`animate-ping`) y un brillo (glow) verde esmeralda.
- Se cambia la paleta para distinguir mejor "conectada" (verde esmeralda con brillo) de "sin conexión" (gris claro, sin animación), evitando que se confundan.

## Plan de pruebas
- [ ] Abrir `/cuentas` y verificar que las cuentas con `origen: "conectada"` muestran el punto verde animado con halo.
- [ ] Verificar que las cuentas desconectadas muestran un punto gris estático, claramente distinto.
- [ ] Comprobar en modo claro y oscuro.


---
_Generated by [Claude Code](https://claude.ai/code/session_01876i5Gi89xqPuqujuBcxNj)_