### PR TITLE
feat(informes): conciliación de descuadres en la generación de memorias

### DIFF
--- a/app/api/informes/descuadres/route.ts
+++ b/app/api/informes/descuadres/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server"
+import { requireDelegationAccess } from "@/lib/services/informe-auth"
+import {
+  buildContext,
+  buildDefaultMapeo,
+  computeDescuadres,
+  type MapeoConfig,
+  type PeriodoTipo,
+} from "@/lib/services/memoria-economica"
+
+const MAX_MOVIMIENTOS = 300
+
+/**
+ * Movimientos del periodo que descuadran la memoria económica (sin categoría,
+ * de categorías sin fila en el informe, o contados en más de una fila).
+ */
+export async function POST(req: Request) {
+  let body: any
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: "JSON inválido" }, { status: 400 })
+  }
+
+  const delegacionId = body.delegacionId as string
+  const periodoTipo = (body.periodoTipo as PeriodoTipo) || "curso"
+  const anio = Number(body.anio)
+  const mapeoEntrada = (body.mapeo as MapeoConfig | undefined) ?? null
+
+  if (!anio) return NextResponse.json({ error: "Falta el año" }, { status: 400 })
+
+  const access = await requireDelegationAccess(delegacionId)
+  if (access.error) return access.error
+
+  try {
+    const ctx = await buildContext(access.supabase, delegacionId, periodoTipo, anio)
+    const mapeo = mapeoEntrada ?? buildDefaultMapeo(ctx)
+    const todos = computeDescuadres(ctx, mapeo)
+    return NextResponse.json({
+      movimientos: todos.slice(0, MAX_MOVIMIENTOS),
+      total: todos.length,
+      periodo: { inicio: ctx.rango.inicio, fin: ctx.rango.fin },
+    })
+  } catch (err: any) {
+    console.error("Error en descuadres de memoria:", err?.message || err)
+    return NextResponse.json(
+      { error: err?.message || "Error calculando los descuadres" },
+      { status: 500 },
+    )
+  }
+}

--- a/components/informes/generar/conciliacion-sheet.tsx
+++ b/components/informes/generar/conciliacion-sheet.tsx
@@ -1,0 +1,473 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { toast } from "sonner"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet"
+import { Button } from "@/components/ui/button"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { CategoriaPickerDialog } from "./categoria-picker-dialog"
+import { DatabaseService } from "@/lib/services/database"
+import { formatCurrency } from "@/lib/utils/format"
+import { cn } from "@/lib/utils"
+import type { Categoria } from "@/lib/types/database"
+import type {
+  Capitulo,
+  MapeoConfig,
+  MovimientoDescuadre,
+  PeriodoTipo,
+} from "@/lib/services/memoria-economica"
+import {
+  CheckCircle2,
+  Circle,
+  CopyX,
+  ExternalLink,
+  ListChecks,
+  Loader2,
+  PartyPopper,
+  Plus,
+  Tag,
+} from "lucide-react"
+
+interface Item extends MovimientoDescuadre {
+  arreglado: boolean
+}
+
+interface Props {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  delegacionId: string
+  periodoTipo: PeriodoTipo
+  anio: number
+  mapeo: MapeoConfig | null
+  categorias: Categoria[]
+  /** Capítulos del informe con filas libres para "Añadir al informe". */
+  capsConFilasLibres: Capitulo[]
+  /** Añade una fila con la categoría al capítulo. Devuelve false si no pudo. */
+  onAddCategoria: (cap: Capitulo, categoriaId: string) => boolean
+  /** El usuario ha cambiado datos (recategorizado): el diálogo debe recalcular. */
+  onDatosCambiados: () => void
+}
+
+const CAP_ADD_OPTIONS: { cap: Capitulo; label: string }[] = [
+  { cap: "IV", label: "Capítulo IV · Actividades" },
+  { cap: "V", label: "Capítulo V · Campañas solidarias" },
+  { cap: "VI", label: "Capítulo VI · Otros" },
+]
+
+function fechaCorta(iso: string): string {
+  const d = new Date(iso + "T00:00:00")
+  return new Intl.DateTimeFormat("es-ES", { day: "numeric", month: "short" }).format(d)
+}
+
+/** Último día del periodo (fin es exclusivo) para los filtros de Transacciones. */
+function diaAntes(iso: string): string {
+  const d = new Date(iso + "T00:00:00Z")
+  d.setUTCDate(d.getUTCDate() - 1)
+  return d.toISOString().slice(0, 10)
+}
+
+export function ConciliacionSheet({
+  open,
+  onOpenChange,
+  delegacionId,
+  periodoTipo,
+  anio,
+  mapeo,
+  categorias,
+  capsConFilasLibres,
+  onAddCategoria,
+  onDatosCambiados,
+}: Props) {
+  const [items, setItems] = useState<Item[]>([])
+  const [loading, setLoading] = useState(false)
+  const [fixingId, setFixingId] = useState<string | null>(null)
+  const [pickerItem, setPickerItem] = useState<Item | null>(null)
+  const [periodo, setPeriodo] = useState<{ inicio: string; fin: string } | null>(null)
+
+  const fetchSeq = useRef(0)
+
+  const refresh = useCallback(
+    async (opts: { reset?: boolean } = {}) => {
+      if (!mapeo) return
+      const seq = ++fetchSeq.current
+      if (opts.reset) {
+        setItems([])
+        setLoading(true)
+      }
+      try {
+        const res = await fetch("/api/informes/descuadres", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ delegacionId, periodoTipo, anio, mapeo }),
+        })
+        const data = await res.json()
+        if (!res.ok) throw new Error(data?.error || "Error cargando los descuadres")
+        if (seq !== fetchSeq.current) return
+        const nuevos = (data.movimientos ?? []) as MovimientoDescuadre[]
+        setPeriodo(data.periodo ?? null)
+        setItems((prev) => {
+          if (opts.reset || prev.length === 0) {
+            return nuevos.map((n) => ({ ...n, arreglado: false }))
+          }
+          // Conservar la lista original para poder "tachar": lo que ya no
+          // aparece está arreglado; lo que sigue se actualiza (p. ej. nueva
+          // categoría tras recategorizar); lo nuevo se añade al final.
+          const nuevoById = new Map(nuevos.map((n) => [n.id, n]))
+          const conocidos = new Set(prev.map((p) => p.id))
+          const conservados = prev.map((p) => {
+            const n = nuevoById.get(p.id)
+            return n ? { ...n, arreglado: false } : { ...p, arreglado: true }
+          })
+          const incorporados = nuevos
+            .filter((n) => !conocidos.has(n.id))
+            .map((n) => ({ ...n, arreglado: false }))
+          return [...conservados, ...incorporados]
+        })
+      } catch (err) {
+        if (seq !== fetchSeq.current) return
+        console.error(err)
+        toast.error(err instanceof Error ? err.message : "Error cargando los descuadres")
+      } finally {
+        if (seq === fetchSeq.current) setLoading(false)
+      }
+    },
+    [delegacionId, periodoTipo, anio, mapeo],
+  )
+
+  // Carga inicial al abrir; refresco (debounced) cuando cambia el mapeo
+  // (p. ej. tras "Añadir al informe") para tachar lo que ya quede recogido.
+  const openedRef = useRef(false)
+  useEffect(() => {
+    if (!open) {
+      openedRef.current = false
+      return
+    }
+    if (!openedRef.current) {
+      openedRef.current = true
+      refresh({ reset: true })
+      return
+    }
+    const t = setTimeout(() => refresh(), 400)
+    return () => clearTimeout(t)
+  }, [open, refresh])
+
+  const recategorizar = async (item: Item, categoriaId: string | null) => {
+    setFixingId(item.id)
+    try {
+      await DatabaseService.updateMovimientoCategoria(item.id, categoriaId)
+      toast.success("Movimiento recategorizado")
+      onDatosCambiados()
+      await refresh()
+    } catch (err) {
+      console.error(err)
+      toast.error("No se pudo recategorizar el movimiento")
+    } finally {
+      setFixingId(null)
+    }
+  }
+
+  const catNameById = useMemo(() => {
+    const m = new Map<string, string>()
+    for (const c of categorias) m.set(c.id, c.nombre)
+    return m
+  }, [categorias])
+
+  // Agrupar: categorías sin fila (por categoría, mayor importe primero),
+  // luego sin categoría, luego dobles.
+  const grupos = useMemo(() => {
+    const porCategoria = new Map<string, Item[]>()
+    const sinCategoria: Item[] = []
+    const dobles: Item[] = []
+    for (const it of items) {
+      if (it.motivo === "doble_contado") dobles.push(it)
+      else if (it.motivo === "sin_categoria") sinCategoria.push(it)
+      else {
+        const arr = porCategoria.get(it.categoriaId!) ?? []
+        arr.push(it)
+        porCategoria.set(it.categoriaId!, arr)
+      }
+    }
+    const cats = [...porCategoria.entries()]
+      .map(([categoriaId, lista]) => ({
+        categoriaId,
+        nombre: lista[0].categoriaNombre ?? catNameById.get(categoriaId) ?? "Categoría",
+        items: lista,
+        pendiente: lista.reduce((s, i) => s + (i.arreglado ? 0 : Math.abs(i.importe)), 0),
+      }))
+      .sort((a, b) => b.pendiente - a.pendiente)
+    return { cats, sinCategoria, dobles }
+  }, [items, catNameById])
+
+  const total = items.length
+  const arreglados = items.filter((i) => i.arreglado).length
+  const todoConciliado = total > 0 && arreglados === total
+
+  const desde = periodo?.inicio
+  const hasta = periodo ? diaAntes(periodo.fin) : undefined
+  const rangoQS = desde && hasta ? `&desde=${desde}&hasta=${hasta}` : ""
+
+  const renderItem = (item: Item) => {
+    const arreglando = fixingId === item.id
+    const puedeRecategorizar = !item.arreglado && item.motivo !== "doble_contado"
+    return (
+      <div
+        key={item.id}
+        className={cn(
+          "flex items-center gap-2.5 rounded-lg border bg-background px-2.5 py-2 transition-all duration-300",
+          item.arreglado && "border-emerald-200 bg-emerald-50/40 opacity-70 dark:border-emerald-900 dark:bg-emerald-900/10",
+        )}
+      >
+        {item.arreglado ? (
+          <CheckCircle2 className="h-4 w-4 shrink-0 text-emerald-500" />
+        ) : arreglando ? (
+          <Loader2 className="h-4 w-4 shrink-0 animate-spin text-muted-foreground" />
+        ) : (
+          <Circle className="h-4 w-4 shrink-0 text-muted-foreground/40" />
+        )}
+        <div className="min-w-0 flex-1">
+          <p
+            className={cn(
+              "truncate text-sm",
+              item.arreglado && "text-muted-foreground line-through decoration-emerald-500/60",
+            )}
+            title={item.concepto}
+          >
+            {item.concepto || "(sin concepto)"}
+          </p>
+          <p className="text-[11px] text-muted-foreground">
+            {fechaCorta(item.fecha)}
+            {item.motivo === "doble_contado" && ` · contado ${item.veces} veces`}
+          </p>
+        </div>
+        <span
+          className={cn(
+            "shrink-0 text-sm font-semibold tabular-nums",
+            item.importe >= 0 ? "text-emerald-600" : "text-red-500",
+            item.arreglado && "line-through opacity-60",
+          )}
+        >
+          {formatCurrency(item.importe)}
+        </span>
+        {puedeRecategorizar && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-8 w-8 shrink-0 p-0 text-muted-foreground hover:text-foreground"
+            title="Recategorizar este movimiento"
+            disabled={arreglando}
+            onClick={() => setPickerItem(item)}
+          >
+            <Tag className="h-4 w-4" />
+          </Button>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <Sheet open={open} onOpenChange={onOpenChange}>
+        <SheetContent side="right" className="flex w-full flex-col gap-0 p-0 sm:max-w-md">
+          <SheetHeader className="space-y-1 border-b p-4 pr-12 text-left">
+            <SheetTitle className="flex items-center gap-2 text-base">
+              <ListChecks className="h-5 w-5 text-primary" /> Conciliar movimientos
+            </SheetTitle>
+            <SheetDescription>
+              Movimientos del periodo que el informe no recoge (o cuenta dos veces). Arréglalos y
+              se irán tachando.
+            </SheetDescription>
+            {total > 0 && (
+              <div className="pt-1.5">
+                <div className="flex items-center justify-between text-xs">
+                  <span className="font-medium">
+                    {arreglados}/{total} conciliados
+                  </span>
+                  {loading && <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />}
+                </div>
+                <div className="mt-1 h-1.5 overflow-hidden rounded-full bg-muted">
+                  <div
+                    className="h-full rounded-full bg-emerald-500 transition-all duration-500"
+                    style={{ width: `${total ? (arreglados / total) * 100 : 0}%` }}
+                  />
+                </div>
+              </div>
+            )}
+          </SheetHeader>
+
+          <div className="min-h-0 flex-1 space-y-4 overflow-y-auto p-4">
+            {loading && items.length === 0 ? (
+              <div className="flex items-center justify-center gap-2 py-10 text-sm text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" /> Buscando descuadres…
+              </div>
+            ) : total === 0 ? (
+              <div className="flex flex-col items-center gap-2 py-10 text-center">
+                <CheckCircle2 className="h-8 w-8 text-emerald-500" />
+                <p className="text-sm font-medium">No hay nada que conciliar</p>
+                <p className="text-xs text-muted-foreground">
+                  Todos los movimientos del periodo están recogidos en el informe.
+                </p>
+              </div>
+            ) : (
+              <>
+                {todoConciliado && (
+                  <div className="flex items-center gap-2.5 rounded-xl border border-emerald-300 bg-emerald-50 p-3 text-sm font-medium text-emerald-700 dark:border-emerald-800 dark:bg-emerald-900/20 dark:text-emerald-300">
+                    <PartyPopper className="h-5 w-5 shrink-0" />
+                    ¡Todo conciliado! El informe ya recoge todos los movimientos.
+                  </div>
+                )}
+
+                {/* 1. Categorías que no están en el informe */}
+                {grupos.cats.map((g) => (
+                  <div key={g.categoriaId} className="space-y-1.5">
+                    <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                      <p className="min-w-0 flex-1 truncate text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                        {g.nombre}
+                        <span className="ml-1.5 font-normal normal-case">
+                          · sin fila en el informe
+                        </span>
+                      </p>
+                      <div className="flex shrink-0 items-center gap-1">
+                        <Popover>
+                          <PopoverTrigger asChild>
+                            <Button
+                              type="button"
+                              variant="outline"
+                              size="sm"
+                              className="h-7 gap-1 px-2 text-xs"
+                              disabled={
+                                g.items.every((i) => i.arreglado) || capsConFilasLibres.length === 0
+                              }
+                            >
+                              <Plus className="h-3.5 w-3.5" /> Añadir al informe
+                            </Button>
+                          </PopoverTrigger>
+                          <PopoverContent align="end" className="w-64 p-1.5">
+                            <p className="px-2 py-1.5 text-xs text-muted-foreground">
+                              Crear una fila con «{g.nombre}» en:
+                            </p>
+                            {CAP_ADD_OPTIONS.map((o) => (
+                              <Button
+                                key={o.cap}
+                                type="button"
+                                variant="ghost"
+                                size="sm"
+                                className="w-full justify-start text-xs"
+                                disabled={!capsConFilasLibres.includes(o.cap)}
+                                onClick={() => {
+                                  if (onAddCategoria(o.cap, g.categoriaId)) {
+                                    toast.success(`«${g.nombre}» añadida al capítulo ${o.cap}`)
+                                  }
+                                }}
+                              >
+                                {o.label}
+                                {!capsConFilasLibres.includes(o.cap) && (
+                                  <span className="ml-auto text-[10px] text-muted-foreground">
+                                    sin filas libres
+                                  </span>
+                                )}
+                              </Button>
+                            ))}
+                          </PopoverContent>
+                        </Popover>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          className="h-7 w-7 p-0 text-muted-foreground"
+                          title="Ver en Transacciones (nueva pestaña)"
+                          asChild
+                        >
+                          <a
+                            href={`/transacciones?categorias=${g.categoriaId}${rangoQS}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            <ExternalLink className="h-3.5 w-3.5" />
+                          </a>
+                        </Button>
+                      </div>
+                    </div>
+                    <div className="space-y-1.5">{g.items.map(renderItem)}</div>
+                  </div>
+                ))}
+
+                {/* 2. Sin categoría */}
+                {grupos.sinCategoria.length > 0 && (
+                  <div className="space-y-1.5">
+                    <div className="flex items-center gap-2">
+                      <p className="min-w-0 flex-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                        Sin categoría
+                        <span className="ml-1.5 font-normal normal-case">
+                          · etiquétalos para que entren
+                        </span>
+                      </p>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="h-7 w-7 shrink-0 p-0 text-muted-foreground"
+                        title="Ver en Transacciones (nueva pestaña)"
+                        asChild
+                      >
+                        <a
+                          href={`/transacciones?uncategorized=1${rangoQS}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          <ExternalLink className="h-3.5 w-3.5" />
+                        </a>
+                      </Button>
+                    </div>
+                    <div className="space-y-1.5">{grupos.sinCategoria.map(renderItem)}</div>
+                  </div>
+                )}
+
+                {/* 3. Contados dos veces */}
+                {grupos.dobles.length > 0 && (
+                  <div className="space-y-1.5">
+                    <p className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      <CopyX className="h-3.5 w-3.5" /> Contados más de una vez
+                    </p>
+                    <p className="text-[11px] text-muted-foreground">
+                      Una categoría madre y su subcategoría están en filas distintas del informe.
+                      Quita una de las dos filas en el paso de revisión.
+                    </p>
+                    <div className="space-y-1.5">{grupos.dobles.map(renderItem)}</div>
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+
+          <div className="border-t p-3">
+            <Button type="button" variant="outline" className="w-full" onClick={() => onOpenChange(false)}>
+              Volver al informe
+            </Button>
+          </div>
+        </SheetContent>
+      </Sheet>
+
+      <CategoriaPickerDialog
+        open={!!pickerItem}
+        onOpenChange={(o) => {
+          if (!o) setPickerItem(null)
+        }}
+        categories={categorias}
+        selectedId={pickerItem?.categoriaId ?? null}
+        disabledIds={[]}
+        onSelect={(id) => {
+          if (pickerItem) recategorizar(pickerItem, id)
+        }}
+        title="Recategorizar movimiento"
+        subtitle={pickerItem ? `${pickerItem.concepto} · ${formatCurrency(pickerItem.importe)}` : undefined}
+      />
+    </>
+  )
+}

--- a/components/informes/generar/generar-informe-dialog.tsx
+++ b/components/informes/generar/generar-informe-dialog.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/select"
 import { InformesService } from "@/lib/services/informes"
 import { CategoriaPickerDialog } from "./categoria-picker-dialog"
+import { ConciliacionSheet } from "./conciliacion-sheet"
 import { useCategorias } from "@/hooks/use-categorias"
 import { getCategoryColorTokens } from "@/lib/utils/category-colors"
 import { formatCurrency } from "@/lib/utils/format"
@@ -54,6 +55,7 @@ import {
   Check,
   Scale,
   ChevronDown,
+  ListChecks,
   type LucideIcon,
 } from "lucide-react"
 
@@ -110,7 +112,7 @@ const STEPS = [
 function Stepper({ step }: { step: (typeof STEPS)[number]["key"] }) {
   const idx = STEPS.findIndex((s) => s.key === step)
   return (
-    <div className="flex items-center gap-1.5 pt-1">
+    <div className="flex flex-wrap items-center gap-1.5 pt-1">
       {STEPS.map((s, i) => {
         const done = i < idx
         const current = i === idx
@@ -147,7 +149,15 @@ function Stepper({ step }: { step: (typeof STEPS)[number]["key"] }) {
 
 // ---------- Panel de validación (cuadre del ejercicio) ----------
 
-function ValidacionPanel({ resumen, finLabel }: { resumen: ResumenValidacion; finLabel: string }) {
+function ValidacionPanel({
+  resumen,
+  finLabel,
+  onConciliar,
+}: {
+  resumen: ResumenValidacion
+  finLabel: string
+  onConciliar: () => void
+}) {
   const [detalle, setDetalle] = useState(false)
   const r = resumen
   const remananteDistinto = Math.abs(r.remanenteInforme - r.remanenteReal) >= 0.005
@@ -230,6 +240,14 @@ function ValidacionPanel({ resumen, finLabel }: { resumen: ResumenValidacion; fi
               ¿Por qué? <ChevronDown className={cn("h-3 w-3 transition-transform", detalle && "rotate-180")} />
             </button>
           </p>
+          <Button
+            type="button"
+            size="sm"
+            onClick={onConciliar}
+            className="h-8 w-full gap-1.5 bg-amber-600 text-white hover:bg-amber-700 sm:w-auto"
+          >
+            <ListChecks className="h-4 w-4" /> Conciliar movimientos
+          </Button>
           {detalle && (
             <ul className="space-y-1 rounded-md bg-background/70 p-2.5 text-xs text-muted-foreground">
               {hayNoRecogido && (
@@ -334,6 +352,7 @@ export function GenerarInformeDialog({
     cuadraConHoja: boolean
   } | null>(null)
   const [pickerFila, setPickerFila] = useState<MapeoFila | null>(null)
+  const [conciliarOpen, setConciliarOpen] = useState(false)
 
   const informeId = initialInforme?.id ?? null
 
@@ -464,6 +483,49 @@ export function GenerarInformeDialog({
   const filasLibres = (cap: Capitulo) =>
     (mapeo?.filas ?? []).some((f) => f.capitulo === cap && !f.enabled && f.fila !== FILA_DONATIVO)
 
+  const capsConFilasLibres = useMemo(() => {
+    const caps: Capitulo[] = []
+    for (const cap of ["IV", "V", "VI"] as Capitulo[]) {
+      if ((mapeo?.filas ?? []).some((f) => f.capitulo === cap && !f.enabled && f.fila !== FILA_DONATIVO)) {
+        caps.push(cap)
+      }
+    }
+    return caps
+  }, [mapeo])
+
+  /** Añade una fila con la categoría al capítulo (desde la conciliación). */
+  const addCategoriaAlInforme = (cap: Capitulo, categoriaId: string): boolean => {
+    if (!mapeo) return false
+    const libre = mapeo.filas.find(
+      (f) => f.capitulo === cap && !f.enabled && f.fila !== FILA_DONATIVO,
+    )
+    if (!libre) {
+      toast.error("No quedan filas libres en ese capítulo")
+      return false
+    }
+    const fuente: Fuente = { tipo: "categoria", categoriaId }
+    const nombre = catNameById.get(categoriaId) ?? ""
+    const next: MapeoConfig = {
+      ...mapeo,
+      filas: mapeo.filas.map((f) =>
+        f.id === libre.id
+          ? {
+              ...f,
+              enabled: true,
+              ingreso: fuente,
+              gasto: fuente,
+              ...(f.escribirDescripcion ? { descripcion: nombre } : {}),
+            }
+          : f,
+      ),
+      // Si el capítulo estaba excluido, se incluye (solo con esta fila activa).
+      capitulosExcluidos: (mapeo.capitulosExcluidos ?? []).filter((c) => c !== cap),
+    }
+    setMapeo(next)
+    recompute(next)
+    return true
+  }
+
   const handleGenerar = async () => {
     if (!google.connected) {
       toast.error("Conecta tu cuenta de Google primero")
@@ -570,7 +632,10 @@ export function GenerarInformeDialog({
     <>
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
-        className={cn("max-w-4xl", step === "mapeo" && "flex h-[95vh] flex-col gap-3")}
+        className={cn(
+          "max-w-4xl overflow-x-hidden",
+          step === "mapeo" && "flex h-[92dvh] flex-col gap-3 sm:h-[95vh]",
+        )}
       >
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
@@ -588,7 +653,7 @@ export function GenerarInformeDialog({
         {/* PASO 1 — CONFIG */}
         {step === "config" && (
           <div className="space-y-5 py-2">
-            <div className="grid grid-cols-2 gap-3">
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
               <div className="space-y-1.5">
                 <Label className="text-xs">Tipo de periodo</Label>
                 <Select value={periodoTipo} onValueChange={(v) => setPeriodoTipo(v as PeriodoTipo)}>
@@ -620,17 +685,17 @@ export function GenerarInformeDialog({
 
             {/* Conexión Google */}
             <div className="rounded-lg border p-4">
-              <div className="flex items-center justify-between gap-3">
-                <div className="flex items-center gap-3">
-                  <div className="rounded-lg bg-muted p-2">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div className="flex min-w-0 flex-1 items-center gap-3">
+                  <div className="shrink-0 rounded-lg bg-muted p-2">
                     <FileSpreadsheet className="h-5 w-5 text-emerald-600" />
                   </div>
-                  <div>
+                  <div className="min-w-0">
                     <p className="text-sm font-medium">Google Drive</p>
                     {google.loading ? (
                       <p className="text-xs text-muted-foreground">Comprobando…</p>
                     ) : google.connected ? (
-                      <p className="text-xs text-emerald-600">
+                      <p className="break-all text-xs text-emerald-600">
                         Conectado{google.email ? ` · ${google.email}` : ""}
                       </p>
                     ) : (
@@ -642,14 +707,14 @@ export function GenerarInformeDialog({
                 </div>
                 {!google.loading &&
                   (google.connected ? (
-                    <div className="flex items-center gap-2">
+                    <div className="flex shrink-0 items-center gap-2">
                       <Button variant="ghost" size="sm" asChild>
                         <a href="/api/google/connect?switch=1">Cambiar cuenta</a>
                       </Button>
                       <CheckCircle2 className="h-5 w-5 shrink-0 text-emerald-600" />
                     </div>
                   ) : (
-                    <Button variant="outline" size="sm" asChild>
+                    <Button variant="outline" size="sm" className="shrink-0" asChild>
                       <a href="/api/google/connect">Conectar Google</a>
                     </Button>
                   ))}
@@ -658,7 +723,7 @@ export function GenerarInformeDialog({
               {google.connected && (
                 <div className="mt-3 flex items-start gap-2 rounded-md bg-muted/50 px-3 py-2 text-xs text-muted-foreground">
                   <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-                  <span>
+                  <span className="min-w-0 break-words">
                     Se generará un archivo de Google Sheets en la carpeta{" "}
                     <span className="font-medium text-foreground">«Mi unidad»</span> de esta cuenta
                     {google.email ? ` (${google.email})` : ""} y luego tendrás que moverlo a su sitio.
@@ -858,13 +923,19 @@ export function GenerarInformeDialog({
               })}
             </div>
 
-            {preview.resumen && <ValidacionPanel resumen={preview.resumen} finLabel={finLabel} />}
+            {preview.resumen && (
+              <ValidacionPanel
+                resumen={preview.resumen}
+                finLabel={finLabel}
+                onConciliar={() => setConciliarOpen(true)}
+              />
+            )}
 
-            <div className="flex items-center justify-between border-t pt-3">
+            <div className="flex flex-wrap items-center justify-between gap-2 border-t pt-3">
               <Button variant="ghost" onClick={() => setStep("config")}>
                 <ChevronLeft className="mr-1 h-4 w-4" /> Atrás
               </Button>
-              <div className="flex gap-2">
+              <div className="flex flex-wrap gap-2">
                 <Button variant="outline" onClick={handleGuardarBorrador} disabled={savingDraft}>
                   {savingDraft ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Save className="mr-2 h-4 w-4" />}
                   Guardar borrador
@@ -997,6 +1068,21 @@ export function GenerarInformeDialog({
         if (pickerFila) setCategoria(pickerFila, id, id ? catNameById.get(id) : undefined)
       }}
       subtitle={pickerFila ? CAP_LABEL[pickerFila.capitulo] : undefined}
+    />
+
+    <ConciliacionSheet
+      open={conciliarOpen}
+      onOpenChange={setConciliarOpen}
+      delegacionId={delegacionId}
+      periodoTipo={periodoTipo}
+      anio={anio}
+      mapeo={mapeo}
+      categorias={dbCategorias}
+      capsConFilasLibres={capsConFilasLibres}
+      onAddCategoria={addCategoriaAlInforme}
+      onDatosCambiados={() => {
+        if (mapeo) fetchPreview(mapeo, { recompute: true })
+      }}
     />
     </>
   )

--- a/components/transactions/transaction-manager.tsx
+++ b/components/transactions/transaction-manager.tsx
@@ -535,6 +535,17 @@ export function TransactionManager() {
       }
     }
 
+    // Rango de fechas por URL (p. ej. desde la conciliación de informes)
+    const desde = searchParams.get("desde")
+    const hasta = searchParams.get("hasta")
+    if (desde || hasta) {
+      setFilters((prev) => ({
+        ...prev,
+        dateFrom: desde ?? prev.dateFrom,
+        dateTo: hasta ?? prev.dateTo,
+      }))
+    }
+
     const movId = searchParams.get("mov")
     if (movId) {
       const found = movements.find((m) => m.id === movId)

--- a/lib/services/memoria-economica.ts
+++ b/lib/services/memoria-economica.ts
@@ -171,8 +171,10 @@ interface CategoriaRow {
   categoria_padre_id: string | null
 }
 interface MovRow {
+  id: string
   cuenta_id: string | null
   fecha: string
+  concepto: string
   importe: number
   categoria_id: string | null
 }
@@ -197,7 +199,7 @@ async function fetchAllMovimientos(supabase: any, delegacionId: string, finISO: 
   for (;;) {
     const { data, error } = await supabase
       .from("movimiento")
-      .select("cuenta_id, fecha, importe, categoria_id, ignorado")
+      .select("id, cuenta_id, fecha, concepto, importe, categoria_id, ignorado")
       .eq("delegacion_id", delegacionId)
       .lt("fecha", finISO)
       .range(from, from + pageSize - 1)
@@ -205,8 +207,10 @@ async function fetchAllMovimientos(supabase: any, delegacionId: string, finISO: 
     const rows = (data || []).filter((r: any) => !r.ignorado)
     for (const r of rows) {
       all.push({
+        id: r.id,
         cuenta_id: r.cuenta_id,
         fecha: r.fecha,
+        concepto: r.concepto || "",
         importe: Number(r.importe) || 0,
         categoria_id: r.categoria_id,
       })
@@ -630,6 +634,73 @@ export function computeValores(ctx: MemoriaContext, mapeo: MapeoConfig): {
 }
 
 /**
+ * Cuántas filas activas del informe recogen cada categoría (con descendientes),
+ * por columna. Un movimiento del periodo queda recogido si su categoría aparece
+ * en el mapa de su signo: >0 en ingresoCount para importes positivos, etc.
+ */
+function buildCaptureCounts(ctx: MemoriaContext, mapeo: MapeoConfig) {
+  const excluidos = new Set<Capitulo>(mapeo.capitulosExcluidos ?? [])
+  const ingresoCount = new Map<string, number>()
+  const gastoCount = new Map<string, number>()
+  for (const f of mapeo.filas) {
+    if (!f.enabled || excluidos.has(f.capitulo) || f.capitulo === "I") continue
+    if (f.ingreso?.tipo === "categoria") {
+      for (const id of descendantIds(ctx, f.ingreso.categoriaId)) {
+        ingresoCount.set(id, (ingresoCount.get(id) ?? 0) + 1)
+      }
+    }
+    if (f.gasto?.tipo === "categoria") {
+      for (const id of descendantIds(ctx, f.gasto.categoriaId)) {
+        gastoCount.set(id, (gastoCount.get(id) ?? 0) + 1)
+      }
+    }
+  }
+  return { ingresoCount, gastoCount }
+}
+
+export type DescuadreMotivo = "sin_categoria" | "categoria_sin_fila" | "doble_contado"
+
+export interface MovimientoDescuadre {
+  id: string
+  fecha: string
+  concepto: string
+  importe: number
+  categoriaId: string | null
+  categoriaNombre: string | null
+  motivo: DescuadreMotivo
+  /** Nº de filas del informe que lo cuentan (>1 solo en doble_contado). */
+  veces: number
+}
+
+/**
+ * Lista los movimientos del periodo que descuadran el informe: sin categoría,
+ * con categoría que ninguna fila recoge, o contados en más de una fila.
+ * Ordenados por importe absoluto descendente (primero lo gordo).
+ */
+export function computeDescuadres(ctx: MemoriaContext, mapeo: MapeoConfig): MovimientoDescuadre[] {
+  const { ingresoCount, gastoCount } = buildCaptureCounts(ctx, mapeo)
+  const out: MovimientoDescuadre[] = []
+  for (const m of ctx.movs) {
+    if (!enPeriodo(ctx, m.fecha)) continue
+    const counts = m.importe >= 0 ? ingresoCount : gastoCount
+    const veces = m.categoria_id ? counts.get(m.categoria_id) ?? 0 : 0
+    if (veces === 1) continue
+    out.push({
+      id: m.id,
+      fecha: m.fecha,
+      concepto: m.concepto,
+      importe: m.importe,
+      categoriaId: m.categoria_id,
+      categoriaNombre: m.categoria_id ? ctx.catById.get(m.categoria_id)?.nombre ?? null : null,
+      motivo: !m.categoria_id ? "sin_categoria" : veces === 0 ? "categoria_sin_fila" : "doble_contado",
+      veces,
+    })
+  }
+  out.sort((a, b) => Math.abs(b.importe) - Math.abs(a.importe))
+  return out
+}
+
+/**
  * Valida el ejercicio: remanente + entradas − salidas del informe frente al
  * dinero real de las cuentas. También detecta movimientos que ninguna fila
  * recoge y los contados dos veces (madre + subcategoría en filas distintas).
@@ -654,12 +725,10 @@ export function computeResumen(
     else realGastos += -m.importe
   }
 
-  // Totales del informe + cuántas filas recogen cada categoría (por columna)
+  // Totales del informe
   let remanenteInforme = 0
   let informeIngresos = 0
   let informeGastos = 0
-  const ingresoCount = new Map<string, number>()
-  const gastoCount = new Map<string, number>()
   for (const f of mapeo.filas) {
     if (!activa(f)) continue
     const v = valores[f.id] || {}
@@ -669,17 +738,9 @@ export function computeResumen(
     }
     informeIngresos += v.ingreso ?? 0
     informeGastos += v.gasto ?? 0
-    if (f.ingreso?.tipo === "categoria") {
-      for (const id of descendantIds(ctx, f.ingreso.categoriaId)) {
-        ingresoCount.set(id, (ingresoCount.get(id) ?? 0) + 1)
-      }
-    }
-    if (f.gasto?.tipo === "categoria") {
-      for (const id of descendantIds(ctx, f.gasto.categoriaId)) {
-        gastoCount.set(id, (gastoCount.get(id) ?? 0) + 1)
-      }
-    }
   }
+
+  const { ingresoCount, gastoCount } = buildCaptureCounts(ctx, mapeo)
 
   let noRecogidoIngresos = 0
   let noRecogidoGastos = 0


### PR DESCRIPTION
## Summary
- Nuevo flujo de conciliación desde el panel de cuadre del asistente de memorias: botón "Conciliar movimientos" que abre un sidebar con los movimientos del periodo que descuadran el informe (categoría sin fila, sin categoría, o contados dos veces), agrupados y ordenados por importe.
- Cada movimiento se puede recategorizar inline (selector de categorías) o, para categorías sin fila, añadir directamente al capítulo IV/V/VI del informe con un clic — se tacha con check verde al arreglarse, con barra de progreso y celebración al conciliar todo.
- Enlaces directos a Transacciones filtrados por categoría/periodo o por "sin categorizar", usando nuevo soporte de `?desde=&hasta=` en la pantalla de transacciones.
- Nuevo endpoint `POST /api/informes/descuadres` y `computeDescuadres()` en el motor de memorias (reutiliza los contadores de cobertura ya existentes, extraídos a `buildCaptureCounts`).
- Arreglos de desbordamiento horizontal del modal en móvil (email de Google, tarjeta de conexión, selects de periodo, stepper y pie de botones ahora envuelven en pantallas estrechas; altura del paso de revisión en `dvh`).

Nota: los commits `cf4b07c` y `e056fb9` (cuadre real F46/F49, cuentas activas, textos por periodo, ambos lados D/E) ya están mergeados en `main` vía #155; esta PR solo añade el commit de conciliación que quedó pendiente.

## Test plan
- [x] `pnpm lint` limpio en los archivos tocados
- [x] `npx tsc --noEmit` sin nuevos errores (el único preexistente es ajeno a este cambio)
- [x] `pnpm build` compila (los fallos de prerender son por falta de `.env.local` en este entorno, preexistentes)
- [x] Simulación con datos reales de MCM Madrid: `computeDescuadres` detecta correctamente el movimiento mal categorizado que impedía el cuadre
- [ ] Probar el flujo completo en el navegador: abrir "Generar memoria", forzar un descuadre, recategorizar desde el sidebar y comprobar que se tacha y el cuadre se recalcula


---
_Generated by [Claude Code](https://claude.ai/code/session_01P6Pw3PjxU6B69iGhiPoTky)_