### PR TITLE
Add MoneyInput component for formatted currency input

### DIFF
--- a/components/informes/subir-informe-sheet.tsx
+++ b/components/informes/subir-informe-sheet.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import { MoneyInput, formatMoney, parseMoney } from "@/components/ui/money-input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 import {
@@ -103,8 +104,8 @@ export function SubirInformeSheet({
       setTituloTouched(true)
       setEstado(informe.estado as InformeEstado)
       setNotas(informe.notas ?? "")
-      setBalanceAnual(informe.balance_anual != null ? String(informe.balance_anual) : "")
-      setDisponibleFinal(informe.disponible_final != null ? String(informe.disponible_final) : "")
+      setBalanceAnual(formatMoney(informe.balance_anual))
+      setDisponibleFinal(formatMoney(informe.disponible_final))
     } else {
       setPeriodo({ periodicidad: "anual", periodo_tipo: "curso", anio: currentYear, sub_periodo: null })
       setTitulo("")
@@ -150,14 +151,6 @@ export function SubirInformeSheet({
   })
 
   const removeFile = (idx: number) => setFiles((prev) => prev.filter((_, i) => i !== idx))
-
-  /** "1.234,56" / "1234.56" / "" -> number | null */
-  const parseMoney = (raw: string): number | null => {
-    const s = raw.trim().replace(/\s|€/g, "").replace(/\./g, "").replace(",", ".")
-    if (!s) return null
-    const n = Number(s)
-    return Number.isFinite(n) ? n : null
-  }
 
   const doSave = async (driveMode: "keep" | "replace") => {
     setSaving(true)
@@ -281,11 +274,10 @@ export function SubirInformeSheet({
             <div className="space-y-1.5">
               <Label className="text-xs">Balance anual (opcional)</Label>
               <div className="relative">
-                <Input
+                <MoneyInput
                   value={balanceAnual}
-                  onChange={(e) => setBalanceAnual(e.target.value)}
+                  onValueChange={setBalanceAnual}
                   placeholder="0,00"
-                  inputMode="decimal"
                   className="pr-7"
                 />
                 <span className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">
@@ -296,11 +288,10 @@ export function SubirInformeSheet({
             <div className="space-y-1.5">
               <Label className="text-xs">Disponible final de año (opcional)</Label>
               <div className="relative">
-                <Input
+                <MoneyInput
                   value={disponibleFinal}
-                  onChange={(e) => setDisponibleFinal(e.target.value)}
+                  onValueChange={setDisponibleFinal}
                   placeholder="0,00"
-                  inputMode="decimal"
                   className="pr-7"
                 />
                 <span className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">

--- a/components/ui/money-input.tsx
+++ b/components/ui/money-input.tsx
@@ -1,0 +1,139 @@
+"use client"
+
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+/**
+ * Normaliza texto pegado/escrito de forma arbitraria a dígitos + como mucho
+ * una coma decimal. Si hay coma, los puntos se tratan como separador de
+ * miles (se eliminan). Si no hay coma pero hay un único punto seguido de 1-2
+ * dígitos, se interpreta como decimal (formato inglés) y se convierte a coma;
+ * cualquier otro punto se trata como separador de miles.
+ */
+function normalizeRaw(raw: string): string {
+  let s = raw.replace(/[^\d.,]/g, "")
+
+  if (s.includes(",")) {
+    s = s.replace(/\./g, "")
+    const firstComma = s.indexOf(",")
+    s = s.slice(0, firstComma + 1) + s.slice(firstComma + 1).replace(/,/g, "")
+  } else {
+    const dotCount = (s.match(/\./g) || []).length
+    if (dotCount === 1) {
+      const idx = s.indexOf(".")
+      const trailing = s.length - idx - 1
+      s = trailing <= 2 ? `${s.slice(0, idx)},${s.slice(idx + 1)}` : s.replace(/\./g, "")
+    } else if (dotCount > 1) {
+      s = s.replace(/\./g, "")
+    }
+  }
+
+  return s
+}
+
+/** Aplica separador de miles y limita los decimales a 2 dígitos. */
+function formatDisplay(normalized: string): string {
+  const [intRaw, decRaw] = normalized.split(",")
+  const intPart = (intRaw ?? "").replace(/^0+(?=\d)/, "")
+  const grouped = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, ".")
+  if (decRaw === undefined) return grouped
+  return `${grouped},${decRaw.slice(0, 2)}`
+}
+
+function countDigits(s: string, upTo: number): number {
+  let n = 0
+  for (let i = 0; i < upTo && i < s.length; i++) {
+    if (/\d/.test(s[i])) n++
+  }
+  return n
+}
+
+function positionAfterDigits(s: string, digitCount: number): number {
+  if (digitCount <= 0) return 0
+  let n = 0
+  for (let i = 0; i < s.length; i++) {
+    if (/\d/.test(s[i])) {
+      n++
+      if (n === digitCount) return i + 1
+    }
+  }
+  return s.length
+}
+
+/** "1.234,56" / "1234.56" / "1234,5" / "" -> number | null */
+export function parseMoney(raw: string): number | null {
+  const normalized = normalizeRaw(raw)
+  if (!normalized) return null
+  const s = normalized.replace(",", ".")
+  const n = Number(s)
+  return Number.isFinite(n) ? n : null
+}
+
+export function formatMoney(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) return ""
+  return value.toLocaleString("es-ES", { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+}
+
+interface MoneyInputProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "value" | "onChange" | "type"> {
+  /** Valor formateado en texto, p.ej. "3.048,22". Controlado por el padre. */
+  value: string
+  onValueChange: (display: string) => void
+}
+
+/**
+ * Input de importe con formato en vivo estilo español: separador de miles
+ * "." y decimales con ",". Pegar "3.048,22", "3048.22" o "3048,22" produce
+ * siempre el mismo resultado formateado, y el punto de miles se añade
+ * automáticamente mientras se escribe.
+ */
+export const MoneyInput = React.forwardRef<HTMLInputElement, MoneyInputProps>(
+  ({ value, onValueChange, className, onBlur, ...props }, ref) => {
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      const el = e.target
+      const rawBefore = el.value
+      const cursor = el.selectionStart ?? rawBefore.length
+      const digitsBeforeCursor = countDigits(rawBefore, cursor)
+
+      const normalized = normalizeRaw(rawBefore)
+      const formatted = formatDisplay(normalized)
+
+      onValueChange(formatted)
+
+      requestAnimationFrame(() => {
+        const pos = positionAfterDigits(formatted, digitsBeforeCursor)
+        el.setSelectionRange(pos, pos)
+      })
+    }
+
+    const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+      const normalized = normalizeRaw(e.target.value)
+      if (normalized) {
+        const [intRaw, decRaw] = normalized.split(",")
+        const intPart = (intRaw ?? "0").replace(/^0+(?=\d)/, "") || "0"
+        const decPart = (decRaw ?? "").padEnd(2, "0").slice(0, 2)
+        const grouped = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, ".")
+        onValueChange(`${grouped},${decPart}`)
+      }
+      onBlur?.(e)
+    }
+
+    return (
+      <input
+        ref={ref}
+        type="text"
+        inputMode="decimal"
+        autoComplete="off"
+        value={value}
+        onChange={handleChange}
+        onBlur={handleBlur}
+        className={cn(
+          "flex h-11 w-full rounded-xl border-2 border-input bg-card/60 backdrop-blur-md px-4 py-2.5 text-base ring-offset-background placeholder:text-muted-foreground/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:border-primary/50 focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm transition-[color,border-color,box-shadow] duration-200 shadow-sm focus-visible:shadow-md tabular-nums",
+          className
+        )}
+        {...props}
+      />
+    )
+  }
+)
+MoneyInput.displayName = "MoneyInput"


### PR DESCRIPTION
## Summary
Introduces a new `MoneyInput` component for handling currency input with live formatting in Spanish locale (thousands separator "." and decimal separator ","). This component intelligently normalizes various input formats and maintains cursor position during formatting.

## Key Changes
- **New component**: `components/ui/money-input.tsx`
  - `MoneyInput`: Forwardable input component with live currency formatting
  - `parseMoney()`: Parses formatted currency strings to numbers (handles "1.234,56", "1234.56", "1234,5" formats)
  - `formatMoney()`: Formats numbers to Spanish locale currency string with 2 decimal places
  - `normalizeRaw()`: Intelligently normalizes pasted/typed text to digits + optional decimal comma
    - Treats commas as decimal separators when present
    - Treats single trailing dots (1-2 digits) as decimals in English format and converts to comma
    - Treats other dots as thousands separators
  - Smart cursor positioning that preserves digit count before cursor after formatting

- **Updated**: `components/informes/subir-informe-sheet.tsx`
  - Replaced generic `Input` components with `MoneyInput` for balance and available final fields
  - Updated initialization to use `formatMoney()` for proper display formatting
  - Removed inline `parseMoney()` function in favor of imported utility
  - Simplified change handlers using `onValueChange` callback

## Implementation Details
- Cursor position is maintained using `requestAnimationFrame` to ensure DOM updates complete before repositioning
- The component counts digits before cursor position to intelligently restore cursor after formatting
- Supports both Spanish ("1.234,56") and English ("1234.56") input formats, normalizing to Spanish display
- Uses `inputMode="decimal"` for appropriate mobile keyboard
- Integrates with existing UI styling (border, focus states, disabled states)

https://claude.ai/code/session_01SxFGJQ8Rc64YRqFiscDsDH