### PR TITLE
fix(informes): cuadre real de la memoria económica + validación en vivo

### DIFF
--- a/app/api/informes/generar/route.ts
+++ b/app/api/informes/generar/route.ts
@@ -92,6 +92,11 @@ export async function POST(req: Request) {
       driveUrl: resultado.webViewLink,
       spreadsheetId: resultado.spreadsheetId,
       titulo,
+      remanente: resultado.remanente,
+      balanceAnual: resultado.balanceAnual,
+      disponibleFinal: resultado.disponibleFinal,
+      resumen: resultado.resumen,
+      cuadraConHoja: resultado.cuadraConHoja,
     })
   } catch (err: any) {
     console.error("Error generando memoria:", err?.message || err)

--- a/components/informes/generar/generar-informe-dialog.tsx
+++ b/components/informes/generar/generar-informe-dialog.tsx
@@ -413,13 +413,13 @@ export function GenerarInformeDialog({
   }
 
   const setCategoria = (fila: MapeoFila, categoriaId: string | null, categoriaNombre?: string) => {
-    const modo = modoDeFila(fila)
+    if (modoDeFila(fila) === "saldo") return
     const fuente: Fuente | null = categoriaId ? { tipo: "categoria", categoriaId } : null
     // En IV/V/VI la descripción de la fila es el propio nombre de la categoría.
     const patchDesc = fila.escribirDescripcion ? { descripcion: categoriaNombre ?? "" } : {}
-    if (modo === "ingreso") updateFila(fila.id, { ingreso: fuente, gasto: null, ...patchDesc })
-    else if (modo === "gasto") updateFila(fila.id, { gasto: fuente, ingreso: null, ...patchDesc })
-    else if (modo === "ambos") updateFila(fila.id, { ingreso: fuente, gasto: fuente, ...patchDesc })
+    // Siempre ambos lados: cada fila del template calcula F = D − E, y si solo
+    // se sumara un lado los abonos/devoluciones se perderían y no cuadraría.
+    updateFila(fila.id, { ingreso: fuente, gasto: fuente, ...patchDesc })
   }
 
   const isCapExcluido = (cap: Capitulo) => (mapeo?.capitulosExcluidos ?? []).includes(cap)
@@ -806,10 +806,15 @@ export function GenerarInformeDialog({
                                   )}
                                 </div>
                                 <div className="shrink-0 space-y-0.5 text-right text-sm tabular-nums">
-                                  {(modo === "ingreso" || modo === "ambos" || modo === "saldo") && (
+                                  {(modo === "ingreso" ||
+                                    modo === "ambos" ||
+                                    modo === "saldo" ||
+                                    Math.abs(v?.ingreso ?? 0) >= 0.005) && (
                                     <div className="font-semibold text-emerald-600">{eur(v?.ingreso)}</div>
                                   )}
-                                  {(modo === "gasto" || modo === "ambos") && (
+                                  {(modo === "gasto" ||
+                                    modo === "ambos" ||
+                                    Math.abs(v?.gasto ?? 0) >= 0.005) && (
                                     <div className="font-semibold text-red-500">{eur(v?.gasto)}</div>
                                   )}
                                 </div>
@@ -826,8 +831,7 @@ export function GenerarInformeDialog({
                               )}
                               {usaPicker && !esSaldo && (
                                 <p className="mt-1 pl-7 text-[11px] text-muted-foreground">
-                                  Suma de la categoría
-                                  {modo === "ambos" ? " (ingresos y gastos)" : modo === "gasto" ? " (gastos)" : " (ingresos)"}
+                                  Suma de la categoría en el periodo (entradas y salidas)
                                 </p>
                               )}
                             </div>

--- a/components/informes/generar/generar-informe-dialog.tsx
+++ b/components/informes/generar/generar-informe-dialog.tsx
@@ -26,6 +26,7 @@ import type {
   MapeoConfig,
   MapeoFila,
   PreviewResultado,
+  ResumenValidacion,
 } from "@/lib/services/memoria-economica"
 import { cn } from "@/lib/utils"
 import {
@@ -50,10 +51,18 @@ import {
   CalendarRange,
   HeartHandshake,
   Boxes,
+  Check,
+  Scale,
+  ChevronDown,
   type LucideIcon,
 } from "lucide-react"
 
 const eur = (n: number | undefined) => (typeof n === "number" ? formatCurrency(n) : "—")
+
+// Fila fija "Donativo total realizado" del capítulo V (misma constante que en
+// lib/services/memoria-economica.ts — no se importa para no meter googleapis
+// en el bundle del cliente).
+const FILA_DONATIVO = 39
 
 const CAP_LABEL: Record<Capitulo, string> = {
   I: "Capítulo I · Saldos curso anterior",
@@ -80,6 +89,7 @@ function modoDeFila(fila: MapeoFila): Modo {
   if (fila.capitulo === "I") return "saldo"
   if (fila.capitulo === "III") return "gasto"
   if (fila.capitulo === "II") return fila.fila === 10 ? "gasto" : "ingreso"
+  if (fila.capitulo === "V" && fila.fila === FILA_DONATIVO) return "gasto"
   return "ambos" // IV, V, VI
 }
 
@@ -87,6 +97,196 @@ function categoriaIdDeFila(fila: MapeoFila): string | null {
   const f = fila.ingreso ?? fila.gasto
   if (f && f.tipo === "categoria") return f.categoriaId
   return null
+}
+
+// ---------- Stepper ----------
+
+const STEPS = [
+  { key: "config", label: "Periodo" },
+  { key: "mapeo", label: "Revisar y cuadrar" },
+  { key: "done", label: "¡Listo!" },
+] as const
+
+function Stepper({ step }: { step: (typeof STEPS)[number]["key"] }) {
+  const idx = STEPS.findIndex((s) => s.key === step)
+  return (
+    <div className="flex items-center gap-1.5 pt-1">
+      {STEPS.map((s, i) => {
+        const done = i < idx
+        const current = i === idx
+        return (
+          <div key={s.key} className="flex items-center gap-1.5">
+            {i > 0 && (
+              <div className={cn("h-px w-5 sm:w-8", i <= idx ? "bg-primary" : "bg-border")} />
+            )}
+            <span
+              className={cn(
+                "flex h-5 w-5 items-center justify-center rounded-full text-[10px] font-bold transition-colors",
+                done || current
+                  ? "bg-primary text-primary-foreground"
+                  : "bg-muted text-muted-foreground",
+                current && "ring-2 ring-primary/25 ring-offset-1 ring-offset-background",
+              )}
+            >
+              {done ? <Check className="h-3 w-3" /> : i + 1}
+            </span>
+            <span
+              className={cn(
+                "text-xs",
+                current ? "font-semibold text-foreground" : "text-muted-foreground",
+              )}
+            >
+              {s.label}
+            </span>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+// ---------- Panel de validación (cuadre del ejercicio) ----------
+
+function ValidacionPanel({ resumen, finLabel }: { resumen: ResumenValidacion; finLabel: string }) {
+  const [detalle, setDetalle] = useState(false)
+  const r = resumen
+  const remananteDistinto = Math.abs(r.remanenteInforme - r.remanenteReal) >= 0.005
+  const hayNoRecogido = r.noRecogidoIngresos >= 0.005 || r.noRecogidoGastos >= 0.005
+  const hayDoble = r.dobleContadoIngresos >= 0.005 || r.dobleContadoGastos >= 0.005
+
+  const celdas: { label: string; value: number; className?: string; signo?: string }[] = [
+    { label: "Remanente anterior", value: r.remanenteInforme },
+    { label: "Entradas", value: r.informeIngresos, className: "text-emerald-600 dark:text-emerald-400", signo: "+" },
+    { label: "Salidas", value: r.informeGastos, className: "text-red-500", signo: "−" },
+    { label: "Terminas con", value: r.disponibleFinal, className: "font-bold" },
+  ]
+
+  return (
+    <div
+      className={cn(
+        "shrink-0 rounded-xl border p-3",
+        r.cuadra
+          ? "border-emerald-300 bg-emerald-50/60 dark:border-emerald-800 dark:bg-emerald-900/15"
+          : "border-amber-300 bg-amber-50/60 dark:border-amber-800 dark:bg-amber-900/15",
+      )}
+    >
+      <div className="flex items-center gap-2">
+        <Scale className="h-4 w-4 shrink-0 text-muted-foreground" />
+        <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Cuadre del ejercicio
+        </span>
+        <span
+          className={cn(
+            "ml-auto inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-semibold",
+            r.cuadra
+              ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/50 dark:text-emerald-300"
+              : "bg-amber-100 text-amber-800 dark:bg-amber-900/50 dark:text-amber-300",
+          )}
+        >
+          {r.cuadra ? (
+            <>
+              <CheckCircle2 className="h-3 w-3" /> Cuadra al céntimo
+            </>
+          ) : (
+            <>
+              <AlertTriangle className="h-3 w-3" /> Descuadre de {eur(Math.abs(r.descuadre))}
+            </>
+          )}
+        </span>
+      </div>
+
+      {/* remanente + entradas − salidas = cierre */}
+      <div className="mt-2 grid grid-cols-2 gap-2 sm:grid-cols-4">
+        {celdas.map((c, i) => (
+          <div key={c.label} className="relative rounded-lg border bg-background/70 px-2.5 py-1.5">
+            {i > 0 && (
+              <span className="absolute -left-2 top-1/2 hidden -translate-y-1/2 text-xs font-bold text-muted-foreground sm:block">
+                {i === 3 ? "=" : c.signo}
+              </span>
+            )}
+            <p className="text-[10px] uppercase tracking-wide text-muted-foreground">{c.label}</p>
+            <p className={cn("text-sm tabular-nums", c.className ?? "font-medium")}>{eur(c.value)}</p>
+          </div>
+        ))}
+      </div>
+
+      {r.cuadra ? (
+        <p className="mt-2 text-xs text-emerald-700 dark:text-emerald-300">
+          Sumando entradas y salidas e incorporando el remanente, terminas el ejercicio con{" "}
+          <strong className="tabular-nums">{eur(r.disponibleFinal)}</strong> — exactamente el saldo
+          real de tus cuentas al {finLabel}. 👌
+        </p>
+      ) : (
+        <div className="mt-2 space-y-1.5">
+          <p className="text-xs text-amber-800 dark:text-amber-300">
+            El informe cierra con <strong className="tabular-nums">{eur(r.disponibleFinal)}</strong>,
+            pero el saldo real de tus cuentas al {finLabel} es{" "}
+            <strong className="tabular-nums">{eur(r.saldoFinalReal)}</strong>.
+            <button
+              type="button"
+              onClick={() => setDetalle((d) => !d)}
+              className="ml-1.5 inline-flex items-center gap-0.5 font-semibold underline underline-offset-2"
+            >
+              ¿Por qué? <ChevronDown className={cn("h-3 w-3 transition-transform", detalle && "rotate-180")} />
+            </button>
+          </p>
+          {detalle && (
+            <ul className="space-y-1 rounded-md bg-background/70 p-2.5 text-xs text-muted-foreground">
+              {hayNoRecogido && (
+                <li className="flex gap-1.5">
+                  <span>•</span>
+                  <span>
+                    <strong>{r.noRecogidoMovs} movimientos del periodo no los recoge ninguna fila</strong>
+                    {": "}
+                    {r.noRecogidoIngresos >= 0.005 && (
+                      <>entradas por <strong className="tabular-nums">{eur(r.noRecogidoIngresos)}</strong></>
+                    )}
+                    {r.noRecogidoIngresos >= 0.005 && r.noRecogidoGastos >= 0.005 && " y "}
+                    {r.noRecogidoGastos >= 0.005 && (
+                      <>salidas por <strong className="tabular-nums">{eur(r.noRecogidoGastos)}</strong></>
+                    )}
+                    . Son movimientos sin categoría o de categorías sin fila en el informe.
+                  </span>
+                </li>
+              )}
+              {hayDoble && (
+                <li className="flex gap-1.5">
+                  <span>•</span>
+                  <span>
+                    <strong>Importes contados más de una vez</strong>
+                    {": "}
+                    {r.dobleContadoIngresos >= 0.005 && (
+                      <>entradas por <strong className="tabular-nums">{eur(r.dobleContadoIngresos)}</strong></>
+                    )}
+                    {r.dobleContadoIngresos >= 0.005 && r.dobleContadoGastos >= 0.005 && " y "}
+                    {r.dobleContadoGastos >= 0.005 && (
+                      <>salidas por <strong className="tabular-nums">{eur(r.dobleContadoGastos)}</strong></>
+                    )}
+                    . Suele pasar al asignar una categoría madre y una subcategoría suya en filas
+                    distintas.
+                  </span>
+                </li>
+              )}
+              {remananteDistinto && (
+                <li className="flex gap-1.5">
+                  <span>•</span>
+                  <span>
+                    El remanente del informe (<span className="tabular-nums">{eur(r.remanenteInforme)}</span>)
+                    no coincide con el saldo inicial real (
+                    <span className="tabular-nums">{eur(r.remanenteReal)}</span>). Revisa las filas del
+                    capítulo I (banco {eur(r.remanenteBanco)} · caja {eur(r.remanenteCaja)}).
+                  </span>
+                </li>
+              )}
+              {!hayNoRecogido && !hayDoble && !remananteDistinto && (
+                <li>Diferencia por filas con importe manual o redondeos.</li>
+              )}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  )
 }
 
 interface Props {
@@ -124,7 +324,15 @@ export function GenerarInformeDialog({
   const [recomputing, setRecomputing] = useState(false)
   const [generating, setGenerating] = useState(false)
   const [savingDraft, setSavingDraft] = useState(false)
-  const [result, setResult] = useState<{ driveUrl: string | null; titulo: string } | null>(null)
+  const [result, setResult] = useState<{
+    driveUrl: string | null
+    titulo: string
+    remanente: number | null
+    balanceAnual: number | null
+    disponibleFinal: number | null
+    resumen: ResumenValidacion | null
+    cuadraConHoja: boolean
+  } | null>(null)
   const [pickerFila, setPickerFila] = useState<MapeoFila | null>(null)
 
   const informeId = initialInforme?.id ?? null
@@ -237,7 +445,9 @@ export function GenerarInformeDialog({
   const addFilaCapitulo = (cap: Capitulo) => {
     setMapeo((prev) => {
       if (!prev) return prev
-      const libre = prev.filas.find((f) => f.capitulo === cap && !f.enabled)
+      const libre = prev.filas.find(
+        (f) => f.capitulo === cap && !f.enabled && f.fila !== FILA_DONATIVO,
+      )
       if (!libre) {
         toast.error("No quedan más filas disponibles en la plantilla para este capítulo")
         return prev
@@ -252,7 +462,7 @@ export function GenerarInformeDialog({
   }
 
   const filasLibres = (cap: Capitulo) =>
-    (mapeo?.filas ?? []).some((f) => f.capitulo === cap && !f.enabled)
+    (mapeo?.filas ?? []).some((f) => f.capitulo === cap && !f.enabled && f.fila !== FILA_DONATIVO)
 
   const handleGenerar = async () => {
     if (!google.connected) {
@@ -273,7 +483,15 @@ export function GenerarInformeDialog({
         return
       }
       if (!res.ok) throw new Error(data?.error || "Error generando la memoria")
-      setResult({ driveUrl: data.driveUrl ?? null, titulo: data.titulo })
+      setResult({
+        driveUrl: data.driveUrl ?? null,
+        titulo: data.titulo,
+        remanente: typeof data.remanente === "number" ? data.remanente : null,
+        balanceAnual: typeof data.balanceAnual === "number" ? data.balanceAnual : null,
+        disponibleFinal: typeof data.disponibleFinal === "number" ? data.disponibleFinal : null,
+        resumen: (data.resumen as ResumenValidacion) ?? null,
+        cuadraConHoja: !!data.cuadraConHoja,
+      })
       setStep("done")
       onSaved()
     } catch (err) {
@@ -345,6 +563,8 @@ export function GenerarInformeDialog({
   }, [mapeo])
 
   const saldoFecha = periodoTipo === "curso" ? "1 de septiembre" : "1 de enero"
+  const finLabel =
+    periodoTipo === "curso" ? `31 de agosto de ${anio + 1}` : `31 de diciembre de ${anio}`
 
   return (
     <>
@@ -358,9 +578,11 @@ export function GenerarInformeDialog({
           </DialogTitle>
           <DialogDescription>
             {step === "config" && "Elige el periodo y conecta tu cuenta de Google."}
-            {step === "mapeo" && "Revisa qué se escribe en cada celda. Puedes editar, vaciar o quitar filas."}
+            {step === "mapeo" &&
+              "Revisa qué se escribe en cada fila y comprueba abajo que el ejercicio cuadra."}
             {step === "done" && "¡Listo! Tu memoria económica está en tu Google Drive."}
           </DialogDescription>
+          <Stepper step={step} />
         </DialogHeader>
 
         {/* PASO 1 — CONFIG */}
@@ -519,7 +741,16 @@ export function GenerarInformeDialog({
                       </p>
                     ) : (
                       <div className="space-y-2 border-t px-3 py-3">
-                        {filasCap.map((fila) => {
+                        {(flexible
+                          ? filasCap.filter(
+                              (f) =>
+                                f.enabled ||
+                                f.fila === FILA_DONATIVO ||
+                                !!categoriaIdDeFila(f) ||
+                                !!f.descripcion,
+                            )
+                          : filasCap
+                        ).map((fila) => {
                           const modo = modoDeFila(fila)
                           const v = preview.valores[fila.id]
                           const catId = categoriaIdDeFila(fila)
@@ -623,6 +854,8 @@ export function GenerarInformeDialog({
               })}
             </div>
 
+            {preview.resumen && <ValidacionPanel resumen={preview.resumen} finLabel={finLabel} />}
+
             <div className="flex items-center justify-between border-t pt-3">
               <Button variant="ghost" onClick={() => setStep("config")}>
                 <ChevronLeft className="mr-1 h-4 w-4" /> Atrás
@@ -661,6 +894,51 @@ export function GenerarInformeDialog({
                 Se ha guardado en <strong>Mi unidad</strong> de tu Google Drive.
               </p>
             </div>
+
+            {/* Cifras finales leídas del documento generado */}
+            {(result.resumen || result.disponibleFinal !== null) && (
+              <div className="w-full space-y-2">
+                <div className="grid grid-cols-3 gap-2">
+                  <div className="rounded-lg border bg-muted/30 px-2 py-2.5">
+                    <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                      Remanente anterior
+                    </p>
+                    <p className="text-sm font-semibold tabular-nums">
+                      {eur(result.remanente ?? result.resumen?.remanenteInforme)}
+                    </p>
+                  </div>
+                  <div className="rounded-lg border bg-muted/30 px-2 py-2.5">
+                    <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                      Balance del ejercicio
+                    </p>
+                    <p className="text-sm font-semibold tabular-nums">
+                      {eur(result.balanceAnual ?? result.resumen?.balanceEjercicio)}
+                    </p>
+                  </div>
+                  <div className="rounded-lg border border-primary/40 bg-primary/5 px-2 py-2.5">
+                    <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                      Terminas con
+                    </p>
+                    <p className="text-sm font-bold tabular-nums">
+                      {eur(result.disponibleFinal ?? result.resumen?.disponibleFinal)}
+                    </p>
+                  </div>
+                </div>
+                {result.resumen &&
+                  (result.resumen.cuadra ? (
+                    <p className="flex items-center justify-center gap-1.5 text-xs font-medium text-emerald-600 dark:text-emerald-400">
+                      <CheckCircle2 className="h-3.5 w-3.5" />
+                      Cuadra al céntimo con el saldo real de tus cuentas al cierre.
+                    </p>
+                  ) : (
+                    <p className="flex items-center justify-center gap-1.5 text-xs font-medium text-amber-700 dark:text-amber-400">
+                      <AlertTriangle className="h-3.5 w-3.5" />
+                      El saldo real al cierre es {eur(result.resumen.saldoFinalReal)} (descuadre de{" "}
+                      {eur(Math.abs(result.resumen.descuadre))}) — repásalo en el Sheet.
+                    </p>
+                  ))}
+              </div>
+            )}
 
             {result.driveUrl && (
               <a

--- a/lib/services/memoria-economica.ts
+++ b/lib/services/memoria-economica.ts
@@ -66,11 +66,57 @@ export interface CategoriaCatalogo {
   esHija: boolean
 }
 
+/**
+ * Validación del ejercicio: compara lo que recogerá el informe con la
+ * realidad de la app (todos los movimientos del periodo, cuentas activas).
+ * La cuenta es la misma que hace la plantilla: remanente + ingresos − gastos.
+ */
+export interface ResumenValidacion {
+  /** Saldo real al inicio del periodo (solo cuentas activas). */
+  remanenteBanco: number
+  remanenteCaja: number
+  remanenteReal: number
+  /** Remanente que escribirá el informe (filas activas del capítulo I). */
+  remanenteInforme: number
+  /** Totales reales del periodo (todos los movimientos no ignorados). */
+  realIngresos: number
+  realGastos: number
+  /** remanenteReal + realIngresos − realGastos = dinero real al cierre. */
+  saldoFinalReal: number
+  /** Totales que suma el informe (filas activas de capítulos II–VI). */
+  informeIngresos: number
+  informeGastos: number
+  balanceEjercicio: number
+  /** remanenteInforme + balanceEjercicio = F49 de la hoja generada. */
+  disponibleFinal: number
+  /** Movimientos del periodo que ninguna fila del informe recoge. */
+  noRecogidoIngresos: number
+  noRecogidoGastos: number
+  noRecogidoMovs: number
+  /** Importes contados en más de una fila (p. ej. madre + subcategoría). */
+  dobleContadoIngresos: number
+  dobleContadoGastos: number
+  /** disponibleFinal − saldoFinalReal. */
+  descuadre: number
+  cuadra: boolean
+}
+
+export interface TextosInforme {
+  titulo: string
+  capituloI: string
+  capituloIV: string
+  saldoBanco: string
+  saldoCaja: string
+  balance: string
+  remanente: string
+}
+
 export interface PreviewResultado {
   mapeo: MapeoConfig
   valores: Record<string, ValorFila>
   avisos: Aviso[]
-  textos: { titulo: string; capituloIV: string; balance: string }
+  resumen: ResumenValidacion
+  textos: TextosInforme
   periodo: { inicio: string; fin: string; label: string }
   categorias: CategoriaCatalogo[]
 }
@@ -195,7 +241,7 @@ export async function buildContext(
 
   const { data: cuentaData, error: cuentaErr } = await supabase
     .from("cuenta")
-    .select("id, tipo")
+    .select("id, tipo, activa")
     .eq("delegacion_id", delegacionId)
   if (cuentaErr) throw cuentaErr
 
@@ -210,12 +256,16 @@ export async function buildContext(
     }
   }
 
+  // Solo cuentas activas: el dashboard también las excluye (join con cuenta,
+  // activa=true), así el informe cuadra con lo que el usuario ve en la app.
   const cuentaTipoById = new Map<string, "banco" | "caja">()
   for (const c of cuentaData || []) {
+    if (c.activa === false) continue
     cuentaTipoById.set(c.id, c.tipo === "caja" ? "caja" : "banco")
   }
 
-  const movs = await fetchAllMovimientos(supabase, delegacionId, rango.fin)
+  const movsAll = await fetchAllMovimientos(supabase, delegacionId, rango.fin)
+  const movs = movsAll.filter((m) => m.cuenta_id && cuentaTipoById.has(m.cuenta_id))
 
   return {
     delegacionId,
@@ -343,6 +393,8 @@ const GASTOS_FUNCIONAMIENTO: { fila: number; nombre: string }[] = [
 // Filas disponibles por capítulo en el template
 export const FILAS_ACTIVIDADES = [23, 24, 25, 26, 27, 28, 29, 30, 31, 32]
 export const FILAS_CAMPANAS = [34, 35, 36, 37, 38]
+/** Fila fija "Donativo total realizado" del capítulo V (gasto en E39). */
+export const FILA_DONATIVO = 39
 export const FILAS_CAP6 = [41, 42, 43]
 
 // Rango COMPLETO de cada capítulo opcional (cabecera + contenido + subtotal).
@@ -494,6 +546,16 @@ export function buildDefaultMapeo(ctx: MemoriaContext): MapeoConfig {
       enabled: false,
     })
   })
+  // Fila fija del template "Donativo total realizado" (solo gasto, E39).
+  filas.push({
+    id: `cap5-${FILA_DONATIVO}`,
+    capitulo: "V",
+    fila: FILA_DONATIVO,
+    descripcion: "Donativo total realizado",
+    escribirDescripcion: false,
+    gasto: null,
+    enabled: false,
+  })
 
   // Cap VI — otros (vacío por defecto)
   FILAS_CAP6.forEach((fila) => {
@@ -560,6 +622,106 @@ export function computeValores(ctx: MemoriaContext, mapeo: MapeoConfig): {
   return { valores, avisos }
 }
 
+/**
+ * Valida el ejercicio: remanente + entradas − salidas del informe frente al
+ * dinero real de las cuentas. También detecta movimientos que ninguna fila
+ * recoge y los contados dos veces (madre + subcategoría en filas distintas).
+ */
+export function computeResumen(
+  ctx: MemoriaContext,
+  mapeo: MapeoConfig,
+  valores: Record<string, ValorFila>,
+): ResumenValidacion {
+  const excluidos = new Set<Capitulo>(mapeo.capitulosExcluidos ?? [])
+  const activa = (f: MapeoFila) => f.enabled && !excluidos.has(f.capitulo)
+
+  const remanenteBanco = saldoInicial(ctx, "banco")
+  const remanenteCaja = saldoInicial(ctx, "caja")
+  const remanenteReal = remanenteBanco + remanenteCaja
+
+  let realIngresos = 0
+  let realGastos = 0
+  for (const m of ctx.movs) {
+    if (!enPeriodo(ctx, m.fecha)) continue
+    if (m.importe >= 0) realIngresos += m.importe
+    else realGastos += -m.importe
+  }
+
+  // Totales del informe + cuántas filas recogen cada categoría (por columna)
+  let remanenteInforme = 0
+  let informeIngresos = 0
+  let informeGastos = 0
+  const ingresoCount = new Map<string, number>()
+  const gastoCount = new Map<string, number>()
+  for (const f of mapeo.filas) {
+    if (!activa(f)) continue
+    const v = valores[f.id] || {}
+    if (f.capitulo === "I") {
+      remanenteInforme += v.ingreso ?? 0
+      continue
+    }
+    informeIngresos += v.ingreso ?? 0
+    informeGastos += v.gasto ?? 0
+    if (f.ingreso?.tipo === "categoria") {
+      for (const id of descendantIds(ctx, f.ingreso.categoriaId)) {
+        ingresoCount.set(id, (ingresoCount.get(id) ?? 0) + 1)
+      }
+    }
+    if (f.gasto?.tipo === "categoria") {
+      for (const id of descendantIds(ctx, f.gasto.categoriaId)) {
+        gastoCount.set(id, (gastoCount.get(id) ?? 0) + 1)
+      }
+    }
+  }
+
+  let noRecogidoIngresos = 0
+  let noRecogidoGastos = 0
+  let noRecogidoMovs = 0
+  let dobleContadoIngresos = 0
+  let dobleContadoGastos = 0
+  for (const m of ctx.movs) {
+    if (!enPeriodo(ctx, m.fecha)) continue
+    const esIngreso = m.importe >= 0
+    const counts = esIngreso ? ingresoCount : gastoCount
+    const veces = m.categoria_id ? counts.get(m.categoria_id) ?? 0 : 0
+    const abs = Math.abs(m.importe)
+    if (veces === 0) {
+      noRecogidoMovs++
+      if (esIngreso) noRecogidoIngresos += abs
+      else noRecogidoGastos += abs
+    } else if (veces > 1) {
+      if (esIngreso) dobleContadoIngresos += (veces - 1) * abs
+      else dobleContadoGastos += (veces - 1) * abs
+    }
+  }
+
+  const balanceEjercicio = informeIngresos - informeGastos
+  const disponibleFinal = remanenteInforme + balanceEjercicio
+  const saldoFinalReal = remanenteReal + realIngresos - realGastos
+  const descuadre = disponibleFinal - saldoFinalReal
+
+  return {
+    remanenteBanco,
+    remanenteCaja,
+    remanenteReal,
+    remanenteInforme,
+    realIngresos,
+    realGastos,
+    saldoFinalReal,
+    informeIngresos,
+    informeGastos,
+    balanceEjercicio,
+    disponibleFinal,
+    noRecogidoIngresos,
+    noRecogidoGastos,
+    noRecogidoMovs,
+    dobleContadoIngresos,
+    dobleContadoGastos,
+    descuadre,
+    cuadra: Math.abs(descuadre) < 0.005,
+  }
+}
+
 export function buildPreview(ctx: MemoriaContext, mapeoEntrada?: MapeoConfig | null): PreviewResultado {
   const mapeo = mapeoEntrada ?? buildDefaultMapeo(ctx)
   const { valores, avisos } = computeValores(ctx, mapeo)
@@ -579,11 +741,18 @@ export function buildPreview(ctx: MemoriaContext, mapeoEntrada?: MapeoConfig | n
   }
 
   const corto = nombreCorto(ctx.delegacionNombre)
-  const prefijoPeriodo = ctx.periodoTipo === "curso" ? "Curso " : "Año "
-  const textos = {
-    titulo: `MCM ${corto} · Balance Económico · ${prefijoPeriodo}${ctx.rango.label}`,
+  const esCurso = ctx.periodoTipo === "curso"
+  const palabra = esCurso ? "CURSO" : "AÑO"
+  const palabraMin = esCurso ? "curso" : "año"
+  const fechaSaldo = esCurso ? "1 septiembre" : "1 enero"
+  const textos: TextosInforme = {
+    titulo: `MCM ${corto} · Balance Económico · ${esCurso ? "Curso " : "Año "}${ctx.rango.label}`,
+    capituloI: `CAPÍTULO I - SALDOS ${palabra} ANTERIOR`,
     capituloIV: `CAPÍTULO IV - ACTIVIDADES ${ctx.rango.labelHeader}`,
-    balance: `BALANCE CURSO ${ctx.rango.label}\n(sin remanente curso anterior)`,
+    saldoBanco: `Saldo Cuenta Bancaria - ${fechaSaldo}`,
+    saldoCaja: `Saldo Caja - ${fechaSaldo}`,
+    balance: `BALANCE ${palabra} ${ctx.rango.label}\n(sin remanente ${palabraMin} anterior)`,
+    remanente: `INCORPORANDO REMANENTE DEL ${palabra} ANTERIOR`,
   }
 
   const categorias: CategoriaCatalogo[] = ctx.categorias
@@ -600,6 +769,7 @@ export function buildPreview(ctx: MemoriaContext, mapeoEntrada?: MapeoConfig | n
     mapeo,
     valores,
     avisos,
+    resumen: computeResumen(ctx, mapeo, valores),
     textos,
     periodo: { inicio: ctx.rango.inicio, fin: ctx.rango.fin, label: ctx.rango.label },
     categorias,
@@ -612,10 +782,16 @@ export interface GenerarResultado {
   spreadsheetId: string
   webViewLink: string | null
   titulo: string
+  /** Remanente del curso anterior leído de la celda F3. */
+  remanente: number | null
   /** Balance anual leído de la celda F46 del documento generado. */
   balanceAnual: number | null
   /** Disponible final de año leído de la celda F49. */
   disponibleFinal: number | null
+  /** Validación calculada con los datos de la app. */
+  resumen: ResumenValidacion
+  /** true si F46/F49 de la hoja coinciden con lo esperado por la app. */
+  cuadraConHoja: boolean
 }
 
 export async function generarSheet(
@@ -663,8 +839,26 @@ export async function generarSheet(
   // 2. Preparar valores (saltando capítulos excluidos por completo)
   const updates: { range: string; values: any[][] }[] = []
   updates.push({ range: "C1", values: [[preview.textos.titulo]] })
+  updates.push({ range: "A3", values: [[preview.textos.capituloI]] })
+  updates.push({ range: "C4", values: [[preview.textos.saldoBanco]] })
+  updates.push({ range: "C5", values: [[preview.textos.saldoCaja]] })
   updates.push({ range: "A22", values: [[preview.textos.capituloIV]] })
   updates.push({ range: "C45", values: [[preview.textos.balance]] })
+  updates.push({ range: "C48", values: [[preview.textos.remanente]] })
+
+  // Corrección de fórmulas del template: D46 original suma también D3 (los
+  // saldos del curso anterior), con lo que F46 ("balance sin remanente") SÍ
+  // incluía el remanente y F49 (= F3 + F46) lo contaba DOS veces. Se reescriben
+  // los totales para que sumen solo los capítulos II–VI y todo cuadre:
+  //   F46 = balance del ejercicio · F49 = remanente + balance = disponible.
+  updates.push({ range: "D46", values: [["=D6+D12+D22+D33+D40"]] })
+  updates.push({ range: "E46", values: [["=E6+E12+E22+E33+E40"]] })
+
+  // Si el capítulo V va incluido, limpiar el placeholder "XXXXXXXX" de D39
+  // (fila "Donativo total realizado": su importe va como gasto en E39).
+  if (!excluidos.has("V")) {
+    updates.push({ range: `D${FILA_DONATIVO}`, values: [[""]] })
+  }
 
   for (const fila of mapeo.filas) {
     if (!fila.enabled || excluidos.has(fila.capitulo)) continue
@@ -711,25 +905,36 @@ export async function generarSheet(
 
   await sheets.spreadsheets.batchUpdate({ spreadsheetId, requestBody: { requests } })
 
-  // 4. Leer totales calculados (F46 = balance anual, F49 = disponible final)
+  // 4. Leer totales calculados (F3 = remanente, F46 = balance, F49 = disponible)
+  let remanente: number | null = null
   let balanceAnual: number | null = null
   let disponibleFinal: number | null = null
   try {
     const vals = await sheets.spreadsheets.values.batchGet({
       spreadsheetId,
-      ranges: ["F46", "F49"],
+      ranges: ["F3", "F46", "F49"],
       valueRenderOption: "UNFORMATTED_VALUE",
     })
     const ranges = vals.data.valueRanges ?? []
-    const f46 = ranges[0]?.values?.[0]?.[0]
-    const f49 = ranges[1]?.values?.[0]?.[0]
+    const f3 = ranges[0]?.values?.[0]?.[0]
+    const f46 = ranges[1]?.values?.[0]?.[0]
+    const f49 = ranges[2]?.values?.[0]?.[0]
+    if (typeof f3 === "number") remanente = f3
     if (typeof f46 === "number") balanceAnual = f46
     if (typeof f49 === "number") disponibleFinal = f49
   } catch {
     // no bloqueante: si no se pueden leer, se dejan en null
   }
 
-  // 5. Enlace
+  // 5. Verificar que la hoja calcula lo mismo que la app
+  const resumen = preview.resumen
+  const cuadraConHoja =
+    balanceAnual !== null &&
+    disponibleFinal !== null &&
+    Math.abs(balanceAnual - resumen.balanceEjercicio) < 0.01 &&
+    Math.abs(disponibleFinal - resumen.disponibleFinal) < 0.01
+
+  // 6. Enlace
   const file = await drive.files.get({
     fileId: spreadsheetId,
     fields: "webViewLink",
@@ -740,7 +945,10 @@ export async function generarSheet(
     spreadsheetId,
     webViewLink: file.data.webViewLink ?? null,
     titulo,
+    remanente,
     balanceAnual,
     disponibleFinal,
+    resumen,
+    cuadraConHoja,
   }
 }

--- a/lib/services/memoria-economica.ts
+++ b/lib/services/memoria-economica.ts
@@ -473,16 +473,23 @@ export function buildDefaultMapeo(ctx: MemoriaContext): MapeoConfig {
   })
 
   // Cap II — cuotas y subvenciones
+  // Cada fila del template calcula F = D − E, así que todas las filas de
+  // categoría suman AMBOS lados (entradas en D y salidas en E). Si no, los
+  // abonos/devoluciones se pierden y el informe no cuadra con las cuentas.
   const cuotasMic = findCatByName(ctx, "Cuotas MIC-COM")
   const cuotasCom = findCatByName(ctx, "Cuotas COM-LC +18")
   const cuotaEce = findCatByName(ctx, "Cuota anual enviada al ECE")
+  const ambos = (cat: CategoriaRow | undefined): Pick<MapeoFila, "ingreso" | "gasto"> => ({
+    ingreso: cat ? { tipo: "categoria", categoriaId: cat.id } : null,
+    gasto: cat ? { tipo: "categoria", categoriaId: cat.id } : null,
+  })
   filas.push({
     id: "cap2-miccom",
     capitulo: "II",
     fila: 7,
     descripcion: "Cuotas - MIC y COM",
     escribirDescripcion: false,
-    ingreso: cuotasMic ? { tipo: "categoria", categoriaId: cuotasMic.id } : null,
+    ...ambos(cuotasMic),
     enabled: true,
   })
   filas.push({
@@ -491,7 +498,7 @@ export function buildDefaultMapeo(ctx: MemoriaContext): MapeoConfig {
     fila: 8,
     descripcion: "Cuotas - COM y LC +18",
     escribirDescripcion: false,
-    ingreso: cuotasCom ? { tipo: "categoria", categoriaId: cuotasCom.id } : null,
+    ...ambos(cuotasCom),
     enabled: true,
   })
   filas.push({
@@ -500,7 +507,7 @@ export function buildDefaultMapeo(ctx: MemoriaContext): MapeoConfig {
     fila: 10,
     descripcion: "Cuota anual enviada al ECE",
     escribirDescripcion: false,
-    gasto: cuotaEce ? { tipo: "categoria", categoriaId: cuotaEce.id } : null,
+    ...ambos(cuotaEce),
     enabled: true,
   })
 
@@ -513,7 +520,7 @@ export function buildDefaultMapeo(ctx: MemoriaContext): MapeoConfig {
       fila: g.fila,
       descripcion: g.nombre,
       escribirDescripcion: false,
-      gasto: cat ? { tipo: "categoria", categoriaId: cat.id } : null,
+      ...ambos(cat),
       enabled: true,
     })
   }
@@ -866,10 +873,14 @@ export async function generarSheet(
     if (fila.escribirDescripcion && fila.descripcion) {
       updates.push({ range: `C${fila.fila}`, values: [[fila.descripcion]] })
     }
-    if (fila.ingreso && typeof v.ingreso === "number") {
+    // Los ceros no se escriben: en el template la celda vacía ya vale 0 para
+    // las fórmulas y el documento queda más limpio (salvo los saldos del
+    // capítulo I, que se muestran siempre aunque sean 0).
+    const esSaldo = fila.capitulo === "I"
+    if (fila.ingreso && typeof v.ingreso === "number" && (esSaldo || Math.abs(v.ingreso) >= 0.005)) {
       updates.push({ range: `D${fila.fila}`, values: [[v.ingreso]] })
     }
-    if (fila.gasto && typeof v.gasto === "number") {
+    if (fila.gasto && typeof v.gasto === "number" && (esSaldo || Math.abs(v.gasto) >= 0.005)) {
       updates.push({ range: `E${fila.fila}`, values: [[v.gasto]] })
     }
   }

--- a/scripts/test-generar-memoria.ts
+++ b/scripts/test-generar-memoria.ts
@@ -92,6 +92,14 @@ async function main() {
   console.log("\n✅ ¡Generado!")
   console.log("   Título:", res.titulo)
   console.log("   Link:  ", res.webViewLink)
+  console.log("   Remanente anterior (F3):   ", res.remanente)
+  console.log("   Balance del ejercicio (F46):", res.balanceAnual)
+  console.log("   Disponible final (F49):    ", res.disponibleFinal)
+  console.log("   ¿Hoja = app?:", res.cuadraConHoja ? "sí ✓" : "NO ✗")
+  console.log(
+    "   ¿Cuadra con el saldo real?:",
+    res.resumen.cuadra ? "sí ✓" : `NO (descuadre ${res.resumen.descuadre.toFixed(2)} €)`,
+  )
 }
 
 main().catch((err) => {


### PR DESCRIPTION
El informe generado no cuadraba con los datos de la app por tres causas:

- La plantilla suma el capítulo I en D46, con lo que el "BALANCE (sin
  remanente)" F46 sí incluía el remanente y F49 (=F3+F46) lo contaba dos
  veces. Ahora se reescriben D46/E46 en la copia generada para sumar solo
  los capítulos II–VI: F46 = balance del ejercicio y F49 = remanente +
  balance = disponible real.
- El generador incluía movimientos de cuentas desactivadas que el
  dashboard excluye (join cuenta.activa=true). Ahora se filtran igual.
- Con año natural, la copia conservaba los textos del curso ("1
  septiembre", "BALANCE CURSO"). Ahora se escriben A3, C4, C5, C45 y C48
  según el tipo de periodo.

Además:

- Nueva validación del ejercicio (ResumenValidacion): remanente +
  entradas − salidas del informe frente al saldo real de las cuentas,
  con detección de movimientos no recogidos por ninguna fila y de
  importes contados dos veces (categoría madre + subcategoría).
- Panel "Cuadre del ejercicio" en el paso de revisión, con desglose del
  descuadre y actualización en vivo al editar filas.
- Stepper de pasos en el diálogo y pantalla final con remanente, balance
  y disponible leídos de la hoja + sello de cuadre.
- Fila "Donativo total realizado" (E39) del capítulo V ahora es mapeable
  y se limpia el placeholder XXXXXXXX de D39 al incluir el capítulo.
- Los capítulos IV/V/VI ya no muestran filas vacías desactivadas: solo
  las configuradas y el botón "Añadir fila".

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01P6Pw3PjxU6B69iGhiPoTky