### PR TITLE
feat(facturas): sección Facturas con bandeja de entrada y conciliación con movimientos

### DIFF
--- a/app/facturas/page.tsx
+++ b/app/facturas/page.tsx
@@ -1,0 +1,10 @@
+import { AppLayout } from "@/components/app-layout"
+import { FacturasManager } from "@/components/facturas/facturas-manager"
+
+export default function FacturasPage() {
+  return (
+    <AppLayout>
+      <FacturasManager />
+    </AppLayout>
+  )
+}

--- a/components/contactos/contacto-detail-sheet.tsx
+++ b/components/contactos/contacto-detail-sheet.tsx
@@ -17,6 +17,7 @@ import {
   Phone,
   Plus,
   Trash2,
+  TriangleAlert,
 } from "lucide-react"
 import {
   Sheet,
@@ -168,7 +169,7 @@ export function ContactoDetailSheet({
               <TabsContent value="info" className="flex-1 overflow-hidden">
                 <ScrollArea className="h-full">
                   <div className="space-y-2 p-6">
-                    {contacto.identificador_fiscal && (
+                    {contacto.identificador_fiscal ? (
                       <CopyableRow
                         icon={<Hash className="h-4 w-4" />}
                         label="CIF / NIF / DNI"
@@ -176,6 +177,13 @@ export function ContactoDetailSheet({
                         onCopy={() => handleCopy(contacto.identificador_fiscal, "Identificador fiscal")}
                         copied={isCopied(contacto.identificador_fiscal)}
                       />
+                    ) : (
+                      contacto.tipo === "proveedor" && (
+                        <div className="flex items-center gap-2 rounded-lg border border-amber-200/70 bg-amber-50/60 px-3 py-2 text-xs text-amber-800 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-200">
+                          <TriangleAlert className="h-3.5 w-3.5 shrink-0" />
+                          Falta el CIF/NIF de este proveedor.
+                        </div>
+                      )
                     )}
                     {contacto.email && (
                       <CopyableRow

--- a/components/contactos/contacto-selector.tsx
+++ b/components/contactos/contacto-selector.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useMemo, useState } from "react"
-import { Check, ChevronsUpDown, Plus, Users, X } from "lucide-react"
+import { Check, ChevronsUpDown, Plus, TriangleAlert, Users, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import {
@@ -104,6 +104,11 @@ export function ContactoSelector({
                   <span className={cn("h-1 w-1 rounded-full", CONTACTO_TIPO_INFO[selected.tipo].dotClass)} aria-hidden />
                   {CONTACTO_TIPO_INFO[selected.tipo].shortLabel}
                 </span>
+                {selected.tipo === "proveedor" && !selected.identificador_fiscal && (
+                  <span title="Falta el NIF/CIF" className="shrink-0">
+                    <TriangleAlert className="h-3.5 w-3.5 text-amber-500" aria-label="Falta el NIF/CIF" />
+                  </span>
+                )}
               </>
             ) : (
               <>
@@ -168,7 +173,14 @@ export function ContactoSelector({
                           className="mr-2"
                         />
                         <div className="flex-1 truncate">
-                          <div className="truncate font-medium">{c.nombre}</div>
+                          <div className="flex items-center gap-1 truncate">
+                            <span className="truncate font-medium">{c.nombre}</span>
+                            {c.tipo === "proveedor" && !c.identificador_fiscal && (
+                              <span title="Falta el NIF/CIF" className="shrink-0">
+                                <TriangleAlert className="h-3 w-3 text-amber-500" aria-label="Falta el NIF/CIF" />
+                              </span>
+                            )}
+                          </div>
                           {(c.email || c.identificador_fiscal) && (
                             <div className="truncate text-[11px] text-muted-foreground">
                               {c.identificador_fiscal ?? c.email}

--- a/components/contactos/contactos-manager.tsx
+++ b/components/contactos/contactos-manager.tsx
@@ -11,6 +11,7 @@ import {
   Plus,
   Search,
   Trash2,
+  TriangleAlert,
   Users,
 } from "lucide-react"
 import { toast } from "sonner"
@@ -315,8 +316,19 @@ function ContactoCard({
                 </span>
               )}
             </div>
-            {contacto.identificador_fiscal && (
+            {contacto.identificador_fiscal ? (
               <div className="mt-1 truncate font-mono text-[11px] text-muted-foreground">{contacto.identificador_fiscal}</div>
+            ) : (
+              contacto.tipo === "proveedor" &&
+              !contacto.archivado && (
+                <div
+                  className="mt-1 flex items-center gap-1 text-[11px] text-amber-600 dark:text-amber-400"
+                  title="Falta el NIF/CIF de este proveedor"
+                >
+                  <TriangleAlert className="h-3 w-3 shrink-0" />
+                  <span>Sin NIF/CIF</span>
+                </div>
+              )
             )}
           </div>
         </div>

--- a/components/facturas/delete-factura-dialog.tsx
+++ b/components/facturas/delete-factura-dialog.tsx
@@ -51,10 +51,10 @@ export function DeleteFacturaDialog({ factura, open, onOpenChange, onDelete }: D
           </DialogTitle>
           <DialogDescription>
             Esta acción no se puede deshacer. La factura y sus archivos adjuntos se eliminarán.
-            {factura.movimiento && (
+            {factura.movimientos && factura.movimientos.length > 0 && (
               <span className="mt-2 block text-amber-700 dark:text-amber-300">
-                Está vinculada a un movimiento bancario. El movimiento NO se eliminará, solo perderá el
-                vínculo.
+                Está vinculada a {factura.movimientos.length === 1 ? "un movimiento bancario" : `${factura.movimientos.length} movimientos bancarios`}.
+                {factura.movimientos.length === 1 ? " El movimiento NO se eliminará" : " Los movimientos NO se eliminarán"}, solo perderán el vínculo.
               </span>
             )}
           </DialogDescription>

--- a/components/facturas/delete-factura-dialog.tsx
+++ b/components/facturas/delete-factura-dialog.tsx
@@ -1,0 +1,86 @@
+"use client"
+
+import { useState } from "react"
+import { toast } from "sonner"
+import { AlertTriangle } from "lucide-react"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { formatCurrency } from "@/lib/utils/format"
+import type { FacturaConRelaciones } from "@/lib/types/database"
+
+interface DeleteFacturaDialogProps {
+  factura: FacturaConRelaciones | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onDelete: (id: string) => Promise<void>
+}
+
+export function DeleteFacturaDialog({ factura, open, onOpenChange, onDelete }: DeleteFacturaDialogProps) {
+  const [busy, setBusy] = useState(false)
+
+  if (!factura) return null
+
+  const titulo = factura.concepto?.trim() || factura.archivos?.[0]?.nombre_original || "Factura sin título"
+
+  const handleDelete = async () => {
+    setBusy(true)
+    try {
+      await onDelete(factura.id)
+    } catch (err) {
+      toast.error("No se pudo eliminar: " + (err instanceof Error ? err.message : "error desconocido"))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => !busy && onOpenChange(v)}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <AlertTriangle className="h-5 w-5 text-amber-500" />
+            Eliminar factura
+          </DialogTitle>
+          <DialogDescription>
+            Esta acción no se puede deshacer. La factura y sus archivos adjuntos se eliminarán.
+            {factura.movimiento && (
+              <span className="mt-2 block text-amber-700 dark:text-amber-300">
+                Está vinculada a un movimiento bancario. El movimiento NO se eliminará, solo perderá el
+                vínculo.
+              </span>
+            )}
+          </DialogDescription>
+        </DialogHeader>
+
+        <Alert>
+          <AlertDescription>
+            <div className="space-y-1">
+              <div className="font-semibold">{titulo}</div>
+              <div className="text-sm text-muted-foreground">
+                {factura.contacto?.nombre ?? "Sin proveedor"}
+                {factura.importe != null && <> · {formatCurrency(Number(factura.importe))}</>}
+              </div>
+            </div>
+          </AlertDescription>
+        </Alert>
+
+        <DialogFooter>
+          <Button variant="outline" disabled={busy} onClick={() => onOpenChange(false)}>
+            Cancelar
+          </Button>
+          <Button variant="destructive" disabled={busy} onClick={handleDelete}>
+            {busy ? "Eliminando…" : "Eliminar"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/facturas/factura-archivos.tsx
+++ b/components/facturas/factura-archivos.tsx
@@ -1,0 +1,130 @@
+"use client"
+
+import { useState } from "react"
+import { useDropzone } from "react-dropzone"
+import { Download, Loader2, Trash2, Upload } from "lucide-react"
+import { toast } from "sonner"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+import { FileService } from "@/lib/services/file-service"
+import { useDelegationContext } from "@/contexts/delegation-context"
+import { useFacturaArchivos } from "@/hooks/use-factura-archivos"
+import type { ArchivoAdjunto } from "@/lib/types/database"
+
+interface FacturaArchivosProps {
+  facturaId: string
+  delegacionId: string
+}
+
+export function FacturaArchivos({ facturaId, delegacionId }: FacturaArchivosProps) {
+  const { getCurrentDelegation } = useDelegationContext()
+  const delegacionCodigo = getCurrentDelegation()?.codigo ?? undefined
+  const { archivos, uploading, loading, error, uploadFile, deleteFile } = useFacturaArchivos(
+    facturaId,
+    delegacionId,
+    delegacionCodigo,
+  )
+  const [deletingId, setDeletingId] = useState<string | null>(null)
+
+  const onDrop = async (accepted: File[]) => {
+    if (accepted.length === 0) return
+    try {
+      for (const file of accepted) {
+        await uploadFile(file)
+      }
+      toast.success(accepted.length === 1 ? "Archivo subido" : `${accepted.length} archivos subidos`)
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "No se pudo subir")
+    }
+  }
+
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+    onDrop,
+    multiple: true,
+    disabled: uploading || !delegacionCodigo,
+    maxSize: 20 * 1024 * 1024,
+  })
+
+  const handleDelete = async (archivo: ArchivoAdjunto) => {
+    setDeletingId(archivo.id)
+    try {
+      await deleteFile(archivo)
+      toast.success("Archivo eliminado")
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "No se pudo eliminar")
+    } finally {
+      setDeletingId(null)
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <div
+        {...getRootProps()}
+        className={cn(
+          "flex cursor-pointer flex-col items-center justify-center gap-1 rounded-lg border-2 border-dashed border-border bg-muted/20 px-3 py-4 text-xs text-muted-foreground transition-colors",
+          isDragActive && "border-primary bg-primary/5",
+          (uploading || !delegacionCodigo) && "cursor-not-allowed opacity-60",
+        )}
+      >
+        <input {...getInputProps()} />
+        {uploading ? (
+          <>
+            <Loader2 className="h-4 w-4 animate-spin" />
+            <span>Subiendo…</span>
+          </>
+        ) : (
+          <>
+            <Upload className="h-4 w-4" />
+            <span>{isDragActive ? "Suelta aquí" : "Arrastra o pulsa para subir la factura"}</span>
+            <span className="text-[10px]">PDF o imagen · máximo 20 MB</span>
+          </>
+        )}
+      </div>
+
+      {error && <p className="text-xs text-rose-600">{error}</p>}
+
+      {loading && archivos.length === 0 && (
+        <p className="flex items-center gap-2 text-xs text-muted-foreground">
+          <Loader2 className="h-3 w-3 animate-spin" /> Cargando archivos…
+        </p>
+      )}
+
+      {archivos.map((a) => (
+        <div
+          key={a.id}
+          className="flex items-center gap-2 rounded-lg border border-border/60 bg-background px-2.5 py-1.5"
+        >
+          <span className="text-base" aria-hidden>
+            {FileService.getFileIcon(a.nombre_original)}
+          </span>
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-xs font-medium">{a.nombre_original}</div>
+            <div className="text-[10px] text-muted-foreground">
+              {FileService.formatFileSize(a.tamano_bytes)}
+            </div>
+          </div>
+          <a
+            href={a.url_publica}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-muted-foreground hover:text-foreground"
+            aria-label="Abrir archivo"
+          >
+            <Download className="h-3.5 w-3.5" />
+          </a>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-6 w-6 p-0 text-rose-600 hover:bg-rose-50 hover:text-rose-700 dark:hover:bg-rose-950/30"
+            disabled={deletingId === a.id}
+            onClick={() => handleDelete(a)}
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/components/facturas/factura-card.tsx
+++ b/components/facturas/factura-card.tsx
@@ -8,7 +8,7 @@ import { StatusPill } from "@/components/ui/status-pill"
 import { cn } from "@/lib/utils"
 import { CONTACTO_TIPO_DEFAULT_EMOJIS, CONTACTO_TIPO_INFO } from "@/lib/utils/contacto-tipos"
 import { formatCurrency, formatDate } from "@/lib/utils/format"
-import { FACTURA_ESTADO_INFO, FACTURA_ORIGEN_INFO } from "@/lib/utils/facturas"
+import { FACTURA_ESTADO_INFO, FACTURA_ORIGEN_INFO, importePendienteFactura } from "@/lib/utils/facturas"
 import type { FacturaConRelaciones } from "@/lib/types/database"
 
 interface FacturaCardProps {
@@ -17,7 +17,7 @@ interface FacturaCardProps {
   onEdit: () => void
   onDelete: () => void
   onVincular?: () => void
-  onDesvincular?: () => void
+  onDesvincular?: (movimientoId: string) => void
   onMarcarPagadaFuera?: () => void
 }
 
@@ -35,6 +35,10 @@ export function FacturaCard({
   const OrigenIcon = origenInfo.icon
   const contactoTipoInfo = factura.contacto ? CONTACTO_TIPO_INFO[factura.contacto.tipo] : null
   const archivoPrincipal = factura.archivos?.[0] ?? null
+  const movimientos = factura.movimientos ?? []
+  const pendiente = importePendienteFactura(factura)
+  // "Sigue abierta" = puede admitir más vínculos (bandeja, sin_pagar, pago parcial)
+  const abierta = factura.estado !== "pagada" && factura.estado !== "pagada_fuera"
 
   const titulo =
     factura.concepto?.trim() ||
@@ -87,6 +91,11 @@ export function FacturaCard({
               {factura.numero && <span className="ml-1.5">· Nº {factura.numero}</span>}
             </span>
           </div>
+          {factura.estado === "pagada_parcial" && pendiente != null && (
+            <div className="text-[11px] font-medium text-orange-700 dark:text-orange-300">
+              Quedan {formatCurrency(pendiente)} por cubrir
+            </div>
+          )}
         </div>
 
         {/* Proveedor */}
@@ -109,6 +118,14 @@ export function FacturaCard({
                     aria-hidden
                     title={contactoTipoInfo.label}
                   />
+                )}
+                {factura.contacto.tipo === "proveedor" && !factura.contacto.identificador_fiscal && (
+                  <span
+                    className="inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-full bg-amber-100 text-[9px] font-bold text-amber-700 dark:bg-amber-950/60 dark:text-amber-300"
+                    title="Falta el NIF/CIF de este proveedor"
+                  >
+                    !
+                  </span>
                 )}
               </div>
               {factura.contacto.identificador_fiscal && (
@@ -143,24 +160,41 @@ export function FacturaCard({
           </div>
         )}
 
-        {/* Movimiento vinculado */}
-        {factura.movimiento && (
-          <div className="flex items-center gap-1.5 rounded-md border border-emerald-200/70 bg-emerald-50/60 px-2 py-1 text-[11px] text-emerald-900 dark:border-emerald-900/60 dark:bg-emerald-950/30 dark:text-emerald-200">
-            <ExternalLink className="h-3 w-3 shrink-0" />
-            <span className="truncate">
-              {formatDate(factura.movimiento.fecha)} · {formatCurrency(Number(factura.movimiento.importe))} ·{" "}
-              {factura.movimiento.concepto}
-            </span>
+        {/* Movimientos vinculados (puede haber varios: pago en varios plazos) */}
+        {movimientos.length > 0 && (
+          <div className="space-y-1">
+            {movimientos.map((m) => (
+              <div
+                key={m.id}
+                className="flex items-center gap-1.5 rounded-md border border-emerald-200/70 bg-emerald-50/60 px-2 py-1 text-[11px] text-emerald-900 dark:border-emerald-900/60 dark:bg-emerald-950/30 dark:text-emerald-200"
+              >
+                <ExternalLink className="h-3 w-3 shrink-0" />
+                <span className="min-w-0 flex-1 truncate">
+                  {formatDate(m.fecha)} · {formatCurrency(Number(m.importe))} · {m.concepto}
+                </span>
+                {canEdit && onDesvincular && (
+                  <button
+                    type="button"
+                    onClick={() => onDesvincular(m.id)}
+                    className="shrink-0 rounded p-0.5 text-emerald-700/70 hover:bg-emerald-100 hover:text-emerald-900 dark:text-emerald-300/70 dark:hover:bg-emerald-900/40"
+                    title="Desvincular este movimiento"
+                  >
+                    <Unlink className="h-3 w-3" />
+                  </button>
+                )}
+              </div>
+            ))}
           </div>
         )}
 
         {/* Acción principal: vincular movimiento */}
-        {canEdit && !factura.movimiento_id && onVincular && (
+        {canEdit && abierta && onVincular && (
           <div className="flex gap-2">
             <Button type="button" onClick={onVincular} size="sm" className="flex-1">
-              <Link2 className="mr-1.5 h-3.5 w-3.5" /> Vincular movimiento
+              <Link2 className="mr-1.5 h-3.5 w-3.5" />
+              {movimientos.length > 0 ? "Vincular otro pago" : "Vincular movimiento"}
             </Button>
-            {factura.estado !== "pagada_fuera" && onMarcarPagadaFuera && (
+            {onMarcarPagadaFuera && (
               <Button
                 type="button"
                 onClick={onMarcarPagadaFuera}
@@ -183,17 +217,6 @@ export function FacturaCard({
           </span>
           {canEdit && (
             <div className="flex items-center gap-0.5 opacity-70 transition-opacity group-hover:opacity-100">
-              {factura.movimiento_id && onDesvincular && (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={onDesvincular}
-                  className="h-7 w-7 p-0"
-                  title="Desvincular movimiento"
-                >
-                  <Unlink className="h-3.5 w-3.5" />
-                </Button>
-              )}
               <Button variant="ghost" size="sm" onClick={onEdit} className="h-7 w-7 p-0" title="Editar">
                 <Edit3 className="h-3.5 w-3.5" />
               </Button>

--- a/components/facturas/factura-card.tsx
+++ b/components/facturas/factura-card.tsx
@@ -1,0 +1,215 @@
+"use client"
+
+import { BadgeCheck, Edit3, ExternalLink, FileText, Link2, Trash2, Unlink } from "lucide-react"
+import { Card, CardContent } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { EntityAvatar } from "@/components/ui/entity-avatar"
+import { StatusPill } from "@/components/ui/status-pill"
+import { cn } from "@/lib/utils"
+import { CONTACTO_TIPO_DEFAULT_EMOJIS, CONTACTO_TIPO_INFO } from "@/lib/utils/contacto-tipos"
+import { formatCurrency, formatDate } from "@/lib/utils/format"
+import { FACTURA_ESTADO_INFO, FACTURA_ORIGEN_INFO } from "@/lib/utils/facturas"
+import type { FacturaConRelaciones } from "@/lib/types/database"
+
+interface FacturaCardProps {
+  factura: FacturaConRelaciones
+  canEdit: boolean
+  onEdit: () => void
+  onDelete: () => void
+  onVincular?: () => void
+  onDesvincular?: () => void
+  onMarcarPagadaFuera?: () => void
+}
+
+export function FacturaCard({
+  factura,
+  canEdit,
+  onEdit,
+  onDelete,
+  onVincular,
+  onDesvincular,
+  onMarcarPagadaFuera,
+}: FacturaCardProps) {
+  const estadoInfo = FACTURA_ESTADO_INFO[factura.estado]
+  const origenInfo = FACTURA_ORIGEN_INFO[factura.origen]
+  const OrigenIcon = origenInfo.icon
+  const contactoTipoInfo = factura.contacto ? CONTACTO_TIPO_INFO[factura.contacto.tipo] : null
+  const archivoPrincipal = factura.archivos?.[0] ?? null
+
+  const titulo =
+    factura.concepto?.trim() ||
+    archivoPrincipal?.nombre_original ||
+    "Factura sin título"
+
+  return (
+    <Card
+      className={cn(
+        "group relative overflow-hidden border-border/60 transition-[border-color,box-shadow] hover:border-foreground/15 hover:shadow-md",
+      )}
+    >
+      {/* Banda lateral coloreada por estado */}
+      <div className={cn("absolute inset-y-0 left-0 w-[3px]", estadoInfo.dotClass)} aria-hidden />
+
+      <CardContent className="space-y-3.5 p-4 pl-[14px]">
+        {/* Header: estado + origen */}
+        <div className="flex items-center justify-between gap-2">
+          <StatusPill
+            label={estadoInfo.label}
+            icon={estadoInfo.icon}
+            bgClass={estadoInfo.bgClass}
+            textClass={estadoInfo.textClass}
+            borderClass={estadoInfo.borderClass}
+            size="sm"
+          />
+          <span
+            className="inline-flex items-center gap-1 text-[10px] uppercase tracking-wider text-muted-foreground"
+            title={origenInfo.label}
+          >
+            <OrigenIcon className="h-3 w-3" aria-hidden />
+          </span>
+        </div>
+
+        {/* Título + importe + fecha */}
+        <div className="space-y-1">
+          <div className="line-clamp-2 text-sm font-semibold leading-snug tracking-tight" title={titulo}>
+            {titulo}
+          </div>
+          <div className="flex items-baseline justify-between gap-2">
+            {factura.importe != null ? (
+              <span className="text-2xl font-bold tracking-tight tabular-nums">
+                {formatCurrency(Number(factura.importe))}
+              </span>
+            ) : (
+              <span className="text-sm italic text-muted-foreground">Sin importe</span>
+            )}
+            <span className="text-[11px] text-muted-foreground tabular-nums">
+              {factura.fecha_emision ? formatDate(factura.fecha_emision) : "Sin fecha"}
+              {factura.numero && <span className="ml-1.5">· Nº {factura.numero}</span>}
+            </span>
+          </div>
+        </div>
+
+        {/* Proveedor */}
+        {factura.contacto ? (
+          <div className="flex items-center gap-2.5 rounded-lg border border-border/50 bg-muted/30 px-2.5 py-2">
+            <EntityAvatar
+              name={factura.contacto.nombre}
+              emoji={factura.contacto.emoji}
+              defaultEmojis={CONTACTO_TIPO_DEFAULT_EMOJIS}
+              colorHex={factura.contacto.color}
+              size="md"
+              seed={`contacto:${factura.contacto.id}`}
+            />
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-1.5">
+                <span className="truncate text-sm font-medium tracking-tight">{factura.contacto.nombre}</span>
+                {contactoTipoInfo && (
+                  <span
+                    className={cn("h-1.5 w-1.5 shrink-0 rounded-full", contactoTipoInfo.dotClass)}
+                    aria-hidden
+                    title={contactoTipoInfo.label}
+                  />
+                )}
+              </div>
+              {factura.contacto.identificador_fiscal && (
+                <div className="mt-0.5 truncate text-[11px] text-muted-foreground">
+                  {factura.contacto.identificador_fiscal}
+                </div>
+              )}
+            </div>
+          </div>
+        ) : (
+          <div className="rounded-lg border border-dashed border-border/60 bg-muted/20 px-2.5 py-2 text-[11px] text-muted-foreground">
+            Sin proveedor asignado
+          </div>
+        )}
+
+        {/* Archivos */}
+        {factura.archivos && factura.archivos.length > 0 && (
+          <div className="flex flex-wrap gap-1.5">
+            {factura.archivos.map((a) => (
+              <a
+                key={a.id}
+                href={a.url_publica}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex max-w-full items-center gap-1 rounded-full border border-border/60 bg-background px-2 py-0.5 text-[11px] text-muted-foreground transition-colors hover:border-primary/40 hover:text-foreground"
+                title={a.nombre_original}
+              >
+                <FileText className="h-3 w-3 shrink-0" />
+                <span className="truncate">{a.nombre_original}</span>
+              </a>
+            ))}
+          </div>
+        )}
+
+        {/* Movimiento vinculado */}
+        {factura.movimiento && (
+          <div className="flex items-center gap-1.5 rounded-md border border-emerald-200/70 bg-emerald-50/60 px-2 py-1 text-[11px] text-emerald-900 dark:border-emerald-900/60 dark:bg-emerald-950/30 dark:text-emerald-200">
+            <ExternalLink className="h-3 w-3 shrink-0" />
+            <span className="truncate">
+              {formatDate(factura.movimiento.fecha)} · {formatCurrency(Number(factura.movimiento.importe))} ·{" "}
+              {factura.movimiento.concepto}
+            </span>
+          </div>
+        )}
+
+        {/* Acción principal: vincular movimiento */}
+        {canEdit && !factura.movimiento_id && onVincular && (
+          <div className="flex gap-2">
+            <Button type="button" onClick={onVincular} size="sm" className="flex-1">
+              <Link2 className="mr-1.5 h-3.5 w-3.5" /> Vincular movimiento
+            </Button>
+            {factura.estado !== "pagada_fuera" && onMarcarPagadaFuera && (
+              <Button
+                type="button"
+                onClick={onMarcarPagadaFuera}
+                size="sm"
+                variant="outline"
+                title="Pagada, pero el movimiento está fuera de MCM Bank"
+              >
+                <BadgeCheck className="mr-1.5 h-3.5 w-3.5" /> Pagada fuera
+              </Button>
+            )}
+          </div>
+        )}
+
+        {/* Footer: fecha + acciones */}
+        <div className="flex items-center justify-between gap-2 border-t border-border/40 pt-2.5">
+          <span className="text-[10px] uppercase tracking-wider text-muted-foreground/70">
+            {origenInfo.value === "email" && factura.email_remitente
+              ? `De ${factura.email_remitente}`
+              : `Creada ${formatDate(factura.creado_en)}`}
+          </span>
+          {canEdit && (
+            <div className="flex items-center gap-0.5 opacity-70 transition-opacity group-hover:opacity-100">
+              {factura.movimiento_id && onDesvincular && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={onDesvincular}
+                  className="h-7 w-7 p-0"
+                  title="Desvincular movimiento"
+                >
+                  <Unlink className="h-3.5 w-3.5" />
+                </Button>
+              )}
+              <Button variant="ghost" size="sm" onClick={onEdit} className="h-7 w-7 p-0" title="Editar">
+                <Edit3 className="h-3.5 w-3.5" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={onDelete}
+                className="h-7 w-7 p-0 text-rose-600 hover:bg-rose-50 hover:text-rose-700 dark:hover:bg-rose-950/30"
+                title="Eliminar"
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+              </Button>
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/facturas/factura-form.tsx
+++ b/components/facturas/factura-form.tsx
@@ -1,0 +1,281 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import { toast } from "sonner"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet"
+import { DateField } from "@/components/ui/date-field"
+import { cn } from "@/lib/utils"
+import { ContactoSelector } from "@/components/contactos/contacto-selector"
+import { ContactoForm, type ContactoFormSubmitPayload } from "@/components/contactos/contacto-form"
+import { FacturaArchivos } from "./factura-archivos"
+import { FACTURA_ESTADO_INFO, FACTURA_ESTADO_ORDER } from "@/lib/utils/facturas"
+import type {
+  Categoria,
+  Contacto,
+  ContactoConCategoriaPredeterminada,
+  Factura,
+  FacturaConRelaciones,
+  FacturaEstado,
+  FacturaInsert,
+  FacturaUpdate,
+} from "@/lib/types/database"
+
+export interface FacturaFormSubmit {
+  insert?: Omit<FacturaInsert, "creado_en" | "actualizado_en">
+  update?: FacturaUpdate
+}
+
+interface FacturaFormProps {
+  delegacionId: string | null
+  factura?: FacturaConRelaciones | null
+  contactos: ContactoConCategoriaPredeterminada[]
+  categorias: Pick<Categoria, "id" | "nombre" | "emoji" | "color">[]
+  canManageGlobalContact?: boolean
+  onCreateContacto?: (payload: ContactoFormSubmitPayload) => Promise<Contacto | void>
+  onSubmit: (payload: FacturaFormSubmit) => Promise<Factura | void>
+  onCancel: () => void
+}
+
+export function FacturaForm({
+  delegacionId,
+  factura,
+  contactos,
+  categorias,
+  canManageGlobalContact,
+  onCreateContacto,
+  onSubmit,
+  onCancel,
+}: FacturaFormProps) {
+  const isEdit = Boolean(factura?.id)
+
+  const [contactoId, setContactoId] = useState<string | null>(factura?.contacto_id ?? null)
+  const [concepto, setConcepto] = useState(factura?.concepto ?? "")
+  const [numero, setNumero] = useState(factura?.numero ?? "")
+  const [fechaEmision, setFechaEmision] = useState<string | null>(factura?.fecha_emision ?? null)
+  const [importeStr, setImporteStr] = useState(
+    factura?.importe != null ? Number(factura.importe).toFixed(2).replace(".", ",") : "",
+  )
+  const [estado, setEstado] = useState<FacturaEstado>(factura?.estado ?? "bandeja")
+  const [notas, setNotas] = useState(factura?.notas ?? "")
+  const [loading, setLoading] = useState(false)
+
+  const [contactoCreateOpen, setContactoCreateOpen] = useState(false)
+  const [contactoInitialNombre, setContactoInitialNombre] = useState("")
+
+  const importeNumerico = useMemo(() => {
+    const trimmed = importeStr.trim()
+    if (!trimmed) return null
+    const v = parseFloat(trimmed.replace(/\./g, "").replace(",", "."))
+    return Number.isFinite(v) && v > 0 ? v : null
+  }, [importeStr])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!delegacionId) {
+      toast.error("Selecciona una delegación antes de guardar la factura")
+      return
+    }
+    if (importeStr.trim() && importeNumerico == null) {
+      toast.error("El importe no es válido")
+      return
+    }
+
+    const base = {
+      contacto_id: contactoId,
+      concepto: concepto.trim() || null,
+      numero: numero.trim() || null,
+      fecha_emision: fechaEmision,
+      importe: importeNumerico,
+      estado,
+      notas: notas.trim() || null,
+    }
+
+    setLoading(true)
+    try {
+      if (isEdit && factura) {
+        await onSubmit({ update: base })
+      } else {
+        await onSubmit({ insert: { ...base, delegacion_id: delegacionId } })
+      }
+      toast.success(isEdit ? "Factura actualizada" : "Factura creada")
+    } catch (err) {
+      toast.error("No se pudo guardar: " + (err instanceof Error ? err.message : "error desconocido"))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <>
+      <form onSubmit={handleSubmit} className="space-y-4 pb-6">
+        {/* Proveedor */}
+        <div className="space-y-1.5">
+          <Label>Proveedor</Label>
+          <ContactoSelector
+            contactos={contactos}
+            value={contactoId}
+            onChange={setContactoId}
+            onCreateNew={
+              onCreateContacto
+                ? (initialNombre) => {
+                    setContactoInitialNombre(initialNombre)
+                    setContactoCreateOpen(true)
+                  }
+                : undefined
+            }
+            placeholder="¿Quién emite la factura?"
+          />
+          <p className="text-[11px] text-muted-foreground">
+            Si no existe, escríbelo y créalo al vuelo sin salir de aquí.
+          </p>
+        </div>
+
+        {/* Concepto */}
+        <div className="space-y-1.5">
+          <Label htmlFor="factura-concepto">Concepto</Label>
+          <Input
+            id="factura-concepto"
+            value={concepto}
+            onChange={(e) => setConcepto(e.target.value)}
+            placeholder="P.ej. Material del campamento de verano"
+          />
+        </div>
+
+        {/* Importe + fecha */}
+        <div className="grid grid-cols-2 gap-3">
+          <div className="space-y-1.5">
+            <Label htmlFor="factura-importe">Importe</Label>
+            <div className="relative">
+              <Input
+                id="factura-importe"
+                type="text"
+                inputMode="decimal"
+                value={importeStr}
+                onChange={(e) => setImporteStr(e.target.value)}
+                placeholder="0,00"
+                className="pr-8 tabular-nums"
+              />
+              <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">
+                €
+              </span>
+            </div>
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="factura-fecha">Fecha de emisión</Label>
+            <DateField id="factura-fecha" value={fechaEmision} onChange={setFechaEmision} />
+          </div>
+        </div>
+
+        {/* Número de factura */}
+        <div className="space-y-1.5">
+          <Label htmlFor="factura-numero">
+            Nº de factura <span className="text-[11px] font-normal text-muted-foreground">(opcional)</span>
+          </Label>
+          <Input
+            id="factura-numero"
+            value={numero}
+            onChange={(e) => setNumero(e.target.value)}
+            placeholder="P.ej. 2026-0042"
+          />
+        </div>
+
+        {/* Estado */}
+        <div className="space-y-1.5">
+          <Label>Estado</Label>
+          <Select value={estado} onValueChange={(v) => setEstado(v as FacturaEstado)}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {FACTURA_ESTADO_ORDER.map((s) => {
+                const info = FACTURA_ESTADO_INFO[s]
+                const lockedPagada = s === "pagada" && !factura?.movimiento_id
+                return (
+                  <SelectItem key={s} value={s} disabled={lockedPagada}>
+                    <span className="inline-flex items-center gap-2">
+                      <span className={cn("h-1.5 w-1.5 rounded-full", info.dotClass)} aria-hidden />
+                      <span>{info.label}</span>
+                      {lockedPagada && (
+                        <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                          vincula un movimiento
+                        </span>
+                      )}
+                    </span>
+                  </SelectItem>
+                )
+              })}
+            </SelectContent>
+          </Select>
+          <p className="text-[11px] text-muted-foreground">{FACTURA_ESTADO_INFO[estado].descripcion}</p>
+        </div>
+
+        {/* Notas */}
+        <div className="space-y-1.5">
+          <Label htmlFor="factura-notas">Notas internas</Label>
+          <Textarea
+            id="factura-notas"
+            value={notas}
+            onChange={(e) => setNotas(e.target.value)}
+            placeholder="Notas privadas para el equipo (opcional)."
+            rows={2}
+          />
+        </div>
+
+        {/* Adjuntos (solo en edición: al crear desde la bandeja el archivo ya viene) */}
+        {isEdit && factura && delegacionId && (
+          <div className="space-y-1.5">
+            <Label>Archivos de la factura</Label>
+            <FacturaArchivos facturaId={factura.id} delegacionId={delegacionId} />
+            <p className="text-[11px] text-muted-foreground">
+              Al vincular la factura a un movimiento, el archivo también quedará disponible desde el
+              movimiento.
+            </p>
+          </div>
+        )}
+
+        {/* Acciones */}
+        <div className="flex items-center justify-end gap-2 pt-2">
+          <Button type="button" variant="outline" onClick={onCancel} disabled={loading}>
+            Cancelar
+          </Button>
+          <Button type="submit" disabled={loading}>
+            {loading ? "Guardando…" : isEdit ? "Guardar cambios" : "Crear factura"}
+          </Button>
+        </div>
+      </form>
+
+      {/* Creación rápida de contacto sin salir del formulario */}
+      {onCreateContacto && (
+        <Sheet open={contactoCreateOpen} onOpenChange={setContactoCreateOpen}>
+          <SheetContent side="right" className="w-full sm:max-w-xl overflow-y-auto z-[70]">
+            <SheetHeader className="mb-2">
+              <SheetTitle>Nuevo contacto</SheetTitle>
+            </SheetHeader>
+            <ContactoForm
+              delegacionId={delegacionId}
+              contacto={null}
+              categorias={categorias}
+              canManageGlobal={Boolean(canManageGlobalContact)}
+              defaultTipo="proveedor"
+              defaultNombre={contactoInitialNombre}
+              onSubmit={async (payload) => {
+                const created = (await onCreateContacto(payload)) as Contacto | void
+                if (created?.id) {
+                  setContactoId(created.id)
+                }
+                return created
+              }}
+              onCancel={() => setContactoCreateOpen(false)}
+              onSaved={() => setContactoCreateOpen(false)}
+            />
+          </SheetContent>
+        </Sheet>
+      )}
+    </>
+  )
+}

--- a/components/facturas/factura-form.tsx
+++ b/components/facturas/factura-form.tsx
@@ -194,7 +194,8 @@ export function FacturaForm({
             <SelectContent>
               {FACTURA_ESTADO_ORDER.map((s) => {
                 const info = FACTURA_ESTADO_INFO[s]
-                const lockedPagada = s === "pagada" && !factura?.movimiento_id
+                const tieneMovimientos = Boolean(factura?.movimientos && factura.movimientos.length > 0)
+                const lockedPagada = (s === "pagada" || s === "pagada_parcial") && !tieneMovimientos
                 return (
                   <SelectItem key={s} value={s} disabled={lockedPagada}>
                     <span className="inline-flex items-center gap-2">

--- a/components/facturas/factura-inbox-dropzone.tsx
+++ b/components/facturas/factura-inbox-dropzone.tsx
@@ -1,0 +1,152 @@
+"use client"
+
+import { useState } from "react"
+import { useDropzone } from "react-dropzone"
+import { Inbox, Loader2 } from "lucide-react"
+import { toast } from "sonner"
+import { cn } from "@/lib/utils"
+import { useAuth } from "@/contexts/auth-context"
+import { useDelegationContext } from "@/contexts/delegation-context"
+import { DatabaseService } from "@/lib/services/database"
+import { FileService } from "@/lib/services/file-service"
+
+interface FacturaInboxDropzoneProps {
+  delegacionId: string | null
+  disabled?: boolean
+  onCreated: () => void | Promise<void>
+}
+
+/** Limpia el nombre de archivo para usarlo como concepto provisional. */
+function conceptoDesdeNombre(nombre: string): string {
+  return nombre
+    .replace(/\.[^.]+$/, "")
+    .replace(/[_-]+/g, " ")
+    .trim()
+    .slice(0, 120)
+}
+
+/**
+ * Bandeja de entrada: suelta uno o varios archivos y se crea una factura por
+ * cada uno (estado 'bandeja'), lista para completar datos y conciliar.
+ */
+export function FacturaInboxDropzone({ delegacionId, disabled, onCreated }: FacturaInboxDropzoneProps) {
+  const { user } = useAuth()
+  const { getCurrentDelegation } = useDelegationContext()
+  const delegacionCodigo = getCurrentDelegation()?.codigo ?? undefined
+  const [uploading, setUploading] = useState(false)
+  const [progreso, setProgreso] = useState<{ done: number; total: number } | null>(null)
+
+  const onDrop = async (accepted: File[]) => {
+    if (accepted.length === 0) return
+    if (!delegacionId || !delegacionCodigo || !user) {
+      toast.error("Selecciona una delegación antes de subir facturas")
+      return
+    }
+
+    setUploading(true)
+    setProgreso({ done: 0, total: accepted.length })
+    let creadas = 0
+    try {
+      for (const file of accepted) {
+        const validation = FileService.validateFile(file, "facturas")
+        if (!validation.valid) {
+          toast.error(`${file.name}: ${validation.error}`)
+          continue
+        }
+
+        const factura = await DatabaseService.createFactura({
+          delegacion_id: delegacionId,
+          concepto: conceptoDesdeNombre(file.name) || null,
+          estado: "bandeja",
+          origen: "subida",
+          creado_por: user.id,
+        })
+
+        try {
+          const upload = await FileService.uploadFileForEntity(
+            file,
+            { scope: "factura", id: factura.id },
+            "facturas",
+            delegacionCodigo,
+          )
+          await DatabaseService.registrarArchivoFactura(factura.id, delegacionId, {
+            nombre_original: file.name,
+            nombre_archivo: upload.path.split("/").pop() || file.name,
+            tipo_mime: file.type,
+            tamanoBytes: file.size,
+            bucket: upload.bucket,
+            path_storage: upload.path,
+            url_publica: upload.url,
+            subido_por: user.id,
+          })
+        } catch (err) {
+          // Si falla la subida del archivo, no dejamos la factura vacía colgando.
+          await DatabaseService.deleteFactura(factura.id).catch(() => undefined)
+          throw err
+        }
+
+        creadas += 1
+        setProgreso({ done: creadas, total: accepted.length })
+      }
+
+      if (creadas > 0) {
+        toast.success(
+          creadas === 1 ? "Factura añadida a la bandeja" : `${creadas} facturas añadidas a la bandeja`,
+        )
+        await onCreated()
+      }
+    } catch (err) {
+      toast.error("No se pudo subir: " + (err instanceof Error ? err.message : "error desconocido"))
+    } finally {
+      setUploading(false)
+      setProgreso(null)
+    }
+  }
+
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+    onDrop,
+    multiple: true,
+    disabled: disabled || uploading || !delegacionId,
+    maxSize: 20 * 1024 * 1024,
+  })
+
+  return (
+    <div
+      {...getRootProps()}
+      className={cn(
+        "group/dz relative flex cursor-pointer flex-col items-center justify-center gap-2 overflow-hidden rounded-2xl border-2 border-dashed border-border/70 bg-gradient-to-br from-muted/40 via-background to-muted/20 px-4 py-8 text-center transition-[border-color,background-color] duration-200",
+        isDragActive
+          ? "border-primary bg-primary/5"
+          : "hover:border-primary/50 hover:bg-primary/[0.03]",
+        (disabled || uploading || !delegacionId) && "cursor-not-allowed opacity-60",
+      )}
+    >
+      <input {...getInputProps()} />
+      <div
+        className={cn(
+          "flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10 text-primary transition-transform duration-200",
+          isDragActive ? "scale-110" : "group-hover/dz:scale-105",
+        )}
+      >
+        {uploading ? <Loader2 className="h-5 w-5 animate-spin" /> : <Inbox className="h-5 w-5" />}
+      </div>
+      {uploading && progreso ? (
+        <div className="text-sm font-medium">
+          Subiendo {progreso.done + 1 > progreso.total ? progreso.total : progreso.done + 1} de{" "}
+          {progreso.total}…
+        </div>
+      ) : (
+        <>
+          <div className="text-sm font-semibold tracking-tight">
+            {isDragActive ? "Suelta las facturas aquí" : "Arrastra facturas a la bandeja"}
+          </div>
+          <p className="max-w-md text-xs leading-relaxed text-muted-foreground">
+            Suelta uno o varios PDF o imágenes y se creará una factura por archivo, lista para
+            completar el proveedor y vincular con su movimiento. También puedes pulsar para elegir
+            archivos.
+          </p>
+        </>
+      )}
+    </div>
+  )
+}

--- a/components/facturas/facturas-manager.tsx
+++ b/components/facturas/facturas-manager.tsx
@@ -1,0 +1,435 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import {
+  CheckCircle2,
+  Clock,
+  Inbox,
+  Loader2,
+  Mail,
+  Plus,
+  ReceiptText,
+  Search,
+  Sparkles,
+  type LucideIcon,
+} from "lucide-react"
+import { toast } from "sonner"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { EmptyState } from "@/components/ui/empty-state"
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet"
+import { cn } from "@/lib/utils"
+import { useAuth } from "@/contexts/auth-context"
+import { useDelegationContext } from "@/contexts/delegation-context"
+import { useCategorias } from "@/hooks/use-categorias"
+import { useContactos } from "@/hooks/use-contactos"
+import { useDebouncedState } from "@/hooks/use-debounced-state"
+import { useDelegationRole } from "@/hooks/use-delegation-role"
+import useIsAdmin from "@/hooks/use-is-admin"
+import { useFacturas } from "@/hooks/use-facturas"
+import { formatCurrency } from "@/lib/utils/format"
+import { FACTURA_ESTADO_INFO } from "@/lib/utils/facturas"
+import type { FacturaConRelaciones, FacturaEstado } from "@/lib/types/database"
+import { FacturaCard } from "./factura-card"
+import { FacturaForm, type FacturaFormSubmit } from "./factura-form"
+import { FacturaInboxDropzone } from "./factura-inbox-dropzone"
+import { VincularMovimientoDialog } from "./vincular-movimiento-dialog"
+import { DeleteFacturaDialog } from "./delete-factura-dialog"
+
+type TabValue = "bandeja" | "sin_pagar" | "pagadas" | "todas"
+
+const TAB_ORDER: TabValue[] = ["bandeja", "sin_pagar", "pagadas", "todas"]
+
+const TAB_LABELS: Record<TabValue, string> = {
+  bandeja: "Bandeja",
+  sin_pagar: "Sin pagar",
+  pagadas: "Pagadas",
+  todas: "Todas",
+}
+
+const TAB_ESTADOS: Record<Exclude<TabValue, "todas">, FacturaEstado[]> = {
+  bandeja: ["bandeja"],
+  sin_pagar: ["sin_pagar"],
+  pagadas: ["pagada", "pagada_fuera"],
+}
+
+export function FacturasManager() {
+  const { selectedDelegation } = useDelegationContext()
+  const { user } = useAuth()
+  const isAdmin = useIsAdmin()
+  const { role } = useDelegationRole(selectedDelegation)
+  const canEdit = isAdmin || role === "gestor_central" || role === "tesorero"
+  const canManageGlobalContact = isAdmin || role === "gestor_central"
+
+  const [tab, setTab] = useState<TabValue>("bandeja")
+  const { value: busquedaDebounced, immediateValue: busqueda, setValue: setBusqueda } = useDebouncedState("", 250)
+
+  const estadosForTab = useMemo<FacturaEstado[] | undefined>(() => {
+    if (tab === "todas") return undefined
+    return TAB_ESTADOS[tab]
+  }, [tab])
+
+  const {
+    facturas,
+    loading,
+    error,
+    refetch,
+    createFactura,
+    updateFactura,
+    deleteFactura,
+    linkToMovimiento,
+    unlinkFromMovimiento,
+  } = useFacturas(selectedDelegation, {
+    estados: estadosForTab,
+    busqueda: busquedaDebounced || undefined,
+  })
+
+  // Recuento global independiente del filtro de tab/búsqueda.
+  const { totals: globalTotals, refetch: refetchTotals } = useFacturas(selectedDelegation, {})
+
+  const { contactos, createContacto } = useContactos(selectedDelegation, { incluirGlobales: true })
+  const { categorias } = useCategorias(selectedDelegation, { includeGlobal: true, includeInactive: false })
+
+  const [formOpen, setFormOpen] = useState(false)
+  const [editing, setEditing] = useState<FacturaConRelaciones | null>(null)
+  const [deleting, setDeleting] = useState<FacturaConRelaciones | null>(null)
+  const [vinculando, setVinculando] = useState<FacturaConRelaciones | null>(null)
+
+  const refreshAll = async () => {
+    await Promise.all([refetch(), refetchTotals()])
+  }
+
+  const handleSubmitForm = async (payload: FacturaFormSubmit) => {
+    if (editing) {
+      if (!payload.update) return
+      await updateFactura(editing.id, payload.update)
+    } else {
+      if (!payload.insert) return
+      await createFactura({ ...payload.insert, creado_por: user?.id ?? null })
+    }
+    await refetchTotals()
+    setFormOpen(false)
+    setEditing(null)
+  }
+
+  const openCreate = () => {
+    setEditing(null)
+    setFormOpen(true)
+  }
+
+  const openEdit = (factura: FacturaConRelaciones) => {
+    setEditing(factura)
+    setFormOpen(true)
+  }
+
+  const marcarPagadaFuera = async (facturaId: string) => {
+    await updateFactura(facturaId, { estado: "pagada_fuera" })
+    await refetchTotals()
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div className="space-y-2">
+          <div className="flex items-center gap-3">
+            <div className="h-10 w-2 rounded-full bg-gradient-to-b from-primary via-primary/70 to-primary/40 shadow-lg shadow-primary/30" />
+            <h1 className="text-3xl font-extrabold sm:text-4xl bg-gradient-to-r from-foreground via-foreground/90 to-foreground/70 bg-clip-text">
+              Facturas
+            </h1>
+          </div>
+          <p className="ml-5 max-w-2xl pl-4 text-sm text-muted-foreground">
+            La bandeja de entrada de las facturas de la delegación. Sube los archivos según lleguen,
+            apunta el proveedor y vincúlalas con su movimiento bancario en un par de clicks.
+          </p>
+        </div>
+        {canEdit && (
+          <Button onClick={openCreate}>
+            <Plus className="mr-1.5 h-4 w-4" /> Nueva factura
+          </Button>
+        )}
+      </div>
+
+      {/* Bandeja de entrada (dropzone) */}
+      {canEdit && (
+        <FacturaInboxDropzone
+          delegacionId={selectedDelegation}
+          onCreated={async () => {
+            setTab("bandeja")
+            await refreshAll()
+          }}
+        />
+      )}
+
+      {/* KPIs */}
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <KpiCard
+          label="En bandeja"
+          value={String(globalTotals.bandeja)}
+          sub="por revisar"
+          icon={Inbox}
+          accent="sky"
+        />
+        <KpiCard
+          label="Sin pagar"
+          value={String(globalTotals.sin_pagar)}
+          sub={globalTotals.sinPagarImporte > 0 ? formatCurrency(globalTotals.sinPagarImporte) : "pendientes de pago"}
+          icon={Clock}
+          accent="amber"
+        />
+        <KpiCard
+          label="Pagadas"
+          value={String(globalTotals.pagada + globalTotals.pagada_fuera)}
+          sub={
+            globalTotals.pagada_fuera > 0
+              ? `${globalTotals.pagada} vinculadas · ${globalTotals.pagada_fuera} fuera`
+              : "conciliadas"
+          }
+          icon={CheckCircle2}
+          accent="emerald"
+        />
+        <KpiCard
+          label="Total"
+          value={String(globalTotals.total)}
+          sub="facturas"
+          icon={ReceiptText}
+          accent="primary"
+        />
+      </div>
+
+      {/* Tabs */}
+      <Tabs value={tab} onValueChange={(v) => setTab(v as TabValue)}>
+        <TabsList className="grid w-full grid-cols-4 sm:mx-auto sm:flex sm:w-fit">
+          {TAB_ORDER.map((t) => {
+            const dotClass =
+              t === "todas" ? null : FACTURA_ESTADO_INFO[TAB_ESTADOS[t][0]].dotClass
+            const n =
+              t === "todas"
+                ? globalTotals.total
+                : t === "bandeja"
+                  ? globalTotals.bandeja
+                  : t === "sin_pagar"
+                    ? globalTotals.sin_pagar
+                    : globalTotals.pagada + globalTotals.pagada_fuera
+            return (
+              <TabsTrigger key={t} value={t} className="gap-1.5">
+                {dotClass ? <span className={cn("h-1.5 w-1.5 rounded-full", dotClass)} aria-hidden /> : null}
+                <span className="hidden sm:inline">{TAB_LABELS[t]}</span>
+                <span className="sm:hidden">{TAB_LABELS[t].slice(0, 3)}</span>
+                {n > 0 && <span className="text-[10px] text-muted-foreground tabular-nums">{n}</span>}
+              </TabsTrigger>
+            )
+          })}
+        </TabsList>
+      </Tabs>
+
+      {/* Buscador */}
+      <div className="relative max-w-xl">
+        <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          value={busqueda}
+          onChange={(e) => setBusqueda(e.target.value)}
+          placeholder="Buscar por concepto, número o notas…"
+          className="pl-9"
+        />
+      </div>
+
+      {/* Lista */}
+      {loading && facturas.length === 0 ? (
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" /> Cargando facturas…
+        </div>
+      ) : error ? (
+        <EmptyState title="No se pudieron cargar las facturas" description={error} />
+      ) : facturas.length === 0 ? (
+        <EmptyState
+          icon={<ReceiptText className="h-6 w-6" />}
+          title={
+            tab === "bandeja"
+              ? "La bandeja está vacía"
+              : tab === "sin_pagar"
+                ? "No hay facturas sin pagar"
+                : tab === "pagadas"
+                  ? "Aún no hay facturas pagadas"
+                  : "Aún no hay facturas"
+          }
+          description={
+            tab === "bandeja"
+              ? "Arrastra los archivos de factura arriba y aparecerán aquí para revisar y conciliar."
+              : tab === "sin_pagar"
+                ? "Cuando registres una factura pendiente de pago, la verás en esta pestaña."
+                : tab === "pagadas"
+                  ? "Al vincular una factura con su movimiento (o marcarla pagada fuera) aparecerá aquí."
+                  : "Sube la primera factura a la bandeja o créala a mano."
+          }
+        >
+          {canEdit && tab !== "pagadas" && (
+            <Button onClick={openCreate}>
+              <Plus className="mr-1.5 h-4 w-4" /> Crear factura
+            </Button>
+          )}
+        </EmptyState>
+      ) : (
+        <div className="grid grid-cols-1 gap-3 lg:grid-cols-2 xl:grid-cols-3">
+          {facturas.map((factura) => (
+            <FacturaCard
+              key={factura.id}
+              factura={factura}
+              canEdit={canEdit}
+              onEdit={() => openEdit(factura)}
+              onDelete={() => setDeleting(factura)}
+              onVincular={() => setVinculando(factura)}
+              onMarcarPagadaFuera={async () => {
+                try {
+                  await marcarPagadaFuera(factura.id)
+                  toast.success("Factura marcada como pagada fuera de MCM Bank")
+                } catch (err) {
+                  toast.error("No se pudo actualizar: " + (err instanceof Error ? err.message : "error"))
+                }
+              }}
+              onDesvincular={async () => {
+                try {
+                  await unlinkFromMovimiento(factura.id)
+                  await refetchTotals()
+                  toast.success("Movimiento desvinculado")
+                } catch (err) {
+                  toast.error("No se pudo desvincular: " + (err instanceof Error ? err.message : "error"))
+                }
+              }}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Integraciones futuras */}
+      <Card className="border-dashed border-border/70 bg-muted/20">
+        <CardContent className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center">
+          <div className="flex items-center gap-2 text-sm font-semibold tracking-tight">
+            <Sparkles className="h-4 w-4 text-primary" /> Próximamente
+          </div>
+          <div className="flex flex-1 flex-col gap-2 text-xs text-muted-foreground sm:flex-row sm:gap-6">
+            <span className="inline-flex items-center gap-1.5">
+              <Mail className="h-3.5 w-3.5 shrink-0" />
+              Buzón de email por delegación: reenvía la factura y aparecerá sola en la bandeja.
+            </span>
+            <span className="inline-flex items-center gap-1.5">
+              <Sparkles className="h-3.5 w-3.5 shrink-0" />
+              Lectura automática con IA: proveedor, fecha e importe rellenos al subir el archivo.
+            </span>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Formulario */}
+      <Sheet open={formOpen} onOpenChange={(open) => { setFormOpen(open); if (!open) setEditing(null) }}>
+        <SheetContent side="right" className="w-full sm:max-w-xl overflow-y-auto">
+          <SheetHeader className="mb-2">
+            <SheetTitle>{editing ? "Editar factura" : "Nueva factura"}</SheetTitle>
+          </SheetHeader>
+          <FacturaForm
+            delegacionId={selectedDelegation}
+            factura={editing}
+            contactos={contactos}
+            categorias={categorias}
+            canManageGlobalContact={canManageGlobalContact}
+            onCreateContacto={async (payload) => {
+              if (!payload.insert) return
+              return await createContacto({ ...payload.insert, creado_por: user?.id ?? null })
+            }}
+            onSubmit={handleSubmitForm}
+            onCancel={() => { setFormOpen(false); setEditing(null) }}
+          />
+        </SheetContent>
+      </Sheet>
+
+      {/* Vincular con movimiento */}
+      {selectedDelegation && (
+        <VincularMovimientoDialog
+          factura={vinculando}
+          open={Boolean(vinculando)}
+          onOpenChange={(open) => !open && setVinculando(null)}
+          delegacionId={selectedDelegation}
+          onLink={async (facturaId, movimientoId, creadoPor) => {
+            await linkToMovimiento(facturaId, movimientoId, creadoPor)
+            await refetchTotals()
+          }}
+          onMarcarPagadaFuera={marcarPagadaFuera}
+        />
+      )}
+
+      {/* Borrar */}
+      <DeleteFacturaDialog
+        factura={deleting}
+        open={Boolean(deleting)}
+        onOpenChange={(open) => !open && setDeleting(null)}
+        onDelete={async (id) => {
+          await deleteFactura(id)
+          await refetchTotals()
+          setDeleting(null)
+          toast.success("Factura eliminada")
+        }}
+      />
+    </div>
+  )
+}
+
+type KpiAccent = "sky" | "amber" | "emerald" | "primary"
+
+const ACCENT_CLASSES: Record<KpiAccent, { bg: string; icon: string; border: string }> = {
+  sky: {
+    bg: "bg-sky-50/70 dark:bg-sky-950/20",
+    icon: "text-sky-700 dark:text-sky-300",
+    border: "border-sky-200/60 dark:border-sky-900/40",
+  },
+  amber: {
+    bg: "bg-amber-50/70 dark:bg-amber-950/20",
+    icon: "text-amber-700 dark:text-amber-300",
+    border: "border-amber-200/60 dark:border-amber-900/40",
+  },
+  emerald: {
+    bg: "bg-emerald-50/70 dark:bg-emerald-950/20",
+    icon: "text-emerald-700 dark:text-emerald-300",
+    border: "border-emerald-200/60 dark:border-emerald-900/40",
+  },
+  primary: {
+    bg: "bg-primary/5",
+    icon: "text-primary",
+    border: "border-primary/20",
+  },
+}
+
+function KpiCard({
+  label,
+  value,
+  sub,
+  icon: Icon,
+  accent,
+}: {
+  label: string
+  value: string
+  sub?: string
+  icon: LucideIcon
+  accent: KpiAccent
+}) {
+  const a = ACCENT_CLASSES[accent]
+  return (
+    <Card className={cn("border", a.border)}>
+      <CardContent className="p-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0 flex-1 space-y-1">
+            <div className="text-[10px] font-medium uppercase tracking-widest text-muted-foreground">
+              {label}
+            </div>
+            <div className="truncate text-xl font-bold tracking-tight tabular-nums">{value}</div>
+            {sub && <div className="text-[11px] text-muted-foreground">{sub}</div>}
+          </div>
+          <div className={cn("flex h-9 w-9 shrink-0 items-center justify-center rounded-xl", a.bg)}>
+            <Icon className={cn("h-4 w-4", a.icon)} aria-hidden />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/facturas/facturas-manager.tsx
+++ b/components/facturas/facturas-manager.tsx
@@ -44,14 +44,14 @@ const TAB_ORDER: TabValue[] = ["bandeja", "sin_pagar", "pagadas", "todas"]
 
 const TAB_LABELS: Record<TabValue, string> = {
   bandeja: "Bandeja",
-  sin_pagar: "Sin pagar",
+  sin_pagar: "Sin cerrar",
   pagadas: "Pagadas",
   todas: "Todas",
 }
 
 const TAB_ESTADOS: Record<Exclude<TabValue, "todas">, FacturaEstado[]> = {
   bandeja: ["bandeja"],
-  sin_pagar: ["sin_pagar"],
+  sin_pagar: ["sin_pagar", "pagada_parcial"],
   pagadas: ["pagada", "pagada_fuera"],
 }
 
@@ -173,9 +173,15 @@ export function FacturasManager() {
           accent="sky"
         />
         <KpiCard
-          label="Sin pagar"
-          value={String(globalTotals.sin_pagar)}
-          sub={globalTotals.sinPagarImporte > 0 ? formatCurrency(globalTotals.sinPagarImporte) : "pendientes de pago"}
+          label="Sin cerrar"
+          value={String(globalTotals.sin_pagar + globalTotals.pagada_parcial)}
+          sub={
+            globalTotals.pagada_parcial > 0
+              ? `${globalTotals.pagada_parcial} con pago parcial`
+              : globalTotals.sinPagarImporte > 0
+                ? formatCurrency(globalTotals.sinPagarImporte)
+                : "pendientes de pago"
+          }
           icon={Clock}
           accent="amber"
         />
@@ -211,7 +217,7 @@ export function FacturasManager() {
                 : t === "bandeja"
                   ? globalTotals.bandeja
                   : t === "sin_pagar"
-                    ? globalTotals.sin_pagar
+                    ? globalTotals.sin_pagar + globalTotals.pagada_parcial
                     : globalTotals.pagada + globalTotals.pagada_fuera
             return (
               <TabsTrigger key={t} value={t} className="gap-1.5">
@@ -289,9 +295,9 @@ export function FacturasManager() {
                   toast.error("No se pudo actualizar: " + (err instanceof Error ? err.message : "error"))
                 }
               }}
-              onDesvincular={async () => {
+              onDesvincular={async (movimientoId) => {
                 try {
-                  await unlinkFromMovimiento(factura.id)
+                  await unlinkFromMovimiento(factura.id, movimientoId)
                   await refetchTotals()
                   toast.success("Movimiento desvinculado")
                 } catch (err) {

--- a/components/facturas/vincular-factura-dialog.tsx
+++ b/components/facturas/vincular-factura-dialog.tsx
@@ -1,0 +1,145 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { toast } from "sonner"
+import { Loader2, ReceiptText } from "lucide-react"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+import { useAuth } from "@/contexts/auth-context"
+import { DatabaseService } from "@/lib/services/database"
+import { formatCurrency, formatDate } from "@/lib/utils/format"
+import { FACTURA_ESTADO_INFO } from "@/lib/utils/facturas"
+import type { FacturaConRelaciones } from "@/lib/types/database"
+
+interface VincularFacturaDialogProps {
+  movimientoId: string | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onLinked?: () => void | Promise<void>
+}
+
+/**
+ * Desde el lado movimiento: elegir una factura existente (sin movimiento
+ * vinculado) para conciliarla con este movimiento.
+ */
+export function VincularFacturaDialog({
+  movimientoId,
+  open,
+  onOpenChange,
+  onLinked,
+}: VincularFacturaDialogProps) {
+  const { user } = useAuth()
+  const [candidatas, setCandidatas] = useState<FacturaConRelaciones[]>([])
+  const [loading, setLoading] = useState(false)
+  const [seleccion, setSeleccion] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  useEffect(() => {
+    if (!open || !movimientoId) return
+    setLoading(true)
+    DatabaseService.findCandidatosFacturaParaMovimiento(movimientoId, { limit: 40 })
+      .then((list) => setCandidatas(list))
+      .catch(() => setCandidatas([]))
+      .finally(() => setLoading(false))
+  }, [open, movimientoId])
+
+  useEffect(() => {
+    if (open) return
+    setCandidatas([])
+    setSeleccion(null)
+  }, [open])
+
+  const handleLink = async () => {
+    if (!movimientoId || !seleccion) return
+    setBusy(true)
+    try {
+      await DatabaseService.linkFacturaToMovimiento(seleccion, movimientoId, user?.id)
+      toast.success("Factura vinculada al movimiento")
+      onOpenChange(false)
+      await onLinked?.()
+    } catch (err) {
+      toast.error("No se pudo vincular: " + (err instanceof Error ? err.message : "error desconocido"))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => !busy && onOpenChange(v)}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <ReceiptText className="h-5 w-5 text-primary" />
+            Vincular una factura existente
+          </DialogTitle>
+          <DialogDescription>
+            Facturas de la bandeja sin movimiento vinculado, con importe compatible, ordenadas por
+            afinidad.
+          </DialogDescription>
+        </DialogHeader>
+
+        {loading ? (
+          <div className="flex items-center gap-2 py-4 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" /> Buscando facturas…
+          </div>
+        ) : candidatas.length === 0 ? (
+          <div className="rounded-lg border border-dashed border-border bg-muted/30 px-3 py-6 text-center text-sm text-muted-foreground">
+            No hay facturas compatibles en la bandeja. Sube la factura desde la pestaña de archivos y
+            quedará vinculada automáticamente.
+          </div>
+        ) : (
+          <div className="max-h-72 space-y-1.5 overflow-y-auto pr-1">
+            {candidatas.map((f) => {
+              const selected = seleccion === f.id
+              const estadoInfo = FACTURA_ESTADO_INFO[f.estado]
+              const titulo = f.concepto?.trim() || f.archivos?.[0]?.nombre_original || "Factura sin título"
+              return (
+                <button
+                  key={f.id}
+                  type="button"
+                  onClick={() => setSeleccion(f.id)}
+                  className={cn(
+                    "w-full rounded-lg border p-2.5 text-left text-sm transition-colors",
+                    selected
+                      ? "border-primary bg-primary/5 shadow-sm"
+                      : "border-border bg-background hover:border-primary/40 hover:bg-muted/40",
+                  )}
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="truncate font-medium">{titulo}</span>
+                    <span className="shrink-0 font-mono text-xs">
+                      {f.importe != null ? formatCurrency(Number(f.importe)) : "—"}
+                    </span>
+                  </div>
+                  <div className="mt-0.5 flex flex-wrap items-center gap-1.5 text-[11px] text-muted-foreground">
+                    <span className={cn("h-1.5 w-1.5 rounded-full", estadoInfo.dotClass)} aria-hidden />
+                    <span>{estadoInfo.label}</span>
+                    {f.fecha_emision && <span>· {formatDate(f.fecha_emision)}</span>}
+                    {f.contacto?.nombre && <span>· {f.contacto.nombre}</span>}
+                  </div>
+                </button>
+              )
+            })}
+          </div>
+        )}
+
+        <DialogFooter className="gap-2 sm:gap-2">
+          <Button variant="outline" disabled={busy} onClick={() => onOpenChange(false)}>
+            Cancelar
+          </Button>
+          <Button onClick={handleLink} disabled={busy || !seleccion}>
+            {busy ? "Vinculando…" : "Vincular factura"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/facturas/vincular-factura-dialog.tsx
+++ b/components/facturas/vincular-factura-dialog.tsx
@@ -81,8 +81,8 @@ export function VincularFacturaDialog({
             Vincular una factura existente
           </DialogTitle>
           <DialogDescription>
-            Facturas de la bandeja sin movimiento vinculado, con importe compatible, ordenadas por
-            afinidad.
+            Facturas de la bandeja aún no cubiertas del todo, con importe pendiente compatible,
+            ordenadas por afinidad.
           </DialogDescription>
         </DialogHeader>
 

--- a/components/facturas/vincular-movimiento-dialog.tsx
+++ b/components/facturas/vincular-movimiento-dialog.tsx
@@ -16,7 +16,7 @@ import { cn } from "@/lib/utils"
 import { useAuth } from "@/contexts/auth-context"
 import { DatabaseService } from "@/lib/services/database"
 import { formatCurrency, formatDate } from "@/lib/utils/format"
-import { esMatchDirecto, scoreCandidatoMovimiento } from "@/lib/utils/facturas"
+import { esMatchDirecto, importePagadoFactura, importePendienteFactura, scoreCandidatoMovimiento } from "@/lib/utils/facturas"
 import type { FacturaConRelaciones, MovimientoConRelaciones } from "@/lib/types/database"
 
 interface VincularMovimientoDialogProps {
@@ -42,6 +42,12 @@ export function VincularMovimientoDialog({
   const [seleccion, setSeleccion] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
 
+  // Importe que le falta cubrir a la factura (total menos lo ya vinculado en
+  // otros movimientos). Se busca por este valor, no por el importe total, para
+  // soportar pagos en varios plazos.
+  const importePendiente = useMemo(() => (factura ? importePendienteFactura(factura) : null), [factura])
+  const yaPagado = useMemo(() => (factura ? importePagadoFactura(factura) : 0), [factura])
+
   // Cargar candidatos al abrir
   useEffect(() => {
     if (!open || !factura) return
@@ -49,7 +55,7 @@ export function VincularMovimientoDialog({
     DatabaseService.findCandidatosMovimientoParaFactura(
       delegacionId,
       {
-        importe: factura.importe,
+        importe: importePendiente,
         fecha_emision: factura.fecha_emision,
         contacto_id: factura.contacto_id,
       },
@@ -58,7 +64,7 @@ export function VincularMovimientoDialog({
       .then((list) => setCandidatos(list))
       .catch(() => setCandidatos([]))
       .finally(() => setCandidatosLoading(false))
-  }, [open, factura, delegacionId])
+  }, [open, factura, delegacionId, importePendiente])
 
   // Reset al cerrar
   useEffect(() => {
@@ -71,11 +77,11 @@ export function VincularMovimientoDialog({
     if (!factura) return []
     return candidatos.map((m) =>
       scoreCandidatoMovimiento(
-        { importe: factura.importe, fecha_emision: factura.fecha_emision, contacto_id: factura.contacto_id },
+        { importe: importePendiente, fecha_emision: factura.fecha_emision, contacto_id: factura.contacto_id },
         m,
       ),
     )
-  }, [candidatos, factura])
+  }, [candidatos, factura, importePendiente])
 
   const matchDirecto = useMemo(() => esMatchDirecto(scores), [scores])
 
@@ -124,7 +130,7 @@ export function VincularMovimientoDialog({
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Link2 className="h-5 w-5 text-primary" />
-            Vincular factura a un movimiento
+            {yaPagado > 0 ? "Vincular otro pago a la factura" : "Vincular factura a un movimiento"}
           </DialogTitle>
           <DialogDescription>
             {titulo}
@@ -137,8 +143,15 @@ export function VincularMovimientoDialog({
           </DialogDescription>
         </DialogHeader>
 
+        {yaPagado > 0 && importePendiente != null && (
+          <p className="rounded-md bg-orange-50 px-2.5 py-1.5 text-xs text-orange-800 dark:bg-orange-950/30 dark:text-orange-200">
+            Ya hay {formatCurrency(yaPagado)} vinculados. Buscando movimientos por el resto:{" "}
+            <span className="font-semibold">{formatCurrency(importePendiente)}</span>.
+          </p>
+        )}
+
         <p className="text-xs text-muted-foreground">
-          {factura.importe != null
+          {importePendiente != null
             ? "Gastos con un importe parecido (con un pelín de margen) sin factura vinculada, ordenados por afinidad."
             : "Últimos gastos sin factura vinculada. Añade el importe a la factura para afinar la búsqueda."}
         </p>

--- a/components/facturas/vincular-movimiento-dialog.tsx
+++ b/components/facturas/vincular-movimiento-dialog.tsx
@@ -1,0 +1,237 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+import { toast } from "sonner"
+import { BadgeCheck, Link2, Loader2, Sparkles } from "lucide-react"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+import { useAuth } from "@/contexts/auth-context"
+import { DatabaseService } from "@/lib/services/database"
+import { formatCurrency, formatDate } from "@/lib/utils/format"
+import { esMatchDirecto, scoreCandidatoMovimiento } from "@/lib/utils/facturas"
+import type { FacturaConRelaciones, MovimientoConRelaciones } from "@/lib/types/database"
+
+interface VincularMovimientoDialogProps {
+  factura: FacturaConRelaciones | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  delegacionId: string
+  onLink: (facturaId: string, movimientoId: string, creadoPor?: string) => Promise<void>
+  onMarcarPagadaFuera?: (facturaId: string) => Promise<void>
+}
+
+export function VincularMovimientoDialog({
+  factura,
+  open,
+  onOpenChange,
+  delegacionId,
+  onLink,
+  onMarcarPagadaFuera,
+}: VincularMovimientoDialogProps) {
+  const { user } = useAuth()
+  const [candidatos, setCandidatos] = useState<MovimientoConRelaciones[]>([])
+  const [candidatosLoading, setCandidatosLoading] = useState(false)
+  const [seleccion, setSeleccion] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  // Cargar candidatos al abrir
+  useEffect(() => {
+    if (!open || !factura) return
+    setCandidatosLoading(true)
+    DatabaseService.findCandidatosMovimientoParaFactura(
+      delegacionId,
+      {
+        importe: factura.importe,
+        fecha_emision: factura.fecha_emision,
+        contacto_id: factura.contacto_id,
+      },
+      { limit: 30 },
+    )
+      .then((list) => setCandidatos(list))
+      .catch(() => setCandidatos([]))
+      .finally(() => setCandidatosLoading(false))
+  }, [open, factura, delegacionId])
+
+  // Reset al cerrar
+  useEffect(() => {
+    if (open) return
+    setCandidatos([])
+    setSeleccion(null)
+  }, [open])
+
+  const scores = useMemo(() => {
+    if (!factura) return []
+    return candidatos.map((m) =>
+      scoreCandidatoMovimiento(
+        { importe: factura.importe, fecha_emision: factura.fecha_emision, contacto_id: factura.contacto_id },
+        m,
+      ),
+    )
+  }, [candidatos, factura])
+
+  const matchDirecto = useMemo(() => esMatchDirecto(scores), [scores])
+
+  // Pre-selecciona el match directo para minimizar clicks
+  useEffect(() => {
+    if (matchDirecto && candidatos[0] && !seleccion) {
+      setSeleccion(candidatos[0].id)
+    }
+  }, [matchDirecto, candidatos, seleccion])
+
+  const handleLink = async () => {
+    if (!factura || !seleccion) return
+    setBusy(true)
+    try {
+      await onLink(factura.id, seleccion, user?.id)
+      toast.success("Factura vinculada al movimiento")
+      onOpenChange(false)
+    } catch (err) {
+      toast.error("No se pudo vincular: " + (err instanceof Error ? err.message : "error desconocido"))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handlePagadaFuera = async () => {
+    if (!factura || !onMarcarPagadaFuera) return
+    setBusy(true)
+    try {
+      await onMarcarPagadaFuera(factura.id)
+      toast.success("Factura marcada como pagada fuera de MCM Bank")
+      onOpenChange(false)
+    } catch (err) {
+      toast.error("No se pudo actualizar: " + (err instanceof Error ? err.message : "error desconocido"))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (!factura) return null
+
+  const titulo = factura.concepto?.trim() || factura.archivos?.[0]?.nombre_original || "Factura"
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => !busy && onOpenChange(v)}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Link2 className="h-5 w-5 text-primary" />
+            Vincular factura a un movimiento
+          </DialogTitle>
+          <DialogDescription>
+            {titulo}
+            {factura.importe != null && (
+              <>
+                {" "}· <span className="font-semibold">{formatCurrency(Number(factura.importe))}</span>
+              </>
+            )}
+            {factura.contacto?.nombre && <> · {factura.contacto.nombre}</>}
+          </DialogDescription>
+        </DialogHeader>
+
+        <p className="text-xs text-muted-foreground">
+          {factura.importe != null
+            ? "Gastos con un importe parecido (con un pelín de margen) sin factura vinculada, ordenados por afinidad."
+            : "Últimos gastos sin factura vinculada. Añade el importe a la factura para afinar la búsqueda."}
+        </p>
+
+        {candidatosLoading ? (
+          <div className="flex items-center gap-2 py-4 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" /> Buscando candidatos…
+          </div>
+        ) : candidatos.length === 0 ? (
+          <div className="rounded-lg border border-dashed border-border bg-muted/30 px-3 py-6 text-center text-sm text-muted-foreground">
+            No hay movimientos candidatos. Puede que aún no se haya importado del banco, o que se
+            pagara fuera de MCM Bank.
+          </div>
+        ) : (
+          <div className="max-h-72 space-y-1.5 overflow-y-auto pr-1">
+            {candidatos.map((m, idx) => {
+              const s = scores[idx]
+              const selected = seleccion === m.id
+              const esTop = idx === 0 && matchDirecto
+              return (
+                <button
+                  key={m.id}
+                  type="button"
+                  onClick={() => setSeleccion(m.id)}
+                  className={cn(
+                    "w-full rounded-lg border p-2.5 text-left text-sm transition-colors",
+                    selected
+                      ? "border-primary bg-primary/5 shadow-sm"
+                      : "border-border bg-background hover:border-primary/40 hover:bg-muted/40",
+                  )}
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="truncate font-medium">{m.concepto}</span>
+                    <span className="font-mono text-xs text-rose-700 dark:text-rose-400">
+                      {formatCurrency(Number(m.importe))}
+                    </span>
+                  </div>
+                  <div className="mt-0.5 flex flex-wrap items-center gap-1.5 text-[11px] text-muted-foreground">
+                    <span>{formatDate(m.fecha)}</span>
+                    {m.cuenta?.nombre && <span>· {m.cuenta.nombre}</span>}
+                    {esTop && (
+                      <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-1.5 py-0.5 text-[10px] font-semibold text-primary">
+                        <Sparkles className="h-3 w-3" /> Match directo
+                      </span>
+                    )}
+                    {s?.importeExacto && !esTop && (
+                      <span className="rounded-full bg-emerald-100 px-1.5 py-0.5 text-[10px] font-medium text-emerald-700 dark:bg-emerald-950/50 dark:text-emerald-300">
+                        importe exacto
+                      </span>
+                    )}
+                    {s?.fechaCercana && (
+                      <span className="rounded-full bg-sky-100 px-1.5 py-0.5 text-[10px] font-medium text-sky-700 dark:bg-sky-950/50 dark:text-sky-300">
+                        fecha cercana
+                      </span>
+                    )}
+                    {s?.mismoContacto && (
+                      <span className="rounded-full bg-violet-100 px-1.5 py-0.5 text-[10px] font-medium text-violet-700 dark:bg-violet-950/50 dark:text-violet-300">
+                        mismo contacto
+                      </span>
+                    )}
+                  </div>
+                </button>
+              )
+            })}
+          </div>
+        )}
+
+        <DialogFooter className="gap-2 sm:justify-between">
+          {onMarcarPagadaFuera && factura.estado !== "pagada_fuera" ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              disabled={busy}
+              onClick={handlePagadaFuera}
+              className="justify-start text-muted-foreground"
+              title="La factura está pagada, pero el movimiento no está en MCM Bank"
+            >
+              <BadgeCheck className="mr-1.5 h-3.5 w-3.5" /> Pagada fuera de MCM Bank
+            </Button>
+          ) : (
+            <span />
+          )}
+          <div className="flex items-center gap-2">
+            <Button variant="outline" disabled={busy} onClick={() => onOpenChange(false)}>
+              Cancelar
+            </Button>
+            <Button onClick={handleLink} disabled={busy || !seleccion}>
+              {busy ? "Vinculando…" : "Vincular"}
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -82,8 +82,8 @@ function SidebarContent({ className, collapsed = false, counts, countsLoading }:
       name: "Facturas",
       href: "/facturas",
       icon: FileText,
-      count: null,
-      enabled: false,
+      count: getCountBadge(counts.facturasBandeja),
+      enabled: true,
     },
     {
       name: "Informes",

--- a/components/transactions/transaction-detail.tsx
+++ b/components/transactions/transaction-detail.tsx
@@ -12,6 +12,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
+import { Checkbox } from "@/components/ui/checkbox"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { Calendar } from "@/components/ui/calendar"
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet"
@@ -88,6 +89,7 @@ export function TransactionDetail({
       descripcion: movement.descripcion || "",
       categoria_id: movement.categoria_id,
       contacto_id: movement.contacto_id ?? null,
+      factura_pendiente: movement.factura_pendiente ?? false,
     }
   }, [movement])
 
@@ -559,6 +561,31 @@ export function TransactionDetail({
                       </p>
                     )}
                   </div>
+
+                  <label
+                    htmlFor="factura-pendiente"
+                    className={cn(
+                      "flex cursor-pointer items-start gap-2.5 rounded-lg border px-3 py-2.5 transition-colors",
+                      formData.factura_pendiente
+                        ? "border-amber-300/70 bg-amber-50/70 dark:border-amber-900/60 dark:bg-amber-950/30"
+                        : "border-border/60 bg-muted/20 hover:bg-muted/30",
+                    )}
+                  >
+                    <Checkbox
+                      id="factura-pendiente"
+                      checked={Boolean(formData.factura_pendiente)}
+                      onCheckedChange={(checked) =>
+                        setFormData((prev) => ({ ...prev, factura_pendiente: Boolean(checked) }))
+                      }
+                      className="mt-0.5"
+                    />
+                    <span className="text-sm">
+                      <span className="font-medium">Falta la factura</span>
+                      <span className="block text-[11px] text-muted-foreground">
+                        Márcalo para acordarte de subirla o vincularla más tarde.
+                      </span>
+                    </span>
+                  </label>
 
                   <div className="space-y-2">
                     <Label htmlFor="descripcion" className="text-sm font-medium">

--- a/components/transactions/transaction-files.tsx
+++ b/components/transactions/transaction-files.tsx
@@ -1,13 +1,21 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
+import Link from "next/link"
 import { Alert, AlertDescription } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
 import { AddFileButton } from "./add-file-button"
 import { FileAttachmentDropzone } from "@/components/ui/file-attachment-dropzone"
 import { FileList } from "./file-list"
-import { AlertTriangle, Loader2 } from "lucide-react"
+import { AlertTriangle, CheckCircle2, Link2, Loader2, ReceiptText } from "lucide-react"
+import { toast } from "sonner"
 import { useMovimientoArchivos } from "@/hooks/use-movimiento-archivos"
 import { supabase } from "@/lib/supabase/client"
+import { DatabaseService } from "@/lib/services/database"
+import { VincularFacturaDialog } from "@/components/facturas/vincular-factura-dialog"
+import { FACTURA_ESTADO_INFO } from "@/lib/utils/facturas"
+import { formatCurrency } from "@/lib/utils/format"
+import type { FacturaConRelaciones, MovimientoArchivo } from "@/lib/types/database"
 
 interface TransactionFilesProps {
   movementId: string | null
@@ -18,6 +26,8 @@ interface TransactionFilesProps {
 export function TransactionFiles({ movementId, delegacionId, onCountChange }: TransactionFilesProps) {
   const [delegacionCodigo, setDelegacionCodigo] = useState<string | null>(null)
   const [uploadingFile, setUploadingFile] = useState(false)
+  const [facturaVinculada, setFacturaVinculada] = useState<FacturaConRelaciones | null>(null)
+  const [vincularOpen, setVincularOpen] = useState(false)
 
   useEffect(() => {
     const getDelegacionCodigo = async () => {
@@ -49,6 +59,23 @@ export function TransactionFiles({ movementId, delegacionId, onCountChange }: Tr
     getDelegacionCodigo()
   }, [delegacionId])
 
+  const fetchFacturaVinculada = useCallback(async () => {
+    if (!movementId) {
+      setFacturaVinculada(null)
+      return
+    }
+    try {
+      const factura = await DatabaseService.getFacturaByMovimiento(movementId)
+      setFacturaVinculada(factura)
+    } catch {
+      setFacturaVinculada(null)
+    }
+  }, [movementId])
+
+  useEffect(() => {
+    fetchFacturaVinculada()
+  }, [fetchFacturaVinculada])
+
   const {
     archivos,
     facturas,
@@ -65,10 +92,45 @@ export function TransactionFiles({ movementId, delegacionId, onCountChange }: Tr
     onCountChange?.(archivos.length)
   }, [archivos, onCountChange])
 
+  /**
+   * Al subir una factura al movimiento, además del adjunto se crea (si no
+   * existe) la entidad factura al otro lado, ya conciliada con este movimiento
+   * y con sus datos (fecha, importe, contacto). Mínimos clicks.
+   */
+  const registrarFacturaEntidad = async (archivo: MovimientoArchivo) => {
+    if (!movementId || !delegacionId) return
+    try {
+      const yaVinculada = Boolean(facturaVinculada)
+      const factura = await DatabaseService.ensureFacturaForMovimiento(movementId, {
+        creadoPor: archivo.subido_por,
+      })
+      await DatabaseService.registrarArchivoFactura(factura.id, delegacionId, {
+        nombre_original: archivo.nombre_original,
+        nombre_archivo: archivo.nombre_archivo,
+        tipo_mime: archivo.tipo_mime,
+        tamanoBytes: archivo["tamaño_bytes"],
+        bucket: archivo.bucket,
+        path_storage: archivo.path_storage,
+        url_publica: archivo.url_publica,
+        descripcion: archivo.descripcion,
+        subido_por: archivo.subido_por,
+      })
+      await fetchFacturaVinculada()
+      if (!yaVinculada) {
+        toast.success("Factura registrada en la sección Facturas y conciliada con este movimiento")
+      }
+    } catch (err) {
+      console.warn("No se pudo registrar la entidad factura:", err)
+    }
+  }
+
   const handleFileUpload = async (file: File, bucketType: "facturas" | "documentos") => {
     setUploadingFile(true)
     try {
-      await uploadFile(file, bucketType)
+      const archivo = await uploadFile(file, bucketType)
+      if (bucketType === "facturas") {
+        await registrarFacturaEntidad(archivo)
+      }
     } catch (error) {
       console.error("Error uploading file:", error)
     } finally {
@@ -88,6 +150,47 @@ export function TransactionFiles({ movementId, delegacionId, onCountChange }: Tr
       <div className="space-y-6">
         <div>
           <h3 className="text-sm font-medium text-muted-foreground mb-3">FACTURA</h3>
+
+          {/* Estado de conciliación con la sección Facturas */}
+          {facturaVinculada ? (
+            <div className="mb-3 flex items-center gap-2 rounded-lg border border-emerald-200/70 bg-emerald-50/60 px-2.5 py-2 text-xs text-emerald-900 dark:border-emerald-900/60 dark:bg-emerald-950/30 dark:text-emerald-200">
+              <CheckCircle2 className="h-3.5 w-3.5 shrink-0" />
+              <span className="min-w-0 flex-1 truncate">
+                Conciliada con la factura{" "}
+                <span className="font-medium">
+                  {facturaVinculada.concepto?.trim() || "sin título"}
+                </span>
+                {facturaVinculada.importe != null && (
+                  <> · {formatCurrency(Number(facturaVinculada.importe))}</>
+                )}
+                {" "}({FACTURA_ESTADO_INFO[facturaVinculada.estado].label.toLowerCase()})
+              </span>
+              <Link
+                href="/facturas"
+                className="shrink-0 font-medium underline-offset-2 hover:underline"
+              >
+                Ver
+              </Link>
+            </div>
+          ) : (
+            movementId &&
+            delegacionId && (
+              <div className="mb-3">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-8 text-xs"
+                  onClick={() => setVincularOpen(true)}
+                >
+                  <Link2 className="mr-1.5 h-3.5 w-3.5" />
+                  Vincular una factura de la bandeja
+                  <ReceiptText className="ml-1.5 h-3.5 w-3.5 text-muted-foreground" />
+                </Button>
+              </div>
+            )
+          )}
+
           {facturas.length === 0 ? (
             <FileAttachmentDropzone
               onFileSelect={(file) => handleFileUpload(file, "facturas")}
@@ -159,6 +262,14 @@ export function TransactionFiles({ movementId, delegacionId, onCountChange }: Tr
           </div>
         )}
       </div>
+
+      {/* Vincular una factura existente de la bandeja a este movimiento */}
+      <VincularFacturaDialog
+        movimientoId={movementId}
+        open={vincularOpen}
+        onOpenChange={setVincularOpen}
+        onLinked={fetchFacturaVinculada}
+      />
     </div>
   )
 }

--- a/components/transactions/transaction-filters.tsx
+++ b/components/transactions/transaction-filters.tsx
@@ -1,5 +1,5 @@
 "use client"
-import { X, Tag, Building2, PiggyBank, Search } from "lucide-react"
+import { X, Tag, Building2, PiggyBank, Search, AlertTriangle } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -21,6 +21,7 @@ interface TransactionFiltersProps {
   accounts?: CuentaConDelegacion[]
   contactos?: ContactoConCategoriaPredeterminada[]
   uncategorizedCount: number
+  facturaPendienteCount?: number
 }
 
 export function TransactionFiltersComponent({
@@ -31,6 +32,7 @@ export function TransactionFiltersComponent({
   accounts = [],
   contactos = [],
   uncategorizedCount,
+  facturaPendienteCount = 0,
 }: TransactionFiltersProps) {
   const updateFilter = (key: keyof Filters, value: any) => {
     onFiltersChange({ ...filters, [key]: value })
@@ -43,7 +45,7 @@ export function TransactionFiltersComponent({
   }
 
   const activeFilterCount = Object.entries(filters).filter(([key, value]) => {
-    if (key === "uncategorized" || key === "dateRange") return false
+    if (key === "uncategorized" || key === "facturaPendiente" || key === "dateRange") return false
     if (key === "categoryIds" || key === "contactoIds" || key === "contactoTipos") {
       return Array.isArray(value) && value.length > 0
     }
@@ -97,6 +99,32 @@ export function TransactionFiltersComponent({
             }`}
           >
             {uncategorizedCount}
+          </Badge>
+        )}
+      </Button>
+
+      <Button
+        variant={filters.facturaPendiente ? "default" : "outline"}
+        size="sm"
+        onClick={() => updateFilter("facturaPendiente", !filters.facturaPendiente)}
+        className={`w-full justify-start gap-2 ${
+          filters.facturaPendiente
+            ? "bg-amber-500 hover:bg-amber-600 text-white"
+            : "bg-background hover:bg-amber-50 border-amber-200 text-amber-700 dark:hover:bg-amber-950/20 dark:text-amber-400"
+        }`}
+      >
+        <AlertTriangle className="h-4 w-4" />
+        <span>Falta factura</span>
+        {facturaPendienteCount > 0 && (
+          <Badge
+            variant="secondary"
+            className={`ml-auto ${
+              filters.facturaPendiente
+                ? "bg-amber-600 text-amber-100"
+                : "bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200"
+            }`}
+          >
+            {facturaPendienteCount}
           </Badge>
         )}
       </Button>

--- a/components/transactions/transaction-list-row.tsx
+++ b/components/transactions/transaction-list-row.tsx
@@ -194,6 +194,7 @@ export const TransactionListRow = memo(function TransactionListRow({
                       description={movement.descripcion}
                       fileCount={movement.archivos?.length || 0}
                       pagoMcmId={(movement as any).pago_mcm_id}
+                      facturaPendiente={movement.factura_pendiente}
                       onOpenFiles={() => onOpenFiles?.(movement)}
                     />
                   </div>

--- a/components/transactions/transaction-manager.tsx
+++ b/components/transactions/transaction-manager.tsx
@@ -65,6 +65,7 @@ export interface TransactionFilters {
   amountFrom?: number
   amountTo?: number
   uncategorized?: boolean
+  facturaPendiente?: boolean
 }
 
 export function TransactionManager() {
@@ -126,6 +127,7 @@ export function TransactionManager() {
     amountFrom: filters.amountFrom,
     amountTo: filters.amountTo,
     uncategorized: filters.uncategorized,
+    facturaPendiente: filters.facturaPendiente,
   })
 
   // Notify on fetch error
@@ -489,6 +491,27 @@ export function TransactionManager() {
     filters.amountTo,
   ])
 
+  const [facturaPendienteCount, setFacturaPendienteCount] = useState(0)
+
+  useEffect(() => {
+    if (!selectedDelegation) {
+      setFacturaPendienteCount(0)
+      return
+    }
+    let countQuery = supabase
+      .from("movimiento")
+      .select("id", { count: "exact", head: true })
+      .eq("delegacion_id", selectedDelegation)
+      .eq("ignorado", false)
+      .eq("factura_pendiente", true)
+
+    if (filters.dateFrom) countQuery = countQuery.gte("fecha", filters.dateFrom)
+    if (filters.dateTo) countQuery = countQuery.lte("fecha", filters.dateTo)
+    if (filters.accountId) countQuery = countQuery.eq("cuenta_id", filters.accountId)
+
+    countQuery.then(({ count }) => setFacturaPendienteCount(count ?? 0))
+  }, [selectedDelegation, filters.dateFrom, filters.dateTo, filters.accountId, movements])
+
   const hasActiveFilters = Object.entries(filters).some(([key, value]) => {
     if (key === "dateFrom" || key === "dateTo") return false
     if (key === "categoryIds" || key === "contactoIds" || key === "contactoTipos") {
@@ -606,6 +629,7 @@ export function TransactionManager() {
               accounts={accounts}
               contactos={contactos}
               uncategorizedCount={uncategorizedCount}
+              facturaPendienteCount={facturaPendienteCount}
             />
           </div>
         )}
@@ -828,6 +852,7 @@ export function TransactionManager() {
                 accounts={accounts}
                 contactos={contactos}
                 uncategorizedCount={uncategorizedCount}
+                facturaPendienteCount={facturaPendienteCount}
               />
             </Card>
           )}

--- a/components/transactions/transaction-row-indicators.tsx
+++ b/components/transactions/transaction-row-indicators.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import React from "react"
-import { FileText, HandCoins, MessageSquare } from "lucide-react"
+import { AlertTriangle, FileText, HandCoins, MessageSquare } from "lucide-react"
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
@@ -11,6 +11,7 @@ interface TransactionRowIndicatorsProps {
   description?: string | null
   fileCount?: number
   pagoMcmId?: string | null
+  facturaPendiente?: boolean
   className?: string
   onOpenFiles?: () => void
 }
@@ -19,6 +20,7 @@ export function TransactionRowIndicators({
   description,
   fileCount = 0,
   pagoMcmId,
+  facturaPendiente,
   className,
   onOpenFiles,
 }: TransactionRowIndicatorsProps) {
@@ -27,7 +29,7 @@ export function TransactionRowIndicators({
   const hasFiles = fileCount > 0
   const hasPagoMcm = Boolean(pagoMcmId)
 
-  if (!hasDescription && !hasFiles && !hasPagoMcm) {
+  if (!hasDescription && !hasFiles && !hasPagoMcm && !facturaPendiente) {
     return null
   }
 
@@ -119,6 +121,23 @@ export function TransactionRowIndicators({
               </div>
             </TooltipTrigger>
             <TooltipContent side="top">Vinculado a un Pago MCM</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      )}
+
+      {/* Indicador de factura pendiente (marca manual) */}
+      {facturaPendiente && (
+        <TooltipProvider delayDuration={150}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div
+                className="h-5 w-5 rounded-full bg-amber-100 dark:bg-amber-950/40 flex items-center justify-center"
+                aria-label="Falta factura"
+              >
+                <AlertTriangle className="h-3 w-3 text-amber-700 dark:text-amber-300" />
+              </div>
+            </TooltipTrigger>
+            <TooltipContent side="top">Falta la factura de este movimiento</TooltipContent>
           </Tooltip>
         </TooltipProvider>
       )}

--- a/docs/09-facturas.md
+++ b/docs/09-facturas.md
@@ -15,9 +15,19 @@ mínimos clicks posibles.
 3. **Vincula el movimiento**: el botón *Vincular movimiento* busca gastos con un importe parecido
    (con un pelín de margen), afinando por fecha y contacto. Si hay un candidato claro, se marca
    como **Match directo** y viene preseleccionado. Al vincular:
-   - La factura pasa a **Pagada**.
+   - La factura pasa a **Pagada** (o **Pago parcial** si el movimiento no cubre el importe total).
    - El movimiento hereda el contacto de la factura (y viceversa si faltaba).
    - Los archivos de la factura aparecen también en el movimiento.
+
+### Pagos en varios plazos
+
+Una factura puede tener **0, 1 o varios movimientos vinculados**. Por ejemplo, una factura de
+3.000 € pagada en dos transferencias de 1.500 € se concilia vinculando ambos movimientos a la
+misma factura: tras el primero queda en **Pago parcial** (indicando cuánto falta por cubrir);
+tras el segundo, la suma alcanza el importe y pasa a **Pagada**. El botón para vincular sigue
+disponible mientras la factura no esté completamente cubierta, y la búsqueda de candidatos usa
+el importe **pendiente**, no el total, para sugerir el siguiente plazo. Cada movimiento vinculado
+se puede desvincular individualmente sin afectar a los demás.
 
 ## Estados
 
@@ -25,10 +35,13 @@ mínimos clicks posibles.
 |--------|-------------|
 | En bandeja | Recién subida, pendiente de revisar/completar datos |
 | Sin pagar | Registrada, pendiente de pago |
-| Pagada | Pagada y vinculada a un movimiento de MCM Bank |
+| Pago parcial | Vinculada a uno o varios movimientos que no cubren aún el importe total |
+| Pagada | Pagada y vinculada a movimiento(s) de MCM Bank que cubren el importe total |
 | Pagada fuera | Pagada, pero el pago se hizo fuera de MCM Bank (no hay movimiento que vincular) |
 
-Al desvincular un movimiento, la factura vuelve a *Sin pagar*.
+El estado (salvo *Pagada fuera*, marca manual) se recalcula automáticamente en base de datos cada
+vez que se vincula o desvincula un movimiento, comparando la suma de sus importes con el importe
+de la factura. Al desvincular el único/último movimiento, la factura vuelve a *Sin pagar*.
 
 ## Desde el lado movimiento
 
@@ -37,16 +50,31 @@ En el detalle de un movimiento (pestaña Archivos):
 - **Subir una factura** al movimiento crea automáticamente la entidad factura al otro lado, ya
   conciliada y con los datos del movimiento (fecha, importe, contacto).
 - **Vincular una factura de la bandeja**: si la factura ya estaba subida en la sección Facturas,
-  se elige de una lista de candidatas compatibles por importe.
+  se elige de una lista de candidatas compatibles por importe pendiente.
+- **Falta factura**: un movimiento no vinculado a ninguna factura se puede marcar a mano como
+  "Falta factura" (checkbox en el detalle del movimiento). No todos los movimientos llevan
+  factura (nóminas, comisiones bancarias…), así que la marca es manual, nunca automática. Los
+  movimientos marcados muestran un icono de aviso en la lista y se pueden filtrar con el botón
+  *Falta factura* en el panel de filtros de Movimientos.
 
 ## Modelo de datos
 
-- Tabla `factura` (migración `scripts/047_create_factura.sql`), con RLS por delegación
-  (lectura: cualquier miembro; escritura: tesorero / gestor_central).
-- Vínculo 1-a-1 con `movimiento` (`factura.movimiento_id` + `movimiento.factura_id`). Un trigger
-  sincroniza el estado (`pagada` al vincular, `sin_pagar` al desvincular).
+- Tabla `factura` (migración `scripts/047_create_factura.sql`, ampliada en
+  `scripts/048_factura_pagos_multiples.sql`), con RLS por delegación (lectura: cualquier
+  miembro; escritura: tesorero / gestor_central).
+- Vínculo **1 factura → N movimientos** vía `movimiento.factura_id` (varios movimientos pueden
+  apuntar a la misma factura; un movimiento, como mucho, a una). La función
+  `recalcular_estado_factura()` y sus triggers mantienen `factura.estado` sincronizado con la
+  suma de los movimientos vinculados (`pagada_parcial` / `pagada`), tanto al cambiar el vínculo
+  como al editar el importe de la factura.
+- `movimiento.factura_pendiente` (boolean, default `false`): marca manual e independiente del
+  vínculo, para señalar movimientos a los que les falta subir/vincular su factura.
 - Archivos en `archivo_adjunto` con `entidad='factura'` (bucket `facturas` de Storage). Al
   conciliar se replican en `movimiento_archivo` apuntando al mismo path.
+- Los contactos (`contacto`) son una única tabla compartida por toda la app: el mismo proveedor
+  usado en una factura aparece igual en movimientos, Pagos MCM y en la sección Contactos, sin
+  duplicados. Un pequeño indicador ⚠️ (en el selector de contacto, en las tarjetas de factura y
+  en la ficha de contacto) avisa cuando un proveedor no tiene NIF/CIF guardado.
 
 ---
 

--- a/docs/09-facturas.md
+++ b/docs/09-facturas.md
@@ -1,0 +1,110 @@
+# Facturas
+
+La sección **Facturas** es la bandeja de entrada de las facturas de cada delegación. No es una
+lista de "pendientes de pagar": casi siempre la factura ya está pagada cuando llega. Lo importante
+es guardarla, apuntar los datos básicos y **conciliarla con su movimiento bancario** con los
+mínimos clicks posibles.
+
+## Flujo básico
+
+1. **Sube archivos a la bandeja**: arrastra uno o varios PDF/imágenes a la zona de subida. Se crea
+   una factura por archivo en estado *En bandeja*.
+2. **Completa los datos**: proveedor (contacto), concepto, importe, fecha de emisión y nº de
+   factura. Si el proveedor no existe, se crea al vuelo desde el propio selector sin salir del
+   formulario.
+3. **Vincula el movimiento**: el botón *Vincular movimiento* busca gastos con un importe parecido
+   (con un pelín de margen), afinando por fecha y contacto. Si hay un candidato claro, se marca
+   como **Match directo** y viene preseleccionado. Al vincular:
+   - La factura pasa a **Pagada**.
+   - El movimiento hereda el contacto de la factura (y viceversa si faltaba).
+   - Los archivos de la factura aparecen también en el movimiento.
+
+## Estados
+
+| Estado | Significado |
+|--------|-------------|
+| En bandeja | Recién subida, pendiente de revisar/completar datos |
+| Sin pagar | Registrada, pendiente de pago |
+| Pagada | Pagada y vinculada a un movimiento de MCM Bank |
+| Pagada fuera | Pagada, pero el pago se hizo fuera de MCM Bank (no hay movimiento que vincular) |
+
+Al desvincular un movimiento, la factura vuelve a *Sin pagar*.
+
+## Desde el lado movimiento
+
+En el detalle de un movimiento (pestaña Archivos):
+
+- **Subir una factura** al movimiento crea automáticamente la entidad factura al otro lado, ya
+  conciliada y con los datos del movimiento (fecha, importe, contacto).
+- **Vincular una factura de la bandeja**: si la factura ya estaba subida en la sección Facturas,
+  se elige de una lista de candidatas compatibles por importe.
+
+## Modelo de datos
+
+- Tabla `factura` (migración `scripts/047_create_factura.sql`), con RLS por delegación
+  (lectura: cualquier miembro; escritura: tesorero / gestor_central).
+- Vínculo 1-a-1 con `movimiento` (`factura.movimiento_id` + `movimiento.factura_id`). Un trigger
+  sincroniza el estado (`pagada` al vincular, `sin_pagar` al desvincular).
+- Archivos en `archivo_adjunto` con `entidad='factura'` (bucket `facturas` de Storage). Al
+  conciliar se replican en `movimiento_archivo` apuntando al mismo path.
+
+---
+
+## Integraciones futuras (estructura ya preparada)
+
+La tabla `factura` ya incluye las columnas necesarias para estas dos integraciones: `origen`
+(`subida | movimiento | email`), `email_remitente` y `datos_ia` (JSONB).
+
+### a) Buzón de email por delegación
+
+**Objetivo**: crear una dirección tipo `facturas-valencia@movimientoconsolacion.com` (Google
+Workspace) a la que cualquiera reenvía facturas, y que aparezcan solas en la bandeja de la
+delegación con estado *En bandeja* y `origen='email'`.
+
+**Cómo se haría** (recomendado, sin servidores propios):
+
+1. **Crear el grupo/buzón en Google Workspace** por delegación (o un único buzón con alias
+   `facturas+valencia@…`; el sufijo `+delegacion` permite enrutar con una sola cuenta).
+2. **Recepción**: dos opciones, de menos a más infraestructura:
+   - **Polling con Gmail API** (recomendado para empezar): una *Supabase Edge Function* programada
+     (cron cada 5–10 min, igual que `039_enable_banking_cron.sql`) que lee los mensajes no
+     procesados del buzón con la Gmail API. Ya existe infraestructura de credenciales Google en la
+     app (`google_credencial`, `lib/services/google.ts`), se reutiliza el mismo patrón OAuth.
+   - **Push**: Gmail API *watch* + Google Cloud Pub/Sub que llama a una Edge Function HTTP. Más
+     inmediato pero requiere proyecto GCP con Pub/Sub.
+3. **Procesado en la Edge Function** (`supabase/functions/facturas-inbound-email`):
+   - Resolver la delegación por el alias/dirección de destino (tabla de mapeo
+     `delegacion.email_facturas` o convención `facturas+<codigo>@`).
+   - Por cada adjunto PDF/imagen: subirlo al bucket `facturas` de Storage
+     (path `<codigo>/<año>/<mes>/factura/<uuid>/...`, el mismo esquema que usa `FileService`).
+   - Insertar la fila en `factura` (`estado='bandeja'`, `origen='email'`,
+     `email_remitente=<from>`, `concepto=<asunto>`) y su `archivo_adjunto` con
+     `entidad='factura'` (con la *service role key*, saltando RLS de forma controlada).
+   - Marcar el mensaje como procesado (label de Gmail) para no duplicar.
+4. **UI**: no requiere cambios; las facturas con `origen='email'` ya muestran el remitente en la
+   tarjeta y caen en la pestaña Bandeja con su contador en el sidebar.
+
+### b) Lectura automática con IA (rellenar datos básicos)
+
+**Objetivo**: al subir un archivo (o al llegar por email), extraer proveedor, fecha de emisión,
+importe total y nº de factura — **sin IVA ni desglose fiscal** — y dejar la factura casi lista:
+proveedor creado/asignado automáticamente si no existe.
+
+**Cómo se haría**:
+
+1. **Servicio**: Gemini API (`gemini-flash` con entrada PDF/imagen es suficiente y muy barato) o
+   Google Cloud Document AI (procesador *Invoice Parser*, más caro y con mucho desglose fiscal que
+   no interesa). Recomendación: **Gemini con salida estructurada (JSON schema)**.
+2. **Dónde**: una Edge Function `facturas-analizar` que recibe `factura_id`:
+   - Descarga el archivo de Storage y lo manda a Gemini con un prompt fijo pidiendo JSON:
+     `{ proveedor: { nombre, nif }, fecha_emision, importe_total, numero, moneda }`.
+   - Guarda la respuesta cruda en `factura.datos_ia` (auditable y re-procesable).
+   - **Proveedor**: busca en `contacto` por `identificador_fiscal` o nombre normalizado dentro de
+     la delegación (+ globales); si no existe, lo crea con `tipo='proveedor'` y lo asigna.
+   - Rellena solo los campos que estén vacíos en la factura (nunca machaca lo editado a mano).
+3. **Disparo**: al crear la factura desde la bandeja (llamada `supabase.functions.invoke` tras la
+   subida, en `factura-inbox-dropzone.tsx`) y desde el procesador de email del punto (a).
+4. **UI**: badge "Rellenada con IA" cuando `datos_ia` no sea nulo, con opción de revisar; los
+   campos siguen siendo editables como siempre.
+5. **Secretos**: `GEMINI_API_KEY` como secret de Edge Functions (`supabase secrets set`), nunca
+   `NEXT_PUBLIC_`.

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -8,3 +8,5 @@
 * [5. Movimientos](05-movimientos.md)
 * [6. Panel de Control](06-dashboard.md)
 * [7. Centro de diagnóstico](07-diagnostico.md)
+* [8. API externa](08-api-externa.md)
+* [9. Facturas](09-facturas.md)

--- a/hooks/use-delegation-counts.ts
+++ b/hooks/use-delegation-counts.ts
@@ -12,6 +12,7 @@ export interface DelegationCounts {
   cuentas: number | null
   contactos: number | null
   pagosMcmPendientes: number | null
+  facturasBandeja: number | null
 }
 
 const INITIAL_COUNTS: DelegationCounts = {
@@ -20,6 +21,7 @@ const INITIAL_COUNTS: DelegationCounts = {
   cuentas: null,
   contactos: null,
   pagosMcmPendientes: null,
+  facturasBandeja: null,
 }
 
 const QUERY_TIMEOUT_MS = 10000
@@ -58,7 +60,7 @@ export function useDelegationCounts() {
     const organizacionId = delegation?.organizacion_id ?? null
 
     try {
-      const [movimientosRes, cuentasRes, categoriasRes, contactosRes, pagosMcmRes] = await Promise.all([
+      const [movimientosRes, cuentasRes, categoriasRes, contactosRes, pagosMcmRes, facturasRes] = await Promise.all([
         runQuery<{ count: number | null }>({
           label: "count-movimientos",
           table: "movimiento",
@@ -129,6 +131,20 @@ export function useDelegationCounts() {
             return { data: { count: typeof count === "number" ? count : 0 }, error }
           },
         }),
+        runQuery<{ count: number | null }>({
+          label: "count-facturas-bandeja",
+          table: "factura",
+          timeoutMs: QUERY_TIMEOUT_MS,
+          build: async (signal) => {
+            const { count, error } = await supabase
+              .from("factura")
+              .select("id", { head: true, count: "exact" })
+              .eq("delegacion_id", delegationId)
+              .eq("estado", "bandeja")
+              .abortSignal(signal)
+            return { data: { count: typeof count === "number" ? count : 0 }, error }
+          },
+        }),
       ])
 
       if (requestRef.current !== fetchId) return
@@ -144,6 +160,7 @@ export function useDelegationCounts() {
               : categoriasRes.data?.count ?? 0,
         contactos: contactosRes.error ? null : contactosRes.data?.count ?? 0,
         pagosMcmPendientes: pagosMcmRes.error ? null : pagosMcmRes.data?.count ?? 0,
+        facturasBandeja: facturasRes.error ? null : facturasRes.data?.count ?? 0,
       }
 
       const hasError =
@@ -151,7 +168,8 @@ export function useDelegationCounts() {
         Boolean(cuentasRes.error) ||
         (organizacionId !== null && Boolean(categoriasRes.error)) ||
         Boolean(contactosRes.error) ||
-        Boolean(pagosMcmRes.error)
+        Boolean(pagosMcmRes.error) ||
+        Boolean(facturasRes.error)
 
       if (hasError) {
         console.warn("⚠️ useDelegationCounts: error loading counts", {

--- a/hooks/use-factura-archivos.ts
+++ b/hooks/use-factura-archivos.ts
@@ -1,0 +1,148 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+import { supabase } from "@/lib/supabase/client"
+import { useAuth } from "@/contexts/auth-context"
+import { FileService, type FileUploadResult } from "@/lib/services/file-service"
+import { runQuery } from "@/lib/db/query"
+import { useRevalidateOnFocusJitter } from "./use-app-status"
+import type { ArchivoAdjunto } from "@/lib/types/database"
+
+const TIMEOUT_MS = 10000
+
+/**
+ * Adjuntos polimórficos (entidad='factura') de una factura.
+ * Paralelo a usePagoMcmArchivos, operando sobre `archivo_adjunto`.
+ */
+export function useFacturaArchivos(
+  facturaId: string | null,
+  delegacionId: string | null,
+  delegacionCodigo?: string,
+) {
+  const { user } = useAuth()
+  const [archivos, setArchivos] = useState<ArchivoAdjunto[]>([])
+  const [loading, setLoading] = useState(false)
+  const [uploading, setUploading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const abortRef = useRef<AbortController | null>(null)
+
+  const fetchArchivos = useCallback(async () => {
+    if (!facturaId) {
+      setArchivos([])
+      return
+    }
+    if (abortRef.current) abortRef.current.abort()
+    const ac = new AbortController()
+    abortRef.current = ac
+
+    setLoading(true)
+    setError(null)
+    try {
+      const { data, error } = await runQuery<any[]>({
+        label: "fetch-factura-archivos",
+        table: "archivo_adjunto",
+        timeoutMs: TIMEOUT_MS,
+        build: async (signal) =>
+          await (supabase as any)
+            .from("archivo_adjunto")
+            .select("*")
+            .eq("entidad", "factura")
+            .eq("entidad_id", facturaId)
+            .order("subido_en", { ascending: false })
+            .abortSignal(signal),
+      })
+      if (error) throw error
+      setArchivos(data || [])
+    } catch (err) {
+      if (!ac.signal.aborted) setError(err instanceof Error ? err.message : "Error al cargar archivos")
+    } finally {
+      setLoading(false)
+    }
+  }, [facturaId])
+
+  useEffect(() => {
+    fetchArchivos()
+    return () => abortRef.current?.abort()
+  }, [fetchArchivos])
+
+  useRevalidateOnFocusJitter(fetchArchivos, { minMs: 80, maxMs: 180 })
+
+  const uploadFile = useCallback(
+    async (file: File, descripcion?: string): Promise<ArchivoAdjunto> => {
+      if (!facturaId || !delegacionId) throw new Error("Factura o delegación no disponibles")
+      if (!user) throw new Error("Usuario no autenticado")
+      if (!delegacionCodigo) throw new Error("Código de delegación requerido")
+
+      setUploading(true)
+      setError(null)
+      try {
+        const uploadResult: FileUploadResult = await FileService.uploadFileForEntity(
+          file,
+          { scope: "factura", id: facturaId },
+          "facturas",
+          delegacionCodigo,
+        )
+
+        const insert = {
+          entidad: "factura" as const,
+          entidad_id: facturaId,
+          delegacion_id: delegacionId,
+          nombre_original: file.name,
+          nombre_archivo: uploadResult.path.split("/").pop() || file.name,
+          tipo_mime: file.type,
+          tamano_bytes: file.size,
+          bucket: "facturas" as const,
+          path_storage: uploadResult.path,
+          url_publica: uploadResult.url,
+          es_factura: true,
+          descripcion: descripcion || null,
+          subido_por: user.id,
+        }
+
+        const { data, error } = await (supabase as any)
+          .from("archivo_adjunto")
+          .insert([insert])
+          .select()
+          .single()
+        if (error) throw error
+
+        setArchivos((prev) => [data, ...prev])
+        return data as ArchivoAdjunto
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : "Error al subir archivo"
+        setError(msg)
+        throw new Error(msg)
+      } finally {
+        setUploading(false)
+      }
+    },
+    [facturaId, delegacionId, delegacionCodigo, user],
+  )
+
+  const deleteFile = useCallback(async (archivo: ArchivoAdjunto): Promise<void> => {
+    setError(null)
+    try {
+      await FileService.deleteFile(archivo.path_storage, archivo.bucket as "facturas" | "documentos")
+      const { error } = await (supabase as any)
+        .from("archivo_adjunto")
+        .delete()
+        .eq("id", archivo.id)
+      if (error) throw error
+      setArchivos((prev) => prev.filter((a) => a.id !== archivo.id))
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Error al eliminar archivo"
+      setError(msg)
+      throw new Error(msg)
+    }
+  }, [])
+
+  return {
+    archivos,
+    loading,
+    uploading,
+    error,
+    uploadFile,
+    deleteFile,
+    refetch: fetchArchivos,
+  }
+}

--- a/hooks/use-facturas.ts
+++ b/hooks/use-facturas.ts
@@ -117,8 +117,8 @@ export function useFacturas(delegacionId?: string | null, options: UseFacturasOp
     await fetchRef.current()
   }, [])
 
-  const unlinkFromMovimiento = useCallback(async (facturaId: string) => {
-    await DatabaseService.unlinkFacturaFromMovimiento(facturaId)
+  const unlinkFromMovimiento = useCallback(async (facturaId: string, movimientoId: string) => {
+    await DatabaseService.unlinkFacturaFromMovimiento(facturaId, movimientoId)
     await fetchRef.current()
   }, [])
 
@@ -126,6 +126,7 @@ export function useFacturas(delegacionId?: string | null, options: UseFacturasOp
     const base = {
       bandeja: 0,
       sin_pagar: 0,
+      pagada_parcial: 0,
       pagada: 0,
       pagada_fuera: 0,
       total: 0,
@@ -134,7 +135,9 @@ export function useFacturas(delegacionId?: string | null, options: UseFacturasOp
     for (const f of facturas) {
       base[f.estado] += 1
       base.total += 1
-      if (f.estado === "sin_pagar" && f.importe != null) base.sinPagarImporte += Number(f.importe)
+      if ((f.estado === "sin_pagar" || f.estado === "pagada_parcial") && f.importe != null) {
+        base.sinPagarImporte += Number(f.importe)
+      }
     }
     return base
   }, [facturas])

--- a/hooks/use-facturas.ts
+++ b/hooks/use-facturas.ts
@@ -1,0 +1,157 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { DatabaseService } from "@/lib/services/database"
+import { registerAC, unregisterAC } from "@/lib/db/in-flight"
+import { useRevalidateOnFocusJitter } from "./use-app-status"
+import type {
+  Factura,
+  FacturaConRelaciones,
+  FacturaEstado,
+  FacturaInsert,
+  FacturaUpdate,
+} from "@/lib/types/database"
+
+const QUERY_TIMEOUT_MS = 12000
+
+export interface UseFacturasOptions {
+  estados?: FacturaEstado[]
+  contactoId?: string
+  busqueda?: string
+}
+
+export function useFacturas(delegacionId?: string | null, options: UseFacturasOptions = {}) {
+  const [facturas, setFacturas] = useState<FacturaConRelaciones[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const abortRef = useRef<AbortController | null>(null)
+  const facturasRef = useRef(facturas)
+  facturasRef.current = facturas
+
+  const estados = options.estados
+  const contactoId = options.contactoId
+  const busqueda = options.busqueda?.trim() || undefined
+  const estadosKey = useMemo(() => (estados ? [...estados].sort().join(",") : ""), [estados])
+
+  const fetchFacturas = useCallback(async () => {
+    if (abortRef.current) {
+      abortRef.current.abort()
+      unregisterAC(abortRef.current)
+    }
+
+    if (!delegacionId) {
+      setFacturas([])
+      setLoading(false)
+      return
+    }
+
+    const ac = new AbortController()
+    abortRef.current = ac
+    registerAC(ac)
+
+    try {
+      if (facturasRef.current.length === 0) {
+        setLoading(true)
+      }
+
+      const data = await Promise.race([
+        DatabaseService.getFacturasByDelegacion(delegacionId, {
+          estados,
+          contactoId,
+          busqueda,
+          signal: ac.signal,
+        }),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error(`facturas timeout after ${QUERY_TIMEOUT_MS}ms`)), QUERY_TIMEOUT_MS),
+        ),
+      ])
+
+      if (ac.signal.aborted) return
+      setFacturas(data)
+      setError(null)
+    } catch (err) {
+      if (ac.signal.aborted) return
+      setError(err instanceof Error ? err.message : "Error desconocido")
+    } finally {
+      unregisterAC(ac)
+      if (!ac.signal.aborted) setLoading(false)
+    }
+  }, [delegacionId, estadosKey, contactoId, busqueda]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const fetchRef = useRef(fetchFacturas)
+  fetchRef.current = fetchFacturas
+
+  useEffect(() => {
+    fetchRef.current()
+    return () => {
+      if (abortRef.current) {
+        abortRef.current.abort()
+        unregisterAC(abortRef.current)
+      }
+    }
+  }, [delegacionId, estadosKey, contactoId, busqueda])
+
+  useRevalidateOnFocusJitter(() => fetchRef.current(), { minMs: 80, maxMs: 200 })
+
+  const createFactura = useCallback(
+    async (payload: Omit<FacturaInsert, "creado_en" | "actualizado_en">) => {
+      const created = await DatabaseService.createFactura(payload)
+      await fetchRef.current()
+      return created
+    },
+    [],
+  )
+
+  const updateFactura = useCallback(async (id: string, updates: FacturaUpdate) => {
+    await DatabaseService.updateFactura(id, updates)
+    await fetchRef.current()
+  }, [])
+
+  const deleteFactura = useCallback(async (id: string) => {
+    await DatabaseService.deleteFactura(id)
+    setFacturas((prev) => prev.filter((f) => f.id !== id))
+  }, [])
+
+  const linkToMovimiento = useCallback(async (facturaId: string, movimientoId: string, creadoPor?: string) => {
+    await DatabaseService.linkFacturaToMovimiento(facturaId, movimientoId, creadoPor)
+    await fetchRef.current()
+  }, [])
+
+  const unlinkFromMovimiento = useCallback(async (facturaId: string) => {
+    await DatabaseService.unlinkFacturaFromMovimiento(facturaId)
+    await fetchRef.current()
+  }, [])
+
+  const totals = useMemo(() => {
+    const base = {
+      bandeja: 0,
+      sin_pagar: 0,
+      pagada: 0,
+      pagada_fuera: 0,
+      total: 0,
+      sinPagarImporte: 0,
+    }
+    for (const f of facturas) {
+      base[f.estado] += 1
+      base.total += 1
+      if (f.estado === "sin_pagar" && f.importe != null) base.sinPagarImporte += Number(f.importe)
+    }
+    return base
+  }, [facturas])
+
+  return {
+    facturas,
+    loading,
+    error,
+    totals,
+    refetch: fetchFacturas,
+    createFactura,
+    updateFactura,
+    deleteFactura,
+    linkToMovimiento,
+    unlinkFromMovimiento,
+  }
+}
+
+export type UseFacturasReturn = ReturnType<typeof useFacturas>
+export type { Factura, FacturaConRelaciones }

--- a/hooks/use-movimientos.ts
+++ b/hooks/use-movimientos.ts
@@ -18,6 +18,7 @@ interface MovimientosFilters {
   amountFrom?: number
   amountTo?: number
   uncategorized?: boolean
+  facturaPendiente?: boolean
 }
 
 const DEFAULT_PAGE_SIZE = 100
@@ -163,6 +164,8 @@ export function useMovimientos(
             categoria_id,
             contacto_id,
             pago_mcm_id,
+            factura_id,
+            factura_pendiente,
             adjunto_principal_url,
             creado_por,
             creado_en,
@@ -238,6 +241,9 @@ export function useMovimientos(
           query = applyAbsoluteAmountFilter(query, memoizedFilters.amountFrom, memoizedFilters.amountTo)
           if (memoizedFilters.uncategorized) {
             query = query.is("categoria_id", null)
+          }
+          if (memoizedFilters.facturaPendiente) {
+            query = query.eq("factura_pendiente", true)
           }
         }
 

--- a/lib/services/database.ts
+++ b/lib/services/database.ts
@@ -9,6 +9,11 @@ import type {
   ContactoInsert,
   ContactoTipo,
   ContactoUpdate,
+  Factura,
+  FacturaConRelaciones,
+  FacturaEstado,
+  FacturaInsert,
+  FacturaUpdate,
   FinancialSummary,
   MonthlyTrendRow,
   MovimientoConRelaciones,
@@ -18,6 +23,7 @@ import type {
   PagoMcmInsert,
   PagoMcmUpdate,
 } from "@/lib/types/database"
+import { margenImporteFactura, scoreCandidatoMovimiento } from "@/lib/utils/facturas"
 
 type CategoriaWithOverrides = Categoria & {
   overrides?: CategoriaOrdenDelegacion[] | null
@@ -770,6 +776,498 @@ export class DatabaseService {
     }
 
     return list
+  }
+
+  // ---------------------------------------------------------------------------
+  // Factura operations (client-side)
+  // ---------------------------------------------------------------------------
+
+  private static readonly FACTURA_SELECT = `
+    *,
+    contacto:contacto_id (
+      id,
+      nombre,
+      tipo,
+      emoji,
+      color,
+      email,
+      identificador_fiscal
+    ),
+    movimiento:movimiento_id (
+      id,
+      fecha,
+      concepto,
+      importe,
+      cuenta_id
+    )
+  `
+
+  /**
+   * archivo_adjunto es polimórfico (sin FK a factura), así que los adjuntos
+   * se cargan aparte y se mezclan en memoria.
+   */
+  private static async attachArchivosToFacturas(
+    facturas: FacturaConRelaciones[],
+    signal?: AbortSignal,
+  ): Promise<FacturaConRelaciones[]> {
+    if (facturas.length === 0) return facturas
+    const supabase = this.getClient() as any
+    let query = supabase
+      .from("archivo_adjunto")
+      .select("id, entidad_id, nombre_original, tipo_mime, url_publica, path_storage, bucket, tamano_bytes, subido_en")
+      .eq("entidad", "factura")
+      .in("entidad_id", facturas.map((f) => f.id))
+      .order("subido_en", { ascending: false })
+    if (signal) query = query.abortSignal(signal)
+    const { data, error } = await query
+    if (error) throw error
+
+    const porFactura = new Map<string, any[]>()
+    for (const archivo of data ?? []) {
+      const list = porFactura.get(archivo.entidad_id) ?? []
+      list.push(archivo)
+      porFactura.set(archivo.entidad_id, list)
+    }
+    return facturas.map((f) => ({ ...f, archivos: porFactura.get(f.id) ?? [] }))
+  }
+
+  static async getFacturasByDelegacion(
+    delegacionId: string,
+    options: {
+      estados?: FacturaEstado[]
+      contactoId?: string
+      busqueda?: string
+      signal?: AbortSignal
+    } = {},
+  ): Promise<FacturaConRelaciones[]> {
+    const supabase = this.getClient() as any
+    let query = supabase
+      .from("factura")
+      .select(this.FACTURA_SELECT)
+      .eq("delegacion_id", delegacionId)
+      .order("creado_en", { ascending: false })
+
+    if (options.estados && options.estados.length > 0) {
+      query = query.in("estado", options.estados)
+    }
+    if (options.contactoId) {
+      query = query.eq("contacto_id", options.contactoId)
+    }
+    if (options.busqueda) {
+      const term = options.busqueda.replace(/%/g, "\\%").replace(/,/g, "\\,")
+      query = query.or(`concepto.ilike.%${term}%,numero.ilike.%${term}%,notas.ilike.%${term}%`)
+    }
+    if (options.signal) {
+      query = query.abortSignal(options.signal)
+    }
+
+    const { data, error } = await query
+    if (error) throw error
+    return this.attachArchivosToFacturas((data ?? []) as FacturaConRelaciones[], options.signal)
+  }
+
+  static async getFacturaById(id: string): Promise<FacturaConRelaciones | null> {
+    const supabase = this.getClient() as any
+    const { data, error } = await supabase
+      .from("factura")
+      .select(this.FACTURA_SELECT)
+      .eq("id", id)
+      .maybeSingle()
+    if (error) throw error
+    if (!data) return null
+    const [conArchivos] = await this.attachArchivosToFacturas([data as FacturaConRelaciones])
+    return conArchivos
+  }
+
+  static async getFacturaByMovimiento(movimientoId: string): Promise<FacturaConRelaciones | null> {
+    const supabase = this.getClient() as any
+    const { data, error } = await supabase
+      .from("factura")
+      .select(this.FACTURA_SELECT)
+      .eq("movimiento_id", movimientoId)
+      .maybeSingle()
+    if (error) throw error
+    return (data ?? null) as FacturaConRelaciones | null
+  }
+
+  static async createFactura(
+    factura: Omit<FacturaInsert, "creado_en" | "actualizado_en">,
+  ): Promise<Factura> {
+    const supabase = this.getClient() as any
+    const { data, error } = await supabase.from("factura").insert(factura).select().single()
+    if (error) throw error
+    return data as Factura
+  }
+
+  static async updateFactura(id: string, updates: FacturaUpdate): Promise<void> {
+    const supabase = this.getClient() as any
+    const { error } = await supabase.from("factura").update(updates).eq("id", id)
+    if (error) throw error
+  }
+
+  /**
+   * Elimina una factura y sus adjuntos (registros; el borrado en Storage lo
+   * hace el hook de archivos antes de llamar aquí, si procede). Si estaba
+   * vinculada a un movimiento, lo desvincula primero.
+   */
+  static async deleteFactura(id: string): Promise<void> {
+    const supabase = this.getClient() as any
+
+    const { data: factura } = await supabase
+      .from("factura")
+      .select("movimiento_id")
+      .eq("id", id)
+      .maybeSingle()
+    if (factura?.movimiento_id) {
+      await supabase.from("movimiento").update({ factura_id: null }).eq("id", factura.movimiento_id)
+    }
+
+    await supabase.from("archivo_adjunto").delete().eq("entidad", "factura").eq("entidad_id", id)
+
+    const { error } = await supabase.from("factura").delete().eq("id", id)
+    if (error) throw error
+  }
+
+  /**
+   * Vincula una factura a un movimiento existente (conciliación).
+   * - El trigger de BD pasa la factura a 'pagada'.
+   * - Sincroniza el contacto en ambos sentidos (sin machacar el que exista).
+   * - Adopta importe/fecha del movimiento si la factura no los tenía.
+   * - Replica los adjuntos de la factura en movimiento_archivo (mismo Storage).
+   */
+  static async linkFacturaToMovimiento(
+    facturaId: string,
+    movimientoId: string,
+    creadoPor?: string,
+  ): Promise<void> {
+    const supabase = this.getClient() as any
+
+    const [{ data: factura, error: facturaErr }, { data: movimiento, error: movErr }] = await Promise.all([
+      supabase.from("factura").select("*").eq("id", facturaId).maybeSingle(),
+      supabase.from("movimiento").select("id, fecha, importe, contacto_id, factura_id").eq("id", movimientoId).maybeSingle(),
+    ])
+    if (facturaErr) throw facturaErr
+    if (movErr) throw movErr
+    if (!factura) throw new Error("Factura no encontrada")
+    if (!movimiento) throw new Error("Movimiento no encontrado")
+    if (factura.movimiento_id) throw new Error("Esta factura ya está vinculada a un movimiento")
+    if (movimiento.factura_id) throw new Error("Ese movimiento ya tiene una factura vinculada")
+
+    const facturaUpdates: Record<string, unknown> = { movimiento_id: movimientoId }
+    if (factura.importe == null) facturaUpdates.importe = Math.abs(Number(movimiento.importe))
+    if (!factura.fecha_emision && movimiento.fecha) facturaUpdates.fecha_emision = movimiento.fecha
+    if (!factura.contacto_id && movimiento.contacto_id) facturaUpdates.contacto_id = movimiento.contacto_id
+
+    const { error: updFacturaErr } = await supabase
+      .from("factura")
+      .update(facturaUpdates)
+      .eq("id", facturaId)
+    if (updFacturaErr) throw updFacturaErr
+
+    const movimientoUpdates: Record<string, unknown> = { factura_id: facturaId }
+    if (factura.contacto_id && !movimiento.contacto_id) movimientoUpdates.contacto_id = factura.contacto_id
+
+    const { error: updMovErr } = await supabase
+      .from("movimiento")
+      .update(movimientoUpdates)
+      .eq("id", movimientoId)
+    if (updMovErr) {
+      // rollback best-effort del lado factura
+      await supabase.from("factura").update({ movimiento_id: null }).eq("id", facturaId)
+      throw updMovErr
+    }
+
+    let userId = creadoPor
+    if (!userId) {
+      const { data } = await supabase.auth.getUser()
+      userId = data?.user?.id ?? undefined
+    }
+    if (userId) {
+      await this.replicateArchivosFacturaToMovimiento(facturaId, movimientoId, userId).catch((err) =>
+        console.warn("No se pudieron replicar adjuntos de la factura al movimiento:", err),
+      )
+    }
+  }
+
+  /**
+   * Desvincula una factura de su movimiento (el trigger la deja en 'sin_pagar').
+   */
+  static async unlinkFacturaFromMovimiento(facturaId: string): Promise<void> {
+    const supabase = this.getClient() as any
+    const { data: factura } = await supabase
+      .from("factura")
+      .select("movimiento_id")
+      .eq("id", facturaId)
+      .maybeSingle()
+    if (!factura?.movimiento_id) return
+
+    const movimientoId = factura.movimiento_id
+    const { error: e1 } = await supabase
+      .from("factura")
+      .update({ movimiento_id: null })
+      .eq("id", facturaId)
+    if (e1) throw e1
+
+    const { error: e2 } = await supabase
+      .from("movimiento")
+      .update({ factura_id: null })
+      .eq("id", movimientoId)
+    if (e2) throw e2
+  }
+
+  /**
+   * Inserta copias de los adjuntos de la factura en movimiento_archivo
+   * apuntando al mismo path de Storage (idempotente por UNIQUE).
+   */
+  private static async replicateArchivosFacturaToMovimiento(
+    facturaId: string,
+    movimientoId: string,
+    subidoPor: string,
+  ): Promise<void> {
+    const supabase = this.getClient() as any
+
+    const { data: adjuntos, error } = await supabase
+      .from("archivo_adjunto")
+      .select("*")
+      .eq("entidad", "factura")
+      .eq("entidad_id", facturaId)
+    if (error) throw error
+    if (!Array.isArray(adjuntos) || adjuntos.length === 0) return
+
+    const inserts = adjuntos.map((a: any) => ({
+      movimiento_id: movimientoId,
+      nombre_original: a.nombre_original,
+      nombre_archivo: a.nombre_archivo,
+      tipo_mime: a.tipo_mime,
+      "tamaño_bytes": a.tamano_bytes,
+      bucket: a.bucket,
+      path_storage: a.path_storage,
+      url_publica: a.url_publica,
+      es_factura: true,
+      descripcion: a.descripcion,
+      subido_por: subidoPor,
+    }))
+
+    await supabase
+      .from("movimiento_archivo")
+      .upsert(inserts, { onConflict: "movimiento_id,path_storage", ignoreDuplicates: true })
+  }
+
+  /**
+   * Crea (si no existe) la entidad factura para un movimiento al que se le ha
+   * subido una factura. Copia fecha, importe y contacto del movimiento y queda
+   * vinculada y 'pagada'. Devuelve la factura (existente o recién creada).
+   */
+  static async ensureFacturaForMovimiento(
+    movimientoId: string,
+    options: { creadoPor?: string } = {},
+  ): Promise<Factura> {
+    const supabase = this.getClient() as any
+
+    const { data: movimiento, error: movErr } = await supabase
+      .from("movimiento")
+      .select("id, delegacion_id, fecha, concepto, importe, contacto_id, factura_id")
+      .eq("id", movimientoId)
+      .maybeSingle()
+    if (movErr) throw movErr
+    if (!movimiento) throw new Error("Movimiento no encontrado")
+
+    if (movimiento.factura_id) {
+      const { data: existente, error } = await supabase
+        .from("factura")
+        .select("*")
+        .eq("id", movimiento.factura_id)
+        .maybeSingle()
+      if (error) throw error
+      if (existente) return existente as Factura
+    }
+    if (!movimiento.delegacion_id) throw new Error("El movimiento no tiene delegación")
+
+    const insert: Record<string, unknown> = {
+      delegacion_id: movimiento.delegacion_id,
+      contacto_id: movimiento.contacto_id,
+      concepto: movimiento.concepto,
+      fecha_emision: movimiento.fecha,
+      importe: Math.abs(Number(movimiento.importe)) || null,
+      movimiento_id: movimiento.id,
+      origen: "movimiento",
+      creado_por: options.creadoPor ?? null,
+    }
+
+    const { data: creada, error: insertErr } = await supabase
+      .from("factura")
+      .insert(insert)
+      .select()
+      .single()
+    if (insertErr) throw insertErr
+
+    const { error: updErr } = await supabase
+      .from("movimiento")
+      .update({ factura_id: creada.id })
+      .eq("id", movimientoId)
+    if (updErr) {
+      await supabase.from("factura").delete().eq("id", creada.id)
+      throw updErr
+    }
+
+    return creada as Factura
+  }
+
+  /**
+   * Registra en archivo_adjunto (entidad='factura') un archivo ya subido a
+   * Storage (desde la bandeja o replicado desde movimiento_archivo). Idempotente.
+   */
+  static async registrarArchivoFactura(
+    facturaId: string,
+    delegacionId: string,
+    archivo: {
+      nombre_original: string
+      nombre_archivo: string
+      tipo_mime: string
+      tamanoBytes: number
+      bucket: string
+      path_storage: string
+      url_publica: string
+      descripcion?: string | null
+      subido_por: string
+    },
+  ): Promise<void> {
+    const supabase = this.getClient() as any
+    const { error } = await supabase.from("archivo_adjunto").upsert(
+      [
+        {
+          entidad: "factura",
+          entidad_id: facturaId,
+          delegacion_id: delegacionId,
+          nombre_original: archivo.nombre_original,
+          nombre_archivo: archivo.nombre_archivo,
+          tipo_mime: archivo.tipo_mime,
+          tamano_bytes: archivo.tamanoBytes,
+          bucket: archivo.bucket,
+          path_storage: archivo.path_storage,
+          url_publica: archivo.url_publica,
+          es_factura: true,
+          descripcion: archivo.descripcion ?? null,
+          subido_por: archivo.subido_por,
+        },
+      ],
+      { onConflict: "entidad,entidad_id,path_storage", ignoreDuplicates: true },
+    )
+    if (error) throw error
+  }
+
+  /**
+   * Busca movimientos candidatos para conciliar con una factura.
+   * El importe manda (con un pequeño margen); la fecha y el contacto afinan.
+   * Devuelve la lista ordenada por puntuación (mejor primero).
+   */
+  static async findCandidatosMovimientoParaFactura(
+    delegacionId: string,
+    factura: { importe?: number | null; fecha_emision?: string | null; contacto_id?: string | null },
+    opts: { limit?: number; signal?: AbortSignal } = {},
+  ): Promise<MovimientoConRelaciones[]> {
+    const supabase = this.getClient() as any
+    let query = supabase
+      .from("movimiento")
+      .select(`
+        id,
+        delegacion_id,
+        cuenta_id,
+        fecha,
+        concepto,
+        descripcion,
+        importe,
+        notas,
+        ignorado,
+        categoria_id,
+        contacto_id,
+        factura_id,
+        creado_en,
+        cuenta:cuenta_id (
+          id,
+          nombre,
+          banco_nombre,
+          color
+        )
+      `)
+      .eq("delegacion_id", delegacionId)
+      .is("factura_id", null)
+      .eq("ignorado", false)
+      .lt("importe", 0)
+      .order("fecha", { ascending: false })
+
+    if (factura.importe != null && factura.importe > 0) {
+      // Facturas son gastos: el movimiento tendrá importe negativo.
+      const margen = margenImporteFactura(factura.importe)
+      query = query
+        .gte("importe", -(Number(factura.importe) + margen))
+        .lte("importe", -(Number(factura.importe) - margen))
+        .limit(opts.limit ?? 30)
+    } else {
+      // Sin importe conocido: últimos gastos sin factura.
+      query = query.limit(opts.limit ?? 30)
+    }
+
+    if (opts.signal) query = query.abortSignal(opts.signal)
+
+    const { data, error } = await query
+    if (error) throw error
+    const list = (data ?? []) as MovimientoConRelaciones[]
+
+    return list
+      .map((m) => ({ m, s: scoreCandidatoMovimiento(factura, m) }))
+      .sort((a, b) => b.s.score - a.s.score || (a.m.fecha < b.m.fecha ? 1 : -1))
+      .map(({ m }) => m)
+  }
+
+  /**
+   * Busca facturas candidatas para conciliar con un movimiento (lado movimiento).
+   * Solo facturas sin movimiento vinculado; el importe manda.
+   */
+  static async findCandidatosFacturaParaMovimiento(
+    movimientoId: string,
+    opts: { limit?: number; signal?: AbortSignal } = {},
+  ): Promise<FacturaConRelaciones[]> {
+    const supabase = this.getClient() as any
+
+    const { data: movimiento, error: movErr } = await supabase
+      .from("movimiento")
+      .select("id, delegacion_id, fecha, importe, contacto_id")
+      .eq("id", movimientoId)
+      .maybeSingle()
+    if (movErr) throw movErr
+    if (!movimiento?.delegacion_id) return []
+
+    let query = supabase
+      .from("factura")
+      .select(this.FACTURA_SELECT)
+      .eq("delegacion_id", movimiento.delegacion_id)
+      .is("movimiento_id", null)
+      .order("creado_en", { ascending: false })
+      .limit(opts.limit ?? 40)
+    if (opts.signal) query = query.abortSignal(opts.signal)
+
+    const { data, error } = await query
+    if (error) throw error
+    const facturas = (data ?? []) as FacturaConRelaciones[]
+
+    const importeMov = Math.abs(Number(movimiento.importe))
+    const scored = facturas
+      .map((f) => {
+        const score = scoreCandidatoMovimiento(
+          { importe: f.importe, fecha_emision: f.fecha_emision, contacto_id: f.contacto_id },
+          { importe: movimiento.importe, fecha: movimiento.fecha, contacto_id: movimiento.contacto_id } as any,
+        )
+        // Descarta las que se van mucho de precio (si ambas tienen importe)
+        const fueraDeMargen =
+          f.importe != null && Math.abs(Number(f.importe) - importeMov) > margenImporteFactura(importeMov)
+        return { f, score, fueraDeMargen }
+      })
+      .filter(({ fueraDeMargen }) => !fueraDeMargen)
+      .sort((a, b) => b.score.score - a.score.score)
+      .map(({ f }) => f)
+
+    return this.attachArchivosToFacturas(scored, opts.signal)
   }
 
   // ---------------------------------------------------------------------------

--- a/lib/services/database.ts
+++ b/lib/services/database.ts
@@ -793,7 +793,7 @@ export class DatabaseService {
       email,
       identificador_fiscal
     ),
-    movimiento:movimiento_id (
+    movimientos:movimiento (
       id,
       fecha,
       concepto,
@@ -881,13 +881,14 @@ export class DatabaseService {
 
   static async getFacturaByMovimiento(movimientoId: string): Promise<FacturaConRelaciones | null> {
     const supabase = this.getClient() as any
-    const { data, error } = await supabase
-      .from("factura")
-      .select(this.FACTURA_SELECT)
-      .eq("movimiento_id", movimientoId)
+    const { data: movimiento, error: movErr } = await supabase
+      .from("movimiento")
+      .select("factura_id")
+      .eq("id", movimientoId)
       .maybeSingle()
-    if (error) throw error
-    return (data ?? null) as FacturaConRelaciones | null
+    if (movErr) throw movErr
+    if (!movimiento?.factura_id) return null
+    return this.getFacturaById(movimiento.factura_id)
   }
 
   static async createFactura(
@@ -907,21 +908,14 @@ export class DatabaseService {
 
   /**
    * Elimina una factura y sus adjuntos (registros; el borrado en Storage lo
-   * hace el hook de archivos antes de llamar aquí, si procede). Si estaba
-   * vinculada a un movimiento, lo desvincula primero.
+   * hace el hook de archivos antes de llamar aquí, si procede). Desvincula
+   * todos los movimientos que tuviera asociados (puede haber varios: pagos
+   * en varios plazos).
    */
   static async deleteFactura(id: string): Promise<void> {
     const supabase = this.getClient() as any
 
-    const { data: factura } = await supabase
-      .from("factura")
-      .select("movimiento_id")
-      .eq("id", id)
-      .maybeSingle()
-    if (factura?.movimiento_id) {
-      await supabase.from("movimiento").update({ factura_id: null }).eq("id", factura.movimiento_id)
-    }
-
+    await supabase.from("movimiento").update({ factura_id: null }).eq("factura_id", id)
     await supabase.from("archivo_adjunto").delete().eq("entidad", "factura").eq("entidad_id", id)
 
     const { error } = await supabase.from("factura").delete().eq("id", id)
@@ -929,10 +923,13 @@ export class DatabaseService {
   }
 
   /**
-   * Vincula una factura a un movimiento existente (conciliación).
-   * - El trigger de BD pasa la factura a 'pagada'.
+   * Vincula una factura a un movimiento existente (conciliación). Una factura
+   * puede tener varios movimientos vinculados (pago en varios plazos); un
+   * movimiento, como mucho, uno.
+   * - El trigger de BD recalcula el estado de la factura (pagada / pagada_parcial)
+   *   comparando su importe con la suma de los movimientos vinculados.
    * - Sincroniza el contacto en ambos sentidos (sin machacar el que exista).
-   * - Adopta importe/fecha del movimiento si la factura no los tenía.
+   * - Rellena importe/fecha de la factura desde el movimiento solo si estaban vacíos.
    * - Replica los adjuntos de la factura en movimiento_archivo (mismo Storage).
    */
   static async linkFacturaToMovimiento(
@@ -950,19 +947,7 @@ export class DatabaseService {
     if (movErr) throw movErr
     if (!factura) throw new Error("Factura no encontrada")
     if (!movimiento) throw new Error("Movimiento no encontrado")
-    if (factura.movimiento_id) throw new Error("Esta factura ya está vinculada a un movimiento")
     if (movimiento.factura_id) throw new Error("Ese movimiento ya tiene una factura vinculada")
-
-    const facturaUpdates: Record<string, unknown> = { movimiento_id: movimientoId }
-    if (factura.importe == null) facturaUpdates.importe = Math.abs(Number(movimiento.importe))
-    if (!factura.fecha_emision && movimiento.fecha) facturaUpdates.fecha_emision = movimiento.fecha
-    if (!factura.contacto_id && movimiento.contacto_id) facturaUpdates.contacto_id = movimiento.contacto_id
-
-    const { error: updFacturaErr } = await supabase
-      .from("factura")
-      .update(facturaUpdates)
-      .eq("id", facturaId)
-    if (updFacturaErr) throw updFacturaErr
 
     const movimientoUpdates: Record<string, unknown> = { factura_id: facturaId }
     if (factura.contacto_id && !movimiento.contacto_id) movimientoUpdates.contacto_id = factura.contacto_id
@@ -971,10 +956,16 @@ export class DatabaseService {
       .from("movimiento")
       .update(movimientoUpdates)
       .eq("id", movimientoId)
-    if (updMovErr) {
-      // rollback best-effort del lado factura
-      await supabase.from("factura").update({ movimiento_id: null }).eq("id", facturaId)
-      throw updMovErr
+    if (updMovErr) throw updMovErr
+
+    // Relleno best-effort de datos de la factura (no bloquea el vínculo si falla).
+    const facturaUpdates: Record<string, unknown> = {}
+    if (factura.importe == null) facturaUpdates.importe = Math.abs(Number(movimiento.importe))
+    if (!factura.fecha_emision && movimiento.fecha) facturaUpdates.fecha_emision = movimiento.fecha
+    if (!factura.contacto_id && movimiento.contacto_id) facturaUpdates.contacto_id = movimiento.contacto_id
+    if (Object.keys(facturaUpdates).length > 0) {
+      const { error } = await supabase.from("factura").update(facturaUpdates).eq("id", facturaId)
+      if (error) console.warn("No se pudieron rellenar los datos de la factura:", error)
     }
 
     let userId = creadoPor
@@ -990,29 +981,18 @@ export class DatabaseService {
   }
 
   /**
-   * Desvincula una factura de su movimiento (el trigger la deja en 'sin_pagar').
+   * Desvincula un movimiento concreto de una factura (una factura puede tener
+   * varios; hay que indicar cuál se desvincula). El trigger recalcula el
+   * estado de la factura con los movimientos restantes.
    */
-  static async unlinkFacturaFromMovimiento(facturaId: string): Promise<void> {
+  static async unlinkFacturaFromMovimiento(facturaId: string, movimientoId: string): Promise<void> {
     const supabase = this.getClient() as any
-    const { data: factura } = await supabase
-      .from("factura")
-      .select("movimiento_id")
-      .eq("id", facturaId)
-      .maybeSingle()
-    if (!factura?.movimiento_id) return
-
-    const movimientoId = factura.movimiento_id
-    const { error: e1 } = await supabase
-      .from("factura")
-      .update({ movimiento_id: null })
-      .eq("id", facturaId)
-    if (e1) throw e1
-
-    const { error: e2 } = await supabase
+    const { error } = await supabase
       .from("movimiento")
       .update({ factura_id: null })
       .eq("id", movimientoId)
-    if (e2) throw e2
+      .eq("factura_id", facturaId)
+    if (error) throw error
   }
 
   /**
@@ -1089,7 +1069,6 @@ export class DatabaseService {
       concepto: movimiento.concepto,
       fecha_emision: movimiento.fecha,
       importe: Math.abs(Number(movimiento.importe)) || null,
-      movimiento_id: movimiento.id,
       origen: "movimiento",
       creado_por: options.creadoPor ?? null,
     }
@@ -1222,7 +1201,9 @@ export class DatabaseService {
 
   /**
    * Busca facturas candidatas para conciliar con un movimiento (lado movimiento).
-   * Solo facturas sin movimiento vinculado; el importe manda.
+   * Excluye facturas ya completamente pagadas. El importe manda, pero comparado
+   * contra el importe PENDIENTE de la factura (importe total menos lo ya
+   * vinculado en otros movimientos), para soportar pagos en varios plazos.
    */
   static async findCandidatosFacturaParaMovimiento(
     movimientoId: string,
@@ -1242,7 +1223,7 @@ export class DatabaseService {
       .from("factura")
       .select(this.FACTURA_SELECT)
       .eq("delegacion_id", movimiento.delegacion_id)
-      .is("movimiento_id", null)
+      .not("estado", "in", "(pagada,pagada_fuera)")
       .order("creado_en", { ascending: false })
       .limit(opts.limit ?? 40)
     if (opts.signal) query = query.abortSignal(opts.signal)
@@ -1254,13 +1235,14 @@ export class DatabaseService {
     const importeMov = Math.abs(Number(movimiento.importe))
     const scored = facturas
       .map((f) => {
+        const pagado = (f.movimientos ?? []).reduce((sum, m) => sum + Math.abs(Number(m.importe)), 0)
+        const pendiente = f.importe != null ? Math.max(Number(f.importe) - pagado, 0) : null
         const score = scoreCandidatoMovimiento(
-          { importe: f.importe, fecha_emision: f.fecha_emision, contacto_id: f.contacto_id },
+          { importe: pendiente, fecha_emision: f.fecha_emision, contacto_id: f.contacto_id },
           { importe: movimiento.importe, fecha: movimiento.fecha, contacto_id: movimiento.contacto_id } as any,
         )
-        // Descarta las que se van mucho de precio (si ambas tienen importe)
-        const fueraDeMargen =
-          f.importe != null && Math.abs(Number(f.importe) - importeMov) > margenImporteFactura(importeMov)
+        // Descarta las que se van mucho de precio (si el pendiente es conocido)
+        const fueraDeMargen = pendiente != null && Math.abs(pendiente - importeMov) > margenImporteFactura(importeMov)
         return { f, score, fueraDeMargen }
       })
       .filter(({ fueraDeMargen }) => !fueraDeMargen)

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -54,7 +54,7 @@ export async function updateSession(request: NextRequest) {
   const isAuthRoute = request.nextUrl.pathname.startsWith("/auth")
 
   // Only protect specific routes, not everything
-  const protectedRoutes = ["/transacciones", "/categorias", "/cuentas", "/delegaciones", "/movimientos", "/contactos", "/pagos-mcm"]
+  const protectedRoutes = ["/transacciones", "/categorias", "/cuentas", "/delegaciones", "/movimientos", "/contactos", "/pagos-mcm", "/facturas"]
   const isProtectedRoute = protectedRoutes.some((route) => request.nextUrl.pathname.startsWith(route))
 
   if (isProtectedRoute && !user) {

--- a/lib/types/database.ts
+++ b/lib/types/database.ts
@@ -79,6 +79,34 @@ export type PagoMcmConRelaciones = PagoMcm & {
   > | null
 }
 
+export type Factura = Database["public"]["Tables"]["factura"]["Row"]
+export type FacturaInsert = Database["public"]["Tables"]["factura"]["Insert"]
+export type FacturaUpdate = Database["public"]["Tables"]["factura"]["Update"]
+// factura.estado y factura.origen son text en la BD; la app los restringe aquí.
+export type FacturaEstado = "bandeja" | "sin_pagar" | "pagada" | "pagada_fuera"
+export type FacturaOrigen = "subida" | "movimiento" | "email"
+
+export const FACTURA_ESTADOS: readonly FacturaEstado[] = [
+  "bandeja",
+  "sin_pagar",
+  "pagada",
+  "pagada_fuera",
+] as const
+
+export type FacturaConRelaciones = Omit<Factura, "estado" | "origen"> & {
+  estado: FacturaEstado
+  origen: FacturaOrigen
+  contacto?: Pick<Contacto, "id" | "nombre" | "tipo" | "emoji" | "color" | "email" | "identificador_fiscal"> | null
+  movimiento?: Pick<
+    Database["public"]["Tables"]["movimiento"]["Row"],
+    "id" | "fecha" | "concepto" | "importe" | "cuenta_id"
+  > | null
+  archivos?: Pick<
+    ArchivoAdjunto,
+    "id" | "nombre_original" | "tipo_mime" | "url_publica" | "path_storage" | "bucket" | "tamano_bytes" | "subido_en"
+  >[] | null
+}
+
 export type BancoSyncLogStep = {
   t: string
   level: "info" | "warn" | "error" | "debug"

--- a/lib/types/database.ts
+++ b/lib/types/database.ts
@@ -83,24 +83,31 @@ export type Factura = Database["public"]["Tables"]["factura"]["Row"]
 export type FacturaInsert = Database["public"]["Tables"]["factura"]["Insert"]
 export type FacturaUpdate = Database["public"]["Tables"]["factura"]["Update"]
 // factura.estado y factura.origen son text en la BD; la app los restringe aquí.
-export type FacturaEstado = "bandeja" | "sin_pagar" | "pagada" | "pagada_fuera"
+export type FacturaEstado = "bandeja" | "sin_pagar" | "pagada_parcial" | "pagada" | "pagada_fuera"
 export type FacturaOrigen = "subida" | "movimiento" | "email"
 
 export const FACTURA_ESTADOS: readonly FacturaEstado[] = [
   "bandeja",
   "sin_pagar",
+  "pagada_parcial",
   "pagada",
   "pagada_fuera",
 ] as const
 
+export type FacturaMovimientoVinculado = Pick<
+  Database["public"]["Tables"]["movimiento"]["Row"],
+  "id" | "fecha" | "concepto" | "importe" | "cuenta_id"
+>
+
+/**
+ * Una factura puede tener 0, 1 o varios movimientos vinculados (pago en
+ * varios plazos). `movimientos` sustituye al antiguo `movimiento` (1-a-1).
+ */
 export type FacturaConRelaciones = Omit<Factura, "estado" | "origen"> & {
   estado: FacturaEstado
   origen: FacturaOrigen
   contacto?: Pick<Contacto, "id" | "nombre" | "tipo" | "emoji" | "color" | "email" | "identificador_fiscal"> | null
-  movimiento?: Pick<
-    Database["public"]["Tables"]["movimiento"]["Row"],
-    "id" | "fecha" | "concepto" | "importe" | "cuenta_id"
-  > | null
+  movimientos?: FacturaMovimientoVinculado[]
   archivos?: Pick<
     ArchivoAdjunto,
     "id" | "nombre_original" | "tipo_mime" | "url_publica" | "path_storage" | "bucket" | "tamano_bytes" | "subido_en"

--- a/lib/types/supabase-generated.ts
+++ b/lib/types/supabase-generated.ts
@@ -685,6 +685,88 @@ export type Database = {
           },
         ]
       }
+      factura: {
+        Row: {
+          actualizado_en: string
+          concepto: string | null
+          contacto_id: string | null
+          creado_en: string
+          creado_por: string | null
+          datos_ia: Json | null
+          delegacion_id: string
+          email_remitente: string | null
+          estado: string
+          fecha_emision: string | null
+          id: string
+          importe: number | null
+          moneda: string
+          movimiento_id: string | null
+          notas: string | null
+          numero: string | null
+          origen: string
+        }
+        Insert: {
+          actualizado_en?: string
+          concepto?: string | null
+          contacto_id?: string | null
+          creado_en?: string
+          creado_por?: string | null
+          datos_ia?: Json | null
+          delegacion_id: string
+          email_remitente?: string | null
+          estado?: string
+          fecha_emision?: string | null
+          id?: string
+          importe?: number | null
+          moneda?: string
+          movimiento_id?: string | null
+          notas?: string | null
+          numero?: string | null
+          origen?: string
+        }
+        Update: {
+          actualizado_en?: string
+          concepto?: string | null
+          contacto_id?: string | null
+          creado_en?: string
+          creado_por?: string | null
+          datos_ia?: Json | null
+          delegacion_id?: string
+          email_remitente?: string | null
+          estado?: string
+          fecha_emision?: string | null
+          id?: string
+          importe?: number | null
+          moneda?: string
+          movimiento_id?: string | null
+          notas?: string | null
+          numero?: string | null
+          origen?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "factura_contacto_id_fkey"
+            columns: ["contacto_id"]
+            isOneToOne: false
+            referencedRelation: "contacto"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "factura_delegacion_id_fkey"
+            columns: ["delegacion_id"]
+            isOneToOne: false
+            referencedRelation: "delegacion"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "factura_movimiento_id_fkey"
+            columns: ["movimiento_id"]
+            isOneToOne: true
+            referencedRelation: "movimiento"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       google_credencial: {
         Row: {
           actualizado_en: string
@@ -888,6 +970,7 @@ export type Database = {
           external_id: string | null
           external_id_source: string | null
           external_raw: Json | null
+          factura_id: string | null
           fecha: string
           id: string
           ignorado: boolean
@@ -917,6 +1000,7 @@ export type Database = {
           external_id?: string | null
           external_id_source?: string | null
           external_raw?: Json | null
+          factura_id?: string | null
           fecha: string
           id?: string
           ignorado?: boolean
@@ -946,6 +1030,7 @@ export type Database = {
           external_id?: string | null
           external_id_source?: string | null
           external_raw?: Json | null
+          factura_id?: string | null
           fecha?: string
           id?: string
           ignorado?: boolean
@@ -986,6 +1071,13 @@ export type Database = {
             columns: ["cuenta_id"]
             isOneToOne: false
             referencedRelation: "cuenta"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "movimiento_factura_id_fkey"
+            columns: ["factura_id"]
+            isOneToOne: true
+            referencedRelation: "factura"
             referencedColumns: ["id"]
           },
           {

--- a/lib/types/supabase-generated.ts
+++ b/lib/types/supabase-generated.ts
@@ -700,7 +700,6 @@ export type Database = {
           id: string
           importe: number | null
           moneda: string
-          movimiento_id: string | null
           notas: string | null
           numero: string | null
           origen: string
@@ -719,7 +718,6 @@ export type Database = {
           id?: string
           importe?: number | null
           moneda?: string
-          movimiento_id?: string | null
           notas?: string | null
           numero?: string | null
           origen?: string
@@ -738,7 +736,6 @@ export type Database = {
           id?: string
           importe?: number | null
           moneda?: string
-          movimiento_id?: string | null
           notas?: string | null
           numero?: string | null
           origen?: string
@@ -756,13 +753,6 @@ export type Database = {
             columns: ["delegacion_id"]
             isOneToOne: false
             referencedRelation: "delegacion"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "factura_movimiento_id_fkey"
-            columns: ["movimiento_id"]
-            isOneToOne: true
-            referencedRelation: "movimiento"
             referencedColumns: ["id"]
           },
         ]
@@ -971,6 +961,7 @@ export type Database = {
           external_id_source: string | null
           external_raw: Json | null
           factura_id: string | null
+          factura_pendiente: boolean
           fecha: string
           id: string
           ignorado: boolean
@@ -1001,6 +992,7 @@ export type Database = {
           external_id_source?: string | null
           external_raw?: Json | null
           factura_id?: string | null
+          factura_pendiente?: boolean
           fecha: string
           id?: string
           ignorado?: boolean
@@ -1031,6 +1023,7 @@ export type Database = {
           external_id_source?: string | null
           external_raw?: Json | null
           factura_id?: string | null
+          factura_pendiente?: boolean
           fecha?: string
           id?: string
           ignorado?: boolean
@@ -1076,7 +1069,7 @@ export type Database = {
           {
             foreignKeyName: "movimiento_factura_id_fkey"
             columns: ["factura_id"]
-            isOneToOne: true
+            isOneToOne: false
             referencedRelation: "factura"
             referencedColumns: ["id"]
           },

--- a/lib/utils/facturas.ts
+++ b/lib/utils/facturas.ts
@@ -1,6 +1,6 @@
 import type { LucideIcon } from "lucide-react"
-import { BadgeCheck, CheckCircle2, Clock, ExternalLink, Inbox, Mail, Upload } from "lucide-react"
-import type { FacturaEstado, FacturaOrigen, MovimientoConRelaciones } from "@/lib/types/database"
+import { BadgeCheck, CheckCircle2, Clock, ExternalLink, Inbox, Mail, PieChart, Upload } from "lucide-react"
+import type { FacturaConRelaciones, FacturaEstado, FacturaOrigen, MovimientoConRelaciones } from "@/lib/types/database"
 
 export interface FacturaEstadoInfo {
   value: FacturaEstado
@@ -37,10 +37,21 @@ export const FACTURA_ESTADO_INFO: Record<FacturaEstado, FacturaEstadoInfo> = {
     textClass: "text-amber-700 dark:text-amber-300",
     borderClass: "border-amber-200/70 dark:border-amber-900/60",
   },
+  pagada_parcial: {
+    value: "pagada_parcial",
+    label: "Pago parcial",
+    descripcion: "Vinculada a uno o varios movimientos, pero aún no cubren el importe total.",
+    icon: PieChart,
+    tone: "amber",
+    dotClass: "bg-orange-500",
+    bgClass: "bg-orange-50 dark:bg-orange-950/30",
+    textClass: "text-orange-700 dark:text-orange-300",
+    borderClass: "border-orange-200/70 dark:border-orange-900/60",
+  },
   pagada: {
     value: "pagada",
     label: "Pagada",
-    descripcion: "Pagada y vinculada a un movimiento de MCM Bank.",
+    descripcion: "Pagada y vinculada a uno o varios movimientos de MCM Bank.",
     icon: CheckCircle2,
     tone: "emerald",
     dotClass: "bg-emerald-500",
@@ -64,9 +75,26 @@ export const FACTURA_ESTADO_INFO: Record<FacturaEstado, FacturaEstadoInfo> = {
 export const FACTURA_ESTADO_ORDER: readonly FacturaEstado[] = [
   "bandeja",
   "sin_pagar",
+  "pagada_parcial",
   "pagada",
   "pagada_fuera",
 ]
+
+/** Suma de los movimientos ya vinculados a una factura (valor absoluto). */
+export function importePagadoFactura(factura: Pick<FacturaConRelaciones, "movimientos">): number {
+  return (factura.movimientos ?? []).reduce((sum, m) => sum + Math.abs(Number(m.importe)), 0)
+}
+
+/**
+ * Importe que le falta a la factura por cubrir (null si no tiene importe
+ * definido). Nunca negativo.
+ */
+export function importePendienteFactura(
+  factura: Pick<FacturaConRelaciones, "movimientos" | "importe">,
+): number | null {
+  if (factura.importe == null) return null
+  return Math.max(Number(factura.importe) - importePagadoFactura(factura), 0)
+}
 
 export interface FacturaOrigenInfo {
   value: FacturaOrigen

--- a/lib/utils/facturas.ts
+++ b/lib/utils/facturas.ts
@@ -1,0 +1,142 @@
+import type { LucideIcon } from "lucide-react"
+import { BadgeCheck, CheckCircle2, Clock, ExternalLink, Inbox, Mail, Upload } from "lucide-react"
+import type { FacturaEstado, FacturaOrigen, MovimientoConRelaciones } from "@/lib/types/database"
+
+export interface FacturaEstadoInfo {
+  value: FacturaEstado
+  label: string
+  descripcion: string
+  icon: LucideIcon
+  tone: "sky" | "amber" | "emerald" | "violet"
+  dotClass: string
+  bgClass: string
+  textClass: string
+  borderClass: string
+}
+
+export const FACTURA_ESTADO_INFO: Record<FacturaEstado, FacturaEstadoInfo> = {
+  bandeja: {
+    value: "bandeja",
+    label: "En bandeja",
+    descripcion: "Recién subida, pendiente de revisar y completar datos.",
+    icon: Inbox,
+    tone: "sky",
+    dotClass: "bg-sky-500",
+    bgClass: "bg-sky-50 dark:bg-sky-950/30",
+    textClass: "text-sky-700 dark:text-sky-300",
+    borderClass: "border-sky-200/70 dark:border-sky-900/60",
+  },
+  sin_pagar: {
+    value: "sin_pagar",
+    label: "Sin pagar",
+    descripcion: "Registrada, pendiente de pago.",
+    icon: Clock,
+    tone: "amber",
+    dotClass: "bg-amber-500",
+    bgClass: "bg-amber-50 dark:bg-amber-950/30",
+    textClass: "text-amber-700 dark:text-amber-300",
+    borderClass: "border-amber-200/70 dark:border-amber-900/60",
+  },
+  pagada: {
+    value: "pagada",
+    label: "Pagada",
+    descripcion: "Pagada y vinculada a un movimiento de MCM Bank.",
+    icon: CheckCircle2,
+    tone: "emerald",
+    dotClass: "bg-emerald-500",
+    bgClass: "bg-emerald-50 dark:bg-emerald-950/30",
+    textClass: "text-emerald-700 dark:text-emerald-300",
+    borderClass: "border-emerald-200/70 dark:border-emerald-900/60",
+  },
+  pagada_fuera: {
+    value: "pagada_fuera",
+    label: "Pagada fuera",
+    descripcion: "Pagada, pero el movimiento está fuera de MCM Bank.",
+    icon: BadgeCheck,
+    tone: "violet",
+    dotClass: "bg-violet-500",
+    bgClass: "bg-violet-50 dark:bg-violet-950/30",
+    textClass: "text-violet-700 dark:text-violet-300",
+    borderClass: "border-violet-200/70 dark:border-violet-900/60",
+  },
+}
+
+export const FACTURA_ESTADO_ORDER: readonly FacturaEstado[] = [
+  "bandeja",
+  "sin_pagar",
+  "pagada",
+  "pagada_fuera",
+]
+
+export interface FacturaOrigenInfo {
+  value: FacturaOrigen
+  label: string
+  icon: LucideIcon
+}
+
+export const FACTURA_ORIGEN_INFO: Record<FacturaOrigen, FacturaOrigenInfo> = {
+  subida: { value: "subida", label: "Subida a mano", icon: Upload },
+  movimiento: { value: "movimiento", label: "Creada desde un movimiento", icon: ExternalLink },
+  email: { value: "email", label: "Recibida por email", icon: Mail },
+}
+
+/**
+ * Margen de importe para buscar movimientos candidatos de una factura:
+ * un 2% del importe con un mínimo de 0,50 € ("un pelín de margen").
+ */
+export function margenImporteFactura(importe: number): number {
+  return Math.max(Math.abs(importe) * 0.02, 0.5)
+}
+
+export interface CandidatoScore {
+  score: number
+  importeExacto: boolean
+  fechaCercana: boolean
+  mismoContacto: boolean
+}
+
+/**
+ * Puntúa un movimiento como candidato para una factura. El precio manda:
+ * importe exacto pesa mucho más que la fecha; el contacto ayuda a desempatar.
+ */
+export function scoreCandidatoMovimiento(
+  factura: { importe?: number | null; fecha_emision?: string | null; contacto_id?: string | null },
+  movimiento: Pick<MovimientoConRelaciones, "importe" | "fecha" | "contacto_id">,
+): CandidatoScore {
+  let score = 0
+
+  const importeExacto =
+    factura.importe != null && Math.abs(Math.abs(Number(movimiento.importe)) - Math.abs(Number(factura.importe))) < 0.005
+  if (importeExacto) score += 4
+  else if (factura.importe != null) score += 1 // dentro del margen (la query ya filtró)
+
+  let fechaCercana = false
+  if (factura.fecha_emision && movimiento.fecha) {
+    const diffDias = Math.abs(
+      (new Date(movimiento.fecha).getTime() - new Date(factura.fecha_emision).getTime()) / 86400000,
+    )
+    if (diffDias <= 5) {
+      score += 2
+      fechaCercana = true
+    } else if (diffDias <= 20) {
+      score += 1
+    }
+  }
+
+  const mismoContacto = Boolean(factura.contacto_id && movimiento.contacto_id === factura.contacto_id)
+  if (mismoContacto) score += 2
+
+  return { score, importeExacto, fechaCercana, mismoContacto }
+}
+
+/**
+ * Un candidato es "match directo" si tiene importe exacto y destaca claramente
+ * sobre el segundo (o es el único).
+ */
+export function esMatchDirecto(scores: CandidatoScore[]): boolean {
+  if (scores.length === 0) return false
+  const [primero, segundo] = scores
+  if (!primero.importeExacto) return false
+  if (!segundo) return true
+  return primero.score >= segundo.score + 2
+}

--- a/scripts/047_create_factura.sql
+++ b/scripts/047_create_factura.sql
@@ -1,0 +1,184 @@
+-- Facturas: bandeja de entrada de facturas de la delegación.
+-- Flujo principal: se sube el archivo (o llega por email en el futuro), se crea
+-- la entidad factura con los datos básicos (proveedor, importe, fecha) y se
+-- vincula a un movimiento bancario. No es una lista de "pendientes de pagar":
+-- casi siempre estarán ya pagadas cuando se suban; lo importante es conciliar.
+--
+-- Estados:
+--   - bandeja       recién subida, pendiente de revisar/completar datos
+--   - sin_pagar     registrada pero aún no pagada
+--   - pagada        pagada y vinculada a un movimiento de MCM Bank
+--   - pagada_fuera  pagada, pero el pago se hizo fuera de MCM Bank (no hay movimiento)
+--
+-- Origen:
+--   - subida        subida a mano desde la sección Facturas
+--   - movimiento    creada automáticamente al subir una factura a un movimiento
+--   - email         (futuro) recibida en el buzón de facturas de la delegación
+--
+-- Los archivos de la factura viven en archivo_adjunto con entidad='factura'.
+-- Al vincular la factura a un movimiento se replican en movimiento_archivo
+-- (mismo path de Storage) para que la UI de movimientos los muestre sin cambios.
+
+CREATE TABLE IF NOT EXISTS public.factura (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    delegacion_id UUID NOT NULL REFERENCES public.delegacion(id) ON DELETE CASCADE,
+    contacto_id UUID REFERENCES public.contacto(id) ON DELETE SET NULL,
+
+    concepto TEXT,
+    numero TEXT,
+    fecha_emision DATE,
+    importe NUMERIC(12, 2) CHECK (importe IS NULL OR importe > 0),
+    moneda TEXT NOT NULL DEFAULT 'EUR',
+
+    estado TEXT NOT NULL DEFAULT 'bandeja'
+        CHECK (estado IN ('bandeja', 'sin_pagar', 'pagada', 'pagada_fuera')),
+
+    -- Vínculo con movimiento (opcional, 1-a-1). Al vincular, estado pasa a 'pagada'.
+    movimiento_id UUID UNIQUE REFERENCES public.movimiento(id) ON DELETE SET NULL,
+
+    origen TEXT NOT NULL DEFAULT 'subida'
+        CHECK (origen IN ('subida', 'movimiento', 'email')),
+    -- Remitente del email (integración futura: buzón de facturas por delegación)
+    email_remitente TEXT,
+    -- Datos extraídos por IA (integración futura: Gemini / Document AI)
+    datos_ia JSONB,
+
+    notas TEXT,
+    creado_por UUID,
+    creado_en TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now()),
+    actualizado_en TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS idx_factura_delegacion_estado
+    ON public.factura(delegacion_id, estado);
+
+CREATE INDEX IF NOT EXISTS idx_factura_contacto
+    ON public.factura(contacto_id)
+    WHERE contacto_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_factura_movimiento
+    ON public.factura(movimiento_id)
+    WHERE movimiento_id IS NOT NULL;
+
+-- Para el matching por importe de facturas sin conciliar
+CREATE INDEX IF NOT EXISTS idx_factura_delegacion_importe_sin_movimiento
+    ON public.factura(delegacion_id, importe)
+    WHERE movimiento_id IS NULL;
+
+-- Trigger BEFORE UPDATE: mantiene actualizado_en y sincroniza estado con movimiento_id
+CREATE OR REPLACE FUNCTION public.set_factura_actualizado_en()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.actualizado_en = timezone('utc', now());
+
+    -- Al vincular un movimiento, la factura queda pagada (y dentro de MCM Bank)
+    IF NEW.movimiento_id IS NOT NULL AND NEW.estado <> 'pagada' THEN
+        NEW.estado = 'pagada';
+    END IF;
+
+    -- Al desvincular, vuelve a 'sin_pagar' (el usuario puede marcarla pagada_fuera)
+    IF NEW.movimiento_id IS NULL AND OLD.movimiento_id IS NOT NULL AND NEW.estado = 'pagada' THEN
+        NEW.estado = 'sin_pagar';
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SET search_path = public, pg_temp;
+
+DROP TRIGGER IF EXISTS trg_factura_actualizado_en ON public.factura;
+CREATE TRIGGER trg_factura_actualizado_en
+    BEFORE UPDATE ON public.factura
+    FOR EACH ROW
+    EXECUTE FUNCTION public.set_factura_actualizado_en();
+
+-- Trigger BEFORE INSERT: coherencia inicial estado/movimiento_id
+CREATE OR REPLACE FUNCTION public.set_factura_insert_defaults()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.movimiento_id IS NOT NULL AND NEW.estado <> 'pagada' THEN
+        NEW.estado = 'pagada';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SET search_path = public, pg_temp;
+
+DROP TRIGGER IF EXISTS trg_factura_insert_defaults ON public.factura;
+CREATE TRIGGER trg_factura_insert_defaults
+    BEFORE INSERT ON public.factura
+    FOR EACH ROW
+    EXECUTE FUNCTION public.set_factura_insert_defaults();
+
+-- RLS (mismo modelo que pago_mcm)
+ALTER TABLE public.factura ENABLE ROW LEVEL SECURITY;
+
+-- SELECT: cualquier miembro de la delegación (incluida solo lectura)
+CREATE POLICY "Users can view facturas of their delegations" ON public.factura
+    FOR SELECT
+    USING (
+        EXISTS (
+            SELECT 1 FROM public.membresia mb
+            WHERE mb.delegacion_id = factura.delegacion_id
+              AND mb.usuario_id = auth.uid()
+        )
+    );
+
+-- INSERT / UPDATE / DELETE: tesorero / gestor_central de la delegación o gestor_central global
+CREATE POLICY "Users can insert facturas in their delegations" ON public.factura
+    FOR INSERT
+    WITH CHECK (
+        EXISTS (
+            SELECT 1 FROM public.membresia mb
+            WHERE mb.usuario_id = auth.uid()
+              AND (
+                (mb.delegacion_id = factura.delegacion_id AND mb.rol IN ('tesorero', 'gestor_central'))
+                OR (mb.rol = 'gestor_central')
+              )
+        )
+    );
+
+CREATE POLICY "Users can update facturas in their delegations" ON public.factura
+    FOR UPDATE
+    USING (
+        EXISTS (
+            SELECT 1 FROM public.membresia mb
+            WHERE mb.usuario_id = auth.uid()
+              AND (
+                (mb.delegacion_id = factura.delegacion_id AND mb.rol IN ('tesorero', 'gestor_central'))
+                OR (mb.rol = 'gestor_central')
+              )
+        )
+    );
+
+CREATE POLICY "Users can delete facturas in their delegations" ON public.factura
+    FOR DELETE
+    USING (
+        EXISTS (
+            SELECT 1 FROM public.membresia mb
+            WHERE mb.usuario_id = auth.uid()
+              AND (
+                (mb.delegacion_id = factura.delegacion_id AND mb.rol IN ('tesorero', 'gestor_central'))
+                OR (mb.rol = 'gestor_central')
+              )
+        )
+    );
+
+-- Vínculo inverso desde movimiento (relación 1-a-1 con factura)
+ALTER TABLE public.movimiento
+    ADD COLUMN IF NOT EXISTS factura_id UUID UNIQUE REFERENCES public.factura(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_movimiento_factura
+    ON public.movimiento(factura_id)
+    WHERE factura_id IS NOT NULL;
+
+-- archivo_adjunto ahora acepta también entidad='factura'
+ALTER TABLE public.archivo_adjunto DROP CONSTRAINT IF EXISTS archivo_adjunto_entidad_check;
+ALTER TABLE public.archivo_adjunto
+    ADD CONSTRAINT archivo_adjunto_entidad_check
+    CHECK (entidad IN ('pago_mcm', 'movimiento', 'factura'));
+
+COMMENT ON TABLE public.factura IS 'Bandeja de facturas por delegación: se suben archivos, se completan datos básicos y se concilian con movimientos bancarios.';
+COMMENT ON COLUMN public.factura.estado IS 'bandeja | sin_pagar | pagada (vinculada a movimiento) | pagada_fuera (pagada fuera de MCM Bank). Pasa a pagada automáticamente al vincular movimiento_id.';
+COMMENT ON COLUMN public.factura.origen IS 'subida | movimiento (creada al subir factura a un movimiento) | email (buzón de facturas, integración futura).';
+COMMENT ON COLUMN public.factura.email_remitente IS 'Remitente del correo que originó la factura (integración futura de buzón por delegación).';
+COMMENT ON COLUMN public.factura.datos_ia IS 'JSON con los datos extraídos por IA (proveedor, fecha, importe) en la integración futura de lectura automática.';
+COMMENT ON COLUMN public.movimiento.factura_id IS 'Factura (1-a-1) conciliada con este movimiento.';

--- a/scripts/048_factura_pagos_multiples.sql
+++ b/scripts/048_factura_pagos_multiples.sql
@@ -1,0 +1,160 @@
+-- Una factura puede tener 0, 1 o varios movimientos vinculados (pago en varios
+-- plazos: p.ej. una factura de 3.000 € pagada en dos transferencias de 1.500 €).
+-- Pasamos de 1-a-1 a 1 factura -> N movimientos: cada movimiento apunta a lo
+-- sumo a una factura (movimiento.factura_id), pero varios movimientos pueden
+-- apuntar a la misma factura. El campo factura.movimiento_id (1-a-1) se elimina;
+-- el estado de la factura se recalcula automáticamente comparando el importe
+-- de la factura con la suma de los movimientos vinculados.
+
+-- 1) movimiento.factura_id deja de ser único (varios movimientos -> misma factura)
+ALTER TABLE public.movimiento DROP CONSTRAINT IF EXISTS movimiento_factura_id_key;
+
+-- 2) factura.movimiento_id (1-a-1) ya no tiene sentido: el vínculo vive solo
+--    del lado movimiento.factura_id.
+DROP INDEX IF EXISTS idx_factura_movimiento;
+ALTER TABLE public.factura DROP COLUMN IF EXISTS movimiento_id;
+
+-- 3) Nuevo estado intermedio: pagada parcialmente.
+ALTER TABLE public.factura DROP CONSTRAINT IF EXISTS factura_estado_check;
+ALTER TABLE public.factura
+    ADD CONSTRAINT factura_estado_check
+    CHECK (estado IN ('bandeja', 'sin_pagar', 'pagada_parcial', 'pagada', 'pagada_fuera'));
+
+-- 4) Los triggers antiguos dependían de factura.movimiento_id: se sustituyen.
+DROP TRIGGER IF EXISTS trg_factura_actualizado_en ON public.factura;
+DROP TRIGGER IF EXISTS trg_factura_insert_defaults ON public.factura;
+DROP FUNCTION IF EXISTS public.set_factura_actualizado_en();
+DROP FUNCTION IF EXISTS public.set_factura_insert_defaults();
+
+-- Mantiene actualizado_en en cualquier UPDATE (sin lógica de movimiento_id: eso
+-- ahora lo gestiona recalcular_estado_factura desde el lado movimiento).
+CREATE OR REPLACE FUNCTION public.set_factura_actualizado_en()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.actualizado_en = timezone('utc', now());
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SET search_path = public, pg_temp;
+
+CREATE TRIGGER trg_factura_actualizado_en
+    BEFORE UPDATE ON public.factura
+    FOR EACH ROW
+    EXECUTE FUNCTION public.set_factura_actualizado_en();
+
+-- 5) Recalcula el estado de una factura a partir de la suma de sus movimientos
+--    vinculados. Un 2% de margen (mínimo 0,50 €) para no exigir centavo exacto.
+--    'pagada_fuera' es una marca manual que se respeta mientras no haya ningún
+--    movimiento real vinculado (si lo hay, la realidad manda).
+CREATE OR REPLACE FUNCTION public.recalcular_estado_factura(p_factura_id UUID)
+RETURNS VOID AS $$
+DECLARE
+    v_total_pagado NUMERIC;
+    v_importe NUMERIC;
+    v_estado_actual TEXT;
+    v_margen NUMERIC;
+    v_nuevo_estado TEXT;
+BEGIN
+    SELECT importe, estado INTO v_importe, v_estado_actual
+    FROM public.factura WHERE id = p_factura_id;
+
+    IF NOT FOUND THEN
+        RETURN;
+    END IF;
+
+    SELECT COALESCE(SUM(ABS(importe)), 0) INTO v_total_pagado
+    FROM public.movimiento WHERE factura_id = p_factura_id;
+
+    v_margen := GREATEST(COALESCE(v_importe, 0) * 0.02, 0.5);
+
+    IF v_total_pagado = 0 THEN
+        v_nuevo_estado := CASE
+            WHEN v_estado_actual IN ('bandeja', 'pagada_fuera') THEN v_estado_actual
+            ELSE 'sin_pagar'
+        END;
+    ELSIF v_importe IS NOT NULL AND v_total_pagado >= (v_importe - v_margen) THEN
+        v_nuevo_estado := 'pagada';
+    ELSE
+        v_nuevo_estado := 'pagada_parcial';
+    END IF;
+
+    IF v_nuevo_estado IS DISTINCT FROM v_estado_actual THEN
+        UPDATE public.factura SET estado = v_nuevo_estado WHERE id = p_factura_id;
+    END IF;
+END;
+$$ LANGUAGE plpgsql SET search_path = public, pg_temp;
+
+-- 6) Trigger en movimiento: cualquier alta/baja/cambio de factura_id o importe
+--    recalcula el estado de la(s) factura(s) afectada(s).
+CREATE OR REPLACE FUNCTION public.trg_movimiento_recalcular_factura()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        IF OLD.factura_id IS NOT NULL THEN
+            PERFORM public.recalcular_estado_factura(OLD.factura_id);
+        END IF;
+        RETURN OLD;
+    END IF;
+
+    IF TG_OP = 'INSERT' THEN
+        IF NEW.factura_id IS NOT NULL THEN
+            PERFORM public.recalcular_estado_factura(NEW.factura_id);
+        END IF;
+        RETURN NEW;
+    END IF;
+
+    -- UPDATE
+    IF OLD.factura_id IS DISTINCT FROM NEW.factura_id THEN
+        IF OLD.factura_id IS NOT NULL THEN
+            PERFORM public.recalcular_estado_factura(OLD.factura_id);
+        END IF;
+        IF NEW.factura_id IS NOT NULL THEN
+            PERFORM public.recalcular_estado_factura(NEW.factura_id);
+        END IF;
+    ELSIF NEW.factura_id IS NOT NULL AND OLD.importe IS DISTINCT FROM NEW.importe THEN
+        PERFORM public.recalcular_estado_factura(NEW.factura_id);
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SET search_path = public, pg_temp;
+
+DROP TRIGGER IF EXISTS trg_movimiento_recalcular_factura ON public.movimiento;
+CREATE TRIGGER trg_movimiento_recalcular_factura
+    AFTER INSERT OR UPDATE OF factura_id, importe OR DELETE ON public.movimiento
+    FOR EACH ROW
+    EXECUTE FUNCTION public.trg_movimiento_recalcular_factura();
+
+-- 7) Cambiar el importe de la factura también debe recalcular su estado
+--    (p.ej. si se corrige el importe total tras vincular algún pago parcial).
+CREATE OR REPLACE FUNCTION public.trg_factura_importe_recalcular()
+RETURNS TRIGGER AS $$
+BEGIN
+    PERFORM public.recalcular_estado_factura(NEW.id);
+    RETURN NULL; -- AFTER trigger: el valor de retorno se ignora
+END;
+$$ LANGUAGE plpgsql SET search_path = public, pg_temp;
+
+DROP TRIGGER IF EXISTS trg_factura_importe_recalcular ON public.factura;
+CREATE TRIGGER trg_factura_importe_recalcular
+    AFTER UPDATE OF importe ON public.factura
+    FOR EACH ROW
+    EXECUTE FUNCTION public.trg_factura_importe_recalcular();
+
+COMMENT ON FUNCTION public.recalcular_estado_factura(UUID) IS 'Recalcula factura.estado comparando su importe con la suma de movimiento.importe de los movimientos vinculados (factura_id). pagada si cubre el importe (con margen del 2%, mín 0,50€), pagada_parcial si cubre una parte, sin_pagar si ninguna.';
+COMMENT ON COLUMN public.factura.estado IS 'bandeja | sin_pagar | pagada_parcial | pagada | pagada_fuera. Se recalcula automáticamente al vincular/desvincular movimientos, salvo pagada_fuera (marca manual) y bandeja (estado inicial sin tocar).';
+
+-- ---------------------------------------------------------------------------
+-- Marca manual "falta factura" en movimientos. No todos los movimientos
+-- llevan factura (nóminas, comisiones bancarias, etc.), pero el equipo puede
+-- marcar a mano los que sí deberían tenerla y aún no se ha subido, para
+-- poder filtrarlos y no perderlos de vista.
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE public.movimiento
+    ADD COLUMN IF NOT EXISTS factura_pendiente BOOLEAN NOT NULL DEFAULT false;
+
+CREATE INDEX IF NOT EXISTS idx_movimiento_factura_pendiente
+    ON public.movimiento(delegacion_id, factura_pendiente)
+    WHERE factura_pendiente = true;
+
+COMMENT ON COLUMN public.movimiento.factura_pendiente IS 'Marca manual: a este movimiento le falta subir/vincular su factura. No se pone automáticamente; el equipo la activa cuando corresponde.';


### PR DESCRIPTION
- Tabla factura (047) con estados bandeja/sin_pagar/pagada/pagada_fuera,
  vínculo 1-a-1 con movimiento, RLS por delegación y triggers de estado
  (migración ya aplicada en Supabase)
- Bandeja de entrada: arrastra varios archivos y se crea una factura por
  cada uno, lista para completar datos
- Conciliación con matching por importe (con margen), fecha y contacto,
  con "match directo" preseleccionado
- Creación inline de contacto proveedor desde el formulario de factura
- Lado movimiento: subir una factura crea la entidad conciliada con los
  datos del movimiento; también se puede vincular una factura de la bandeja
- Adjuntos en archivo_adjunto (entidad='factura') replicados a
  movimiento_archivo al conciliar
- Sidebar habilitado con contador de bandeja, ruta protegida y docs
  (docs/09-facturas.md) con la estructura para las integraciones de
  buzón de email por delegación y lectura automática con IA

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017oNeYa6MGTnEQkyWViDoRM