### PR TITLE
Add notices and tasks widget for delegation communication

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,8 @@ The app uses Supabase with a hierarchical structure:
 - **propuesta_mejora**: Improvement proposals (ideas and bug reports)
 - **propuesta_mejora_comentario**: Comments on proposals
 - **propuesta_mejora_voto**: Votes/reactions on proposals
+- **aviso**: Notices and tasks per delegation (technical office ↔ treasurers)
+- **aviso_lectura**: Read receipts for notices (one row per aviso/user)
 
 Type definitions for all tables are in `lib/types/database.ts` (Row/Insert/Update types for each table).
 
@@ -100,6 +102,7 @@ Also includes: `ThemeStateWatcher`, `ConnectionMonitor`, `Toaster` (Sonner).
 | `use-is-admin.ts` | Admin check |
 | `use-perfil.ts` | User profile |
 | `use-improvement-proposals.ts` | Proposals CRUD, voting, commenting |
+| `use-avisos.ts` | Notices/tasks per delegation, unread + pending counters |
 | `use-movimiento-archivos.ts` | Transaction file attachments |
 | `use-delegation-counts.ts` | Counts of items per delegation |
 | `use-app-status.ts` | App status with debounced revalidation |
@@ -125,6 +128,16 @@ Full feature for submitting ideas and bug reports:
 - **Features**: Comments, voting/reactions, author tracking, Kanban board view
 - **Components**: `components/improvement-proposals/` (7 components including board, cards, dialogs)
 - **Service**: `lib/services/improvement-proposals.ts`
+
+### Notices & Tasks (Avisos y tareas)
+Short notes between the central technical office (`gestor_central`) and each delegation's treasurers:
+- **Types**: `"tarea"` (has `estado` pendiente/hecha) and `"nota"` (informational; `hecha` = archived)
+- **Recipient** (`destinatario`): `"oficina_tecnica"` or `"delegacion"`
+- **Isolation**: every aviso belongs to a delegation; RLS only grants access to `membresia` holders of that delegation, so delegation A never sees B's notes
+- **Unread**: `aviso_lectura` holds one row per (aviso, user); the badge counts avisos with no receipt for the current user
+- **Email**: `POST /api/avisos/notificar` sends it with Resend (needs `RESEND_API_KEY`) to the treasurers of the delegation or to all central managers, never to the author
+- **UI**: floating button bottom-right, mounted once in `components/app-layout.tsx` (`components/avisos/`), opens with ⌘/Ctrl+I
+- **Types/service/hook**: `lib/types/avisos.ts`, `lib/services/avisos.ts`, `hooks/use-avisos.ts`
 
 ### File Uploads
 - Files uploaded to Supabase Storage buckets
@@ -162,12 +175,13 @@ components/                 # Reusable React components
   cuentas/                  # Account management (manager, edit form, delete dialog)
   categories/               # Category management (list, edit form, delete dialog)
   improvement-proposals/    # Proposals system (board, cards, comments, creation)
+  avisos/                   # Notices & tasks (floating widget, panel, composer, item)
   configuracion/            # Configuration page component
   diagnostics/              # Diagnostic center component
   debug/                    # Debug call stats viewer
 lib/                        # Business logic, utilities, types
   supabase/                 # Supabase clients (client, server, admin, middleware, redirect)
-  services/                 # Data service layer (database, server-database, file-service, improvement-proposals)
+  services/                 # Data service layer (database, server-database, file-service, avisos)
   types/                    # TypeScript types (database.ts, improvement-proposals.ts)
   utils/                    # Utilities (format, category-colors, export-to-excel, date-input, etc.)
   db/                       # Query execution and telemetry (query.ts, telemetry.ts)
@@ -193,6 +207,7 @@ docs/                       # End-user documentation in Spanish
 | `/auth/login` | Login page |
 | `/auth/sign-up` | Registration page |
 | `/auth/callback` | OAuth callback |
+| `/api/avisos/notificar` | Sends a notice/task by email via Resend |
 | `/api/admin/users` | Admin user management API |
 | `/api/supabase-sanity` | Supabase health check API |
 
@@ -293,7 +308,7 @@ This returns `CategoriaConOrdenEfectivo[]` with proper ordering and visibility.
 
 ## Documentation
 
-- **User manual**: `docs/README.md` and numbered chapters (`docs/01-acceso.md` through `docs/13-api-externa.md`, see `docs/SUMMARY.md` for the full index)
+- **User manual**: `docs/README.md` and numbered chapters (`docs/01-acceso.md` through `docs/14-avisos-tareas.md`, see `docs/SUMMARY.md` for the full index)
 - **Pending work (single backlog)**: `docs/ANALISIS_MEJORAS.md` — la lista única de desarrollos pendientes (seguridad, rendimiento, bugs, UI, funcionalidades y deuda técnica)
 - **Technical docs**: `docs/SUMMARY.md`, `docs/NEXTJS_16_UPGRADE.md`, `docs/OPTIMIZACIONES_REALIZADAS.md` (registro histórico de lo ya optimizado)
 - **Agent guidelines**: `AGENTS.md` for contributor coding conventions (in Spanish)

--- a/app/api/avisos/notificar/route.ts
+++ b/app/api/avisos/notificar/route.ts
@@ -1,0 +1,289 @@
+import { NextResponse } from "next/server"
+import { createClient } from "@/lib/supabase/server"
+import { createAdminClient } from "@/lib/supabase/admin"
+import { AVISO_DESTINATARIO_LABELS } from "@/lib/types/avisos"
+import type { AvisoDestinatario, AvisoTipo } from "@/lib/types/avisos"
+
+const ROLES_ESCRITURA = ["tesorero", "gestor_central"]
+const REMITENTE = "MCM Bank <no-reply@movimientoconsolacion.com>"
+
+/**
+ * Envía por correo (Resend) un aviso o tarea a quien corresponda:
+ *   - destinatario "delegacion"      → tesoreros de esa delegación
+ *   - destinatario "oficina_tecnica" → gestores centrales
+ * Nunca se envía al propio autor. El aviso queda marcado con notificado_en.
+ */
+export async function POST(req: Request) {
+  let body: any
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: "JSON inválido" }, { status: 400 })
+  }
+
+  const avisoId = typeof body?.avisoId === "string" ? body.avisoId : null
+  if (!avisoId) {
+    return NextResponse.json({ error: "Falta avisoId" }, { status: 400 })
+  }
+
+  const supabase = createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: "No autorizado" }, { status: 401 })
+  }
+
+  // RLS ya limita el aviso a las delegaciones del usuario.
+  const { data: aviso, error: avisoError } = await (supabase as any)
+    .from("aviso")
+    .select("id, delegacion_id, tipo, contenido, referencia, destinatario, creado_por, creado_en")
+    .eq("id", avisoId)
+    .maybeSingle()
+
+  if (avisoError) {
+    console.error("Error cargando el aviso a notificar:", avisoError)
+    return NextResponse.json({ error: "No se pudo cargar el aviso" }, { status: 500 })
+  }
+  if (!aviso) {
+    return NextResponse.json({ error: "Aviso no encontrado" }, { status: 404 })
+  }
+
+  // Solo quien puede escribir en la delegación puede lanzar correos.
+  const { data: membresia } = await (supabase as any)
+    .from("membresia")
+    .select("rol")
+    .eq("usuario_id", user.id)
+    .eq("delegacion_id", aviso.delegacion_id)
+    .maybeSingle()
+
+  const esGestorCentralGlobal = await (async () => {
+    const { data } = await (supabase as any)
+      .from("membresia")
+      .select("rol")
+      .eq("usuario_id", user.id)
+      .eq("rol", "gestor_central")
+      .limit(1)
+    return Boolean(data?.length)
+  })()
+
+  if (!membresia && !esGestorCentralGlobal) {
+    return NextResponse.json({ error: "Sin acceso a la delegación" }, { status: 403 })
+  }
+  if (!esGestorCentralGlobal && !ROLES_ESCRITURA.includes(membresia?.rol)) {
+    return NextResponse.json({ error: "Acceso restringido" }, { status: 403 })
+  }
+
+  const resendApiKey = process.env.RESEND_API_KEY
+  if (!resendApiKey) {
+    console.error("Falta RESEND_API_KEY: no se puede notificar el aviso.")
+    return NextResponse.json(
+      { error: "El servicio de correo no está configurado. El aviso se ha guardado igualmente." },
+      { status: 503 },
+    )
+  }
+
+  const destinatario = aviso.destinatario as AvisoDestinatario
+  const admin = createAdminClient()
+
+  // Destinatarios: tesoreros de la delegación, o toda la oficina técnica.
+  let membresiasQuery = (admin as any).from("membresia").select("usuario_id, rol")
+  membresiasQuery =
+    destinatario === "delegacion"
+      ? membresiasQuery.eq("delegacion_id", aviso.delegacion_id).eq("rol", "tesorero")
+      : membresiasQuery.eq("rol", "gestor_central")
+
+  const { data: destinatarios, error: destError } = await membresiasQuery
+  if (destError) {
+    console.error("Error resolviendo destinatarios del aviso:", destError)
+    return NextResponse.json({ error: "No se pudieron resolver los destinatarios" }, { status: 500 })
+  }
+
+  const idsDestino = Array.from(
+    new Set<string>((destinatarios ?? []).map((m: any) => String(m.usuario_id))),
+  ).filter((id) => id !== user.id)
+
+  if (idsDestino.length === 0) {
+    return NextResponse.json(
+      {
+        error:
+          destinatario === "delegacion"
+            ? "Esta delegación no tiene ningún tesorero al que avisar."
+            : "No hay nadie en la oficina técnica a quien avisar.",
+      },
+      { status: 409 },
+    )
+  }
+
+  // Emails y nombres
+  const { data: usuarios, error: usuariosError } = await admin.auth.admin.listUsers({ perPage: 1000 })
+  if (usuariosError) {
+    console.error("Error listando usuarios para notificar:", usuariosError)
+    return NextResponse.json({ error: "No se pudieron obtener los correos" }, { status: 500 })
+  }
+
+  const emailPorId = new Map<string, string>()
+  for (const u of usuarios?.users ?? []) {
+    if (u.email) emailPorId.set(u.id, u.email)
+  }
+
+  const emails = idsDestino.map((id) => emailPorId.get(id)).filter(Boolean) as string[]
+  if (emails.length === 0) {
+    return NextResponse.json({ error: "Los destinatarios no tienen correo configurado" }, { status: 409 })
+  }
+
+  const [{ data: delegacion }, { data: perfilAutor }] = await Promise.all([
+    (admin as any).from("delegacion").select("nombre").eq("id", aviso.delegacion_id).maybeSingle(),
+    (admin as any).from("perfil").select("nombre_completo").eq("usuario_id", aviso.creado_por).maybeSingle(),
+  ])
+
+  const autor = perfilAutor?.nombre_completo?.trim() || emailPorId.get(aviso.creado_por) || "Alguien"
+  const delegacionNombre = delegacion?.nombre || "MCM"
+  const tipo = aviso.tipo as AvisoTipo
+  const contenido = String(aviso.contenido ?? "")
+  const referencia = aviso.referencia ? String(aviso.referencia) : null
+
+  const asunto = `${tipo === "tarea" ? "Nueva tarea" : "Aviso"} · ${delegacionNombre} — ${resumen(contenido)}`
+  const enlace = (process.env.NEXT_PUBLIC_SITE_URL || "https://banco.movimientoconsolacion.com").replace(/\/$/, "")
+
+  const html = renderEmail({
+    tipo,
+    contenido,
+    referencia,
+    autor,
+    delegacionNombre,
+    destinatario,
+    enlace,
+  })
+
+  try {
+    const response = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${resendApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        from: REMITENTE,
+        to: emails,
+        subject: asunto,
+        html,
+        text: renderTexto({ tipo, contenido, referencia, autor, delegacionNombre, enlace }),
+        ...(emailPorId.get(aviso.creado_por) ? { reply_to: [emailPorId.get(aviso.creado_por)] } : {}),
+      }),
+    })
+
+    if (!response.ok) {
+      const detalle = await response.text()
+      console.error("Resend rechazó la notificación del aviso:", detalle)
+      return NextResponse.json({ error: "El correo no se pudo enviar" }, { status: 502 })
+    }
+  } catch (err: any) {
+    console.error("Error enviando la notificación del aviso:", err?.message || err)
+    return NextResponse.json({ error: "El correo no se pudo enviar" }, { status: 502 })
+  }
+
+  const { error: updateError } = await (supabase as any)
+    .from("aviso")
+    .update({ notificado_en: new Date().toISOString(), notificado_por: user.id })
+    .eq("id", aviso.id)
+
+  if (updateError) {
+    // El correo ya salió: no hacemos fallar la petición por el sello.
+    console.warn("Aviso notificado pero no se pudo sellar notificado_en:", updateError)
+  }
+
+  return NextResponse.json({ ok: true, destinatarios: emails })
+}
+
+function resumen(texto: string, max = 70): string {
+  const limpio = texto.replace(/\s+/g, " ").trim()
+  return limpio.length > max ? `${limpio.slice(0, max - 1)}…` : limpio
+}
+
+function escapeHtml(texto: string): string {
+  return texto
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;")
+}
+
+interface EmailData {
+  tipo: AvisoTipo
+  contenido: string
+  referencia: string | null
+  autor: string
+  delegacionNombre: string
+  destinatario: AvisoDestinatario
+  enlace: string
+}
+
+function renderEmail({ tipo, contenido, referencia, autor, delegacionNombre, destinatario, enlace }: EmailData) {
+  const esTarea = tipo === "tarea"
+  const etiqueta = esTarea ? "Tarea pendiente" : "Nota informativa"
+  const acento = esTarea ? "#b45309" : "#2563eb"
+  const acentoFondo = esTarea ? "#fffbeb" : "#eff6ff"
+
+  return `<!doctype html>
+<html lang="es">
+  <body style="margin:0;padding:32px 16px;background:#f6f7f9;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;color:#111827;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:520px;margin:0 auto;">
+      <tr>
+        <td style="background:#ffffff;border:1px solid #e5e7eb;border-radius:16px;padding:28px;">
+          <p style="margin:0 0 18px;font-size:12px;font-weight:600;letter-spacing:.04em;text-transform:uppercase;color:${acento};">
+            ${etiqueta}
+          </p>
+          <p style="margin:0 0 20px;font-size:17px;line-height:1.55;color:#111827;white-space:pre-wrap;">${escapeHtml(contenido)}</p>
+          ${
+            referencia
+              ? `<p style="margin:0 0 20px;"><span style="display:inline-block;background:${acentoFondo};color:${acento};border-radius:999px;padding:5px 12px;font-size:13px;">${escapeHtml(referencia)}</span></p>`
+              : ""
+          }
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border-top:1px solid #f3f4f6;margin-top:4px;">
+            <tr>
+              <td style="padding-top:16px;font-size:13px;line-height:1.6;color:#6b7280;">
+                <strong style="color:#374151;">${escapeHtml(autor)}</strong> lo ha anotado en
+                <strong style="color:#374151;">${escapeHtml(delegacionNombre)}</strong><br />
+                Dirigido a: ${escapeHtml(AVISO_DESTINATARIO_LABELS[destinatario])}
+              </td>
+            </tr>
+          </table>
+          <p style="margin:24px 0 0;">
+            <a href="${enlace}" style="display:inline-block;background:#2563eb;color:#ffffff;text-decoration:none;font-size:14px;font-weight:600;padding:11px 20px;border-radius:10px;">
+              Abrir en MCM Bank
+            </a>
+          </p>
+        </td>
+      </tr>
+      <tr>
+        <td style="padding:16px 4px 0;text-align:center;font-size:12px;color:#9ca3af;">
+          Avisos y tareas de MCM Bank · no respondas a este correo si no hace falta
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`
+}
+
+function renderTexto({
+  tipo,
+  contenido,
+  referencia,
+  autor,
+  delegacionNombre,
+  enlace,
+}: Omit<EmailData, "destinatario">) {
+  return [
+    tipo === "tarea" ? "TAREA PENDIENTE" : "NOTA INFORMATIVA",
+    "",
+    contenido,
+    referencia ? `\nReferencia: ${referencia}` : "",
+    "",
+    `${autor} · ${delegacionNombre}`,
+    enlace,
+  ]
+    .filter((linea) => linea !== "")
+    .join("\n")
+}

--- a/components/app-layout.tsx
+++ b/components/app-layout.tsx
@@ -3,6 +3,7 @@
 import type React from "react"
 import { Sidebar } from "./sidebar"
 import { Topbar } from "./topbar"
+import { AvisosWidget } from "./avisos/avisos-widget"
 import { useDelegationContext } from "@/contexts/delegation-context"
 import { useAuth } from "@/contexts/auth-context"
 import { useRouter } from "next/navigation"
@@ -105,6 +106,9 @@ export function AppLayout({ children }: AppLayoutProps) {
         {/* Page Content */}
         <main className="flex-1 p-3 sm:p-4 md:p-6 lg:p-8">{children}</main>
       </div>
+
+      {/* Avisos y tareas: botón flotante disponible en toda la app */}
+      <AvisosWidget />
     </div>
   )
 }

--- a/components/avisos/aviso-composer.tsx
+++ b/components/avisos/aviso-composer.tsx
@@ -1,0 +1,243 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+import { ArrowUp, Bell, Building2, Loader2, Tag, Users, X } from "lucide-react"
+import { cn } from "@/lib/utils"
+import type { AvisoDestinatario, AvisoTipo } from "@/lib/types/avisos"
+import { AVISO_MAX_CONTENIDO, AVISO_MAX_REFERENCIA } from "@/lib/types/avisos"
+
+export interface AvisoDraft {
+  tipo: AvisoTipo
+  destinatario: AvisoDestinatario
+  contenido: string
+  referencia: string
+  notificar: boolean
+  referenciaAbierta: boolean
+}
+
+export const AVISO_DRAFT_VACIO: AvisoDraft = {
+  tipo: "tarea",
+  destinatario: "delegacion",
+  contenido: "",
+  referencia: "",
+  notificar: false,
+  referenciaAbierta: false,
+}
+
+interface AvisoComposerProps {
+  draft: AvisoDraft
+  onDraftChange: (cambios: Partial<AvisoDraft>) => void
+  onSubmit: () => void
+  enviando: boolean
+  /** Ref al textarea para poder enfocarlo al abrir el panel. */
+  textareaRef?: React.RefObject<HTMLTextAreaElement | null>
+}
+
+const PLACEHOLDERS: Record<AvisoTipo, string> = {
+  tarea: "Qué hay que hacer…",
+  nota: "Qué queremos contar…",
+}
+
+const DESTINATARIO_ICONO: Record<AvisoDestinatario, typeof Building2> = {
+  oficina_tecnica: Users,
+  delegacion: Building2,
+}
+
+const DESTINATARIO_TEXTO: Record<AvisoDestinatario, string> = {
+  oficina_tecnica: "Oficina técnica",
+  delegacion: "Delegación",
+}
+
+export function AvisoComposer({ draft, onDraftChange, onSubmit, enviando, textareaRef }: AvisoComposerProps) {
+  const internalRef = useRef<HTMLTextAreaElement | null>(null)
+  const ref = textareaRef ?? internalRef
+  const referenciaRef = useRef<HTMLInputElement | null>(null)
+
+  // Autoajuste de altura: crece hasta 5 líneas y luego hace scroll.
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    el.style.height = "auto"
+    el.style.height = `${Math.min(el.scrollHeight, 124)}px`
+  }, [draft.contenido, ref])
+
+  useEffect(() => {
+    if (draft.referenciaAbierta) referenciaRef.current?.focus()
+  }, [draft.referenciaAbierta])
+
+  const puedeEnviar = draft.contenido.trim().length > 0 && !enviando
+  const DestinatarioIcono = DESTINATARIO_ICONO[draft.destinatario]
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key === "Enter" && !event.shiftKey) {
+      event.preventDefault()
+      if (puedeEnviar) onSubmit()
+    }
+  }
+
+  const alternarDestinatario = () =>
+    onDraftChange({
+      destinatario: draft.destinatario === "delegacion" ? "oficina_tecnica" : "delegacion",
+    })
+
+  return (
+    <div className="px-2.5 pb-2.5">
+      <div
+        className={cn(
+          "rounded-2xl border border-border/70 bg-background/70",
+          "transition-[border-color,box-shadow] duration-150",
+          "focus-within:border-primary/45 focus-within:shadow-[0_0_0_3.5px_hsl(var(--primary)/0.10)]",
+        )}
+      >
+        <textarea
+          ref={ref}
+          rows={1}
+          value={draft.contenido}
+          maxLength={AVISO_MAX_CONTENIDO}
+          onChange={(event) => onDraftChange({ contenido: event.target.value })}
+          onKeyDown={handleKeyDown}
+          placeholder={PLACEHOLDERS[draft.tipo]}
+          aria-label={draft.tipo === "tarea" ? "Nueva tarea" : "Nueva nota"}
+          className={cn(
+            "block w-full resize-none bg-transparent px-3 pt-2.5 text-[13px] leading-[1.5]",
+            "outline-none placeholder:text-muted-foreground/60",
+            "scrollbar-thin",
+          )}
+        />
+
+        {draft.referenciaAbierta && (
+          <div className="flex items-center gap-1.5 px-3 pt-1.5">
+            <Tag className="h-3 w-3 shrink-0 text-muted-foreground/70" aria-hidden />
+            <input
+              ref={referenciaRef}
+              value={draft.referencia}
+              maxLength={AVISO_MAX_REFERENCIA}
+              onChange={(event) => onDraftChange({ referencia: event.target.value })}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  event.preventDefault()
+                  if (puedeEnviar) onSubmit()
+                }
+                if (event.key === "Escape") {
+                  event.preventDefault()
+                  onDraftChange({ referenciaAbierta: false, referencia: "" })
+                  ref.current?.focus()
+                }
+              }}
+              placeholder="Hablar con David, con Lucía…"
+              aria-label="Referencia"
+              className="min-w-0 flex-1 bg-transparent text-[12px] leading-none outline-none placeholder:text-muted-foreground/50"
+            />
+            <button
+              type="button"
+              title="Quitar referencia"
+              aria-label="Quitar referencia"
+              onClick={() => {
+                onDraftChange({ referenciaAbierta: false, referencia: "" })
+                ref.current?.focus()
+              }}
+              className="relative flex h-5 w-5 items-center justify-center rounded-md text-muted-foreground/60 before:absolute before:-inset-2.5 before:content-[''] transition-colors duration-150 hover:bg-muted hover:text-foreground"
+            >
+              <X className="h-3 w-3" aria-hidden />
+            </button>
+          </div>
+        )}
+
+        <div className="flex items-center gap-1 px-2 pb-2 pt-2">
+          {/* Tipo: tarea o nota */}
+          <div className="flex rounded-lg bg-muted/70 p-[2px]">
+            {(["tarea", "nota"] as const).map((tipo) => (
+              <button
+                key={tipo}
+                type="button"
+                onClick={() => onDraftChange({ tipo })}
+                aria-pressed={draft.tipo === tipo}
+                className={cn(
+                  "rounded-md px-2 py-1 text-[11px] font-medium capitalize",
+                  "transition-[background-color,color,box-shadow] duration-150",
+                  draft.tipo === tipo
+                    ? "bg-background text-foreground shadow-sm"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+              >
+                {tipo}
+              </button>
+            ))}
+          </div>
+
+          {/* Destinatario */}
+          <button
+            type="button"
+            onClick={alternarDestinatario}
+            title="Cambiar destinatario"
+            className={cn(
+              "inline-flex min-w-0 items-center gap-1 rounded-lg px-1.5 py-1 text-[11px] font-medium text-muted-foreground",
+              "transition-[background-color,color] duration-150 hover:bg-muted hover:text-foreground",
+            )}
+          >
+            <DestinatarioIcono className="h-3 w-3 shrink-0" aria-hidden />
+            <span className="truncate">{DESTINATARIO_TEXTO[draft.destinatario]}</span>
+          </button>
+
+          <div className="flex-1" />
+
+          {!draft.referenciaAbierta && (
+            <button
+              type="button"
+              onClick={() => onDraftChange({ referenciaAbierta: true })}
+              title="Añadir una referencia corta"
+              aria-label="Añadir una referencia corta"
+              className="relative flex h-7 w-7 items-center justify-center rounded-lg text-muted-foreground/70 before:absolute before:-inset-[6.5px] before:content-[''] transition-[background-color,color,transform] duration-150 hover:bg-muted hover:text-foreground active:scale-[0.96]"
+            >
+              <Tag className="h-[15px] w-[15px]" aria-hidden />
+            </button>
+          )}
+
+          <button
+            type="button"
+            onClick={() => onDraftChange({ notificar: !draft.notificar })}
+            aria-pressed={draft.notificar}
+            title={draft.notificar ? "Se avisará por correo al enviar" : "Avisar por correo al enviar"}
+            aria-label="Avisar por correo al enviar"
+            className={cn(
+              "relative flex h-7 w-7 items-center justify-center rounded-lg",
+              "before:absolute before:-inset-[6.5px] before:content-['']",
+              "transition-[background-color,color,transform] duration-150 active:scale-[0.96]",
+              draft.notificar
+                ? "bg-primary/10 text-primary hover:bg-primary/15"
+                : "text-muted-foreground/70 hover:bg-muted hover:text-foreground",
+            )}
+          >
+            <Bell className="h-[15px] w-[15px]" aria-hidden />
+          </button>
+
+          <button
+            type="button"
+            onClick={onSubmit}
+            disabled={!puedeEnviar}
+            title="Enviar (Intro)"
+            aria-label="Enviar"
+            className={cn(
+              "relative flex h-7 w-7 items-center justify-center rounded-lg bg-primary text-primary-foreground",
+              "before:absolute before:-inset-[6.5px] before:content-['']",
+              "transition-[background-color,opacity,transform] duration-150",
+              "hover:bg-primary/90 active:scale-[0.96]",
+              "disabled:pointer-events-none disabled:bg-muted disabled:text-muted-foreground/50",
+            )}
+          >
+            {enviando ? (
+              <Loader2 className="h-[15px] w-[15px] animate-spin" aria-hidden />
+            ) : (
+              <ArrowUp className="h-[15px] w-[15px]" strokeWidth={2.5} aria-hidden />
+            )}
+          </button>
+        </div>
+      </div>
+
+      <p className="mt-1.5 px-1.5 text-[10.5px] leading-none text-muted-foreground/70">
+        Intro para enviar · Mayús+Intro para otra línea
+        {draft.notificar && " · se avisará por correo"}
+      </p>
+    </div>
+  )
+}

--- a/components/avisos/aviso-item.tsx
+++ b/components/avisos/aviso-item.tsx
@@ -1,0 +1,263 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+import { Archive, ArrowUpLeft, Bell, BellRing, Check, Loader2, Trash2 } from "lucide-react"
+import { cn } from "@/lib/utils"
+import type { Aviso } from "@/lib/types/avisos"
+import { AVISO_DESTINATARIO_LABELS } from "@/lib/types/avisos"
+import { formatFechaCompleta, formatRelativoCorto, primerNombre } from "./utils"
+
+interface AvisoItemProps {
+  aviso: Aviso
+  puedeEscribir: boolean
+  onCompletar: (id: string) => Promise<void> | void
+  onReabrir: (id: string) => Promise<void> | void
+  onEliminar: (id: string) => Promise<void> | void
+  onMarcarLeido: (id: string) => Promise<void> | void
+  onNotificar: (id: string) => Promise<void> | void
+}
+
+/** Botón de icono discreto con área de pulsación de 40×40 vía pseudoelemento. */
+function AccionIcono({
+  label,
+  onClick,
+  children,
+  className,
+  disabled,
+}: {
+  label: string
+  onClick: () => void
+  children: React.ReactNode
+  className?: string
+  disabled?: boolean
+}) {
+  return (
+    <button
+      type="button"
+      title={label}
+      aria-label={label}
+      disabled={disabled}
+      onClick={(event) => {
+        event.stopPropagation()
+        onClick()
+      }}
+      className={cn(
+        "relative flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground/70",
+        "before:absolute before:-inset-1 before:content-['']",
+        "transition-[color,background-color,transform] duration-150",
+        "hover:bg-muted hover:text-foreground active:scale-[0.96]",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background",
+        "disabled:pointer-events-none disabled:opacity-40",
+        className,
+      )}
+    >
+      {children}
+    </button>
+  )
+}
+
+export function AvisoItem({
+  aviso,
+  puedeEscribir,
+  onCompletar,
+  onReabrir,
+  onEliminar,
+  onMarcarLeido,
+  onNotificar,
+}: AvisoItemProps) {
+  const [confirmandoBorrado, setConfirmandoBorrado] = useState(false)
+  const [ocupado, setOcupado] = useState<"completar" | "notificar" | null>(null)
+  const confirmTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (confirmTimer.current) clearTimeout(confirmTimer.current)
+    }
+  }, [])
+
+  const esTarea = aviso.tipo === "tarea"
+  const hecha = aviso.estado === "hecha"
+  const autor = primerNombre(aviso.autorNombre)
+  const notificado = Boolean(aviso.notificado_en)
+
+  const pedirBorrado = () => {
+    if (confirmandoBorrado) {
+      if (confirmTimer.current) clearTimeout(confirmTimer.current)
+      setConfirmandoBorrado(false)
+      void onEliminar(aviso.id)
+      return
+    }
+    setConfirmandoBorrado(true)
+    confirmTimer.current = setTimeout(() => setConfirmandoBorrado(false), 3000)
+  }
+
+  const completar = async () => {
+    setOcupado("completar")
+    try {
+      await onCompletar(aviso.id)
+    } finally {
+      setOcupado(null)
+    }
+  }
+
+  const notificar = async () => {
+    setOcupado("notificar")
+    try {
+      await onNotificar(aviso.id)
+    } finally {
+      setOcupado(null)
+    }
+  }
+
+  return (
+    <div
+      onClick={aviso.noLeido ? () => onMarcarLeido(aviso.id) : undefined}
+      className={cn(
+        "group relative flex gap-2.5 rounded-2xl px-2.5 py-2.5",
+        "transition-[background-color] duration-150",
+        aviso.noLeido && "bg-primary/[0.055] dark:bg-primary/[0.09]",
+        aviso.noLeido ? "hover:bg-primary/[0.09] cursor-pointer" : "hover:bg-muted/60",
+      )}
+    >
+      {/* Marca de no leído: punto en el borde izquierdo */}
+      {aviso.noLeido && (
+        <span
+          aria-label="Sin leer"
+          className="absolute left-0 top-1/2 h-1.5 w-1.5 -translate-y-1/2 rounded-full bg-primary"
+        />
+      )}
+
+      {/* Control principal: casilla en tareas, punto de color en notas */}
+      {esTarea && !hecha ? (
+        <button
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation()
+            void completar()
+          }}
+          title="Marcar como hecha"
+          aria-label="Marcar como hecha"
+          disabled={!puedeEscribir || ocupado === "completar"}
+          className={cn(
+            "relative mt-[3px] flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-full",
+            "border-[1.5px] border-amber-500/60 text-transparent",
+            "before:absolute before:-inset-[11px] before:content-['']",
+            "transition-[background-color,border-color,color,transform] duration-150",
+            "hover:border-amber-500 hover:bg-amber-500/10 hover:text-amber-600 active:scale-[0.96]",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/50 focus-visible:ring-offset-1 focus-visible:ring-offset-background",
+            "disabled:pointer-events-none disabled:opacity-50",
+          )}
+        >
+          {ocupado === "completar" ? (
+            <Loader2 className="h-3 w-3 animate-spin text-amber-600" />
+          ) : (
+            <Check className="h-3 w-3" strokeWidth={3} />
+          )}
+        </button>
+      ) : (
+        <span
+          aria-hidden
+          className={cn(
+            "mt-[7px] h-[9px] w-[9px] shrink-0 rounded-full",
+            hecha ? "bg-emerald-500/70" : "bg-primary/70",
+          )}
+        />
+      )}
+
+      {/* Contenido */}
+      <div className="min-w-0 flex-1">
+        <p
+          className={cn(
+            "whitespace-pre-wrap break-words text-[13px] leading-[1.5] text-pretty",
+            aviso.noLeido ? "font-medium text-foreground" : "text-foreground/90",
+            hecha && "text-muted-foreground line-through decoration-muted-foreground/40",
+          )}
+        >
+          {aviso.contenido}
+        </p>
+
+        <div className="mt-1 flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px] leading-none text-muted-foreground">
+          {aviso.referencia && (
+            <span className="inline-flex max-w-[160px] items-center truncate rounded-md bg-muted px-1.5 py-[3px] font-medium text-foreground/70">
+              {aviso.referencia}
+            </span>
+          )}
+          <span className="truncate">{autor ?? "Alguien"}</span>
+          <span aria-hidden className="text-muted-foreground/40">
+            ·
+          </span>
+          <span title={formatFechaCompleta(aviso.creado_en)} className="tabular-nums">
+            {formatRelativoCorto(aviso.creado_en)}
+          </span>
+          <span aria-hidden className="text-muted-foreground/40">
+            ·
+          </span>
+          <span className={cn(aviso.esParaMi && "text-foreground/70")}>
+            {aviso.esParaMi ? "para ti" : `para ${AVISO_DESTINATARIO_LABELS[aviso.destinatario].toLowerCase()}`}
+          </span>
+          {notificado && (
+            <span title={`Avisado por correo · ${formatFechaCompleta(aviso.notificado_en)}`} className="inline-flex items-center gap-1 text-muted-foreground/70">
+              <span aria-hidden className="text-muted-foreground/40">
+                ·
+              </span>
+              <BellRing className="h-3 w-3" aria-hidden />
+              avisado
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Acciones: visibles al pasar por encima, siempre en táctil */}
+      {puedeEscribir && (
+        <div
+          className={cn(
+            "flex shrink-0 items-start gap-0.5 self-start",
+            "opacity-100 transition-opacity duration-150",
+            "sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100",
+          )}
+        >
+          {hecha ? (
+            <AccionIcono label="Volver a pendiente" onClick={() => void onReabrir(aviso.id)}>
+              <ArrowUpLeft className="h-4 w-4" aria-hidden />
+            </AccionIcono>
+          ) : (
+            <>
+              {!esTarea && (
+                <AccionIcono label="Archivar nota" onClick={() => void completar()}>
+                  <Archive className="h-4 w-4" aria-hidden />
+                </AccionIcono>
+              )}
+              <AccionIcono
+                label={notificado ? "Volver a avisar por correo" : "Avisar por correo"}
+                onClick={() => void notificar()}
+                disabled={ocupado === "notificar"}
+                className={notificado ? "text-primary/70" : undefined}
+              >
+                {ocupado === "notificar" ? (
+                  <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+                ) : notificado ? (
+                  <BellRing className="h-4 w-4" aria-hidden />
+                ) : (
+                  <Bell className="h-4 w-4" aria-hidden />
+                )}
+              </AccionIcono>
+            </>
+          )}
+          {aviso.esMio && (
+            <AccionIcono
+              label={confirmandoBorrado ? "Pulsa otra vez para borrar" : "Borrar"}
+              onClick={pedirBorrado}
+              className={confirmandoBorrado ? "bg-destructive/10 text-destructive hover:bg-destructive/15 hover:text-destructive" : undefined}
+            >
+              {confirmandoBorrado ? (
+                <Check className="h-4 w-4" aria-hidden />
+              ) : (
+                <Trash2 className="h-4 w-4" aria-hidden />
+              )}
+            </AccionIcono>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/avisos/avisos-panel.tsx
+++ b/components/avisos/avisos-panel.tsx
@@ -1,0 +1,223 @@
+"use client"
+
+import { useCallback, useMemo, useState } from "react"
+import { CheckCheck, ClipboardList, Loader2, X } from "lucide-react"
+import { cn } from "@/lib/utils"
+import type { Aviso, AvisoContadores } from "@/lib/types/avisos"
+import { AvisoComposer, type AvisoDraft } from "./aviso-composer"
+import { AvisoItem } from "./aviso-item"
+
+type Pestana = "pendientes" | "hechas"
+
+interface AvisosPanelProps {
+  delegacionNombre: string
+  avisos: Aviso[]
+  hechos: Aviso[]
+  loading: boolean
+  loadingHechos: boolean
+  error: string | null
+  contadores: AvisoContadores
+  puedeEscribir: boolean
+  draft: AvisoDraft
+  enviando: boolean
+  onDraftChange: (cambios: Partial<AvisoDraft>) => void
+  onSubmit: () => void
+  onCompletar: (id: string) => Promise<void> | void
+  onReabrir: (id: string) => Promise<void> | void
+  onEliminar: (id: string) => Promise<void> | void
+  onMarcarLeido: (id: string) => Promise<void> | void
+  onMarcarTodoLeido: () => Promise<void> | void
+  onNotificar: (id: string) => Promise<void> | void
+  onCargarHechos: () => Promise<void> | void
+  onClose: () => void
+  textareaRef?: React.RefObject<HTMLTextAreaElement | null>
+}
+
+export function AvisosPanel({
+  delegacionNombre,
+  avisos,
+  hechos,
+  loading,
+  loadingHechos,
+  error,
+  contadores,
+  puedeEscribir,
+  draft,
+  enviando,
+  onDraftChange,
+  onSubmit,
+  onCompletar,
+  onReabrir,
+  onEliminar,
+  onMarcarLeido,
+  onMarcarTodoLeido,
+  onNotificar,
+  onCargarHechos,
+  onClose,
+  textareaRef,
+}: AvisosPanelProps) {
+  const [pestana, setPestana] = useState<Pestana>("pendientes")
+
+  const cambiarPestana = useCallback(
+    (siguiente: Pestana) => {
+      setPestana(siguiente)
+      if (siguiente === "hechas") void onCargarHechos()
+    },
+    [onCargarHechos],
+  )
+
+  // Lo que no he leído sube arriba; el resto, del más reciente al más antiguo.
+  const pendientesOrdenados = useMemo(
+    () =>
+      [...avisos].sort((a, b) => {
+        if (a.noLeido !== b.noLeido) return a.noLeido ? -1 : 1
+        return new Date(b.creado_en).getTime() - new Date(a.creado_en).getTime()
+      }),
+    [avisos],
+  )
+
+  const lista = pestana === "pendientes" ? pendientesOrdenados : hechos
+  const cargando = pestana === "pendientes" ? loading : loadingHechos
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Avisos y tareas"
+      className={cn(
+        "flex max-h-[min(78vh,620px)] flex-col overflow-hidden rounded-3xl",
+        "border border-border/60 bg-card/95 backdrop-blur-2xl",
+        "shadow-[0_1px_2px_rgba(0,0,0,0.04),0_12px_28px_-8px_rgba(0,0,0,0.16),0_32px_60px_-24px_rgba(0,0,0,0.22)]",
+      )}
+    >
+      {/* Cabecera */}
+      <div className="flex items-start justify-between gap-2 px-4 pb-1 pt-3.5 duration-200 animate-in fade-in-0">
+        <div className="min-w-0">
+          <h2 className="text-[13px] font-semibold leading-none tracking-tight text-balance">Avisos y tareas</h2>
+          <p className="mt-1 truncate text-[11px] leading-none text-muted-foreground">{delegacionNombre}</p>
+        </div>
+        <div className="flex shrink-0 items-center gap-0.5">
+          {contadores.noLeidos > 0 && (
+            <button
+              type="button"
+              onClick={() => void onMarcarTodoLeido()}
+              title="Marcar todo como leído"
+              className={cn(
+                "relative inline-flex items-center gap-1 rounded-lg px-1.5 py-1 text-[11px] font-medium text-muted-foreground",
+                "transition-[background-color,color] duration-150 hover:bg-muted hover:text-foreground",
+              )}
+            >
+              <CheckCheck className="h-3.5 w-3.5" aria-hidden />
+              <span className="hidden sm:inline">Marcar leído</span>
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={onClose}
+            title="Cerrar (Esc)"
+            aria-label="Cerrar"
+            className={cn(
+              "relative flex h-7 w-7 items-center justify-center rounded-lg text-muted-foreground/70",
+              "before:absolute before:-inset-[6.5px] before:content-['']",
+              "transition-[background-color,color,transform] duration-150 hover:bg-muted hover:text-foreground active:scale-[0.96]",
+            )}
+          >
+            <X className="h-4 w-4" aria-hidden />
+          </button>
+        </div>
+      </div>
+
+      {/* Pestañas */}
+      <div className="flex items-center gap-1 px-3 pb-1.5 pt-2 duration-200 animate-in fade-in-0 slide-in-from-bottom-1">
+        {(
+          [
+            { id: "pendientes" as const, label: "Pendientes", count: avisos.length },
+            { id: "hechas" as const, label: "Hechas", count: null },
+          ] satisfies { id: Pestana; label: string; count: number | null }[]
+        ).map((tab) => (
+          <button
+            key={tab.id}
+            type="button"
+            onClick={() => cambiarPestana(tab.id)}
+            aria-pressed={pestana === tab.id}
+            className={cn(
+              "inline-flex items-center gap-1 rounded-lg px-2 py-1 text-[11.5px] font-medium",
+              "transition-[background-color,color] duration-150",
+              pestana === tab.id
+                ? "bg-muted text-foreground"
+                : "text-muted-foreground hover:bg-muted/60 hover:text-foreground",
+            )}
+          >
+            {tab.label}
+            {tab.count !== null && tab.count > 0 && (
+              <span className="tabular-nums text-muted-foreground/70">{tab.count}</span>
+            )}
+          </button>
+        ))}
+        {contadores.pendientes > 0 && (
+          <span className="ml-auto inline-flex items-center gap-1.5 rounded-full bg-amber-500/10 px-2 py-[3px] text-[10.5px] font-medium text-amber-700 dark:text-amber-400">
+            <span aria-hidden className="h-1.5 w-1.5 rounded-full bg-amber-500" />
+            <span className="tabular-nums">{contadores.pendientes}</span> para ti
+          </span>
+        )}
+      </div>
+
+      {/* Compositor */}
+      {puedeEscribir && (
+        <div className="duration-200 animate-in fade-in-0 slide-in-from-bottom-1 delay-75 fill-mode-backwards">
+          <AvisoComposer
+            draft={draft}
+            onDraftChange={onDraftChange}
+            onSubmit={onSubmit}
+            enviando={enviando}
+            textareaRef={textareaRef}
+          />
+        </div>
+      )}
+
+      <div className="mx-3 h-px bg-border/60" aria-hidden />
+
+      {/* Lista */}
+      <div className="scrollbar-thin flex-1 overflow-y-auto overscroll-contain px-1.5 py-1.5 duration-200 animate-in fade-in-0 delay-150 fill-mode-backwards">
+        {error && (
+          <p className="mx-2 my-3 rounded-xl bg-destructive/10 px-3 py-2 text-[12px] leading-snug text-destructive">
+            {error}
+          </p>
+        )}
+
+        {cargando && lista.length === 0 ? (
+          <div className="flex items-center justify-center gap-2 py-10 text-[12px] text-muted-foreground">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+            Cargando…
+          </div>
+        ) : lista.length === 0 ? (
+          <div className="flex flex-col items-center gap-1.5 px-6 py-10 text-center">
+            <ClipboardList className="h-5 w-5 text-muted-foreground/40" aria-hidden />
+            <p className="text-[12.5px] font-medium text-foreground/80">
+              {pestana === "pendientes" ? "Nada pendiente por aquí" : "Todavía no hay nada hecho"}
+            </p>
+            <p className="text-pretty text-[11.5px] leading-snug text-muted-foreground">
+              {pestana === "pendientes"
+                ? "Apunta una tarea o deja una nota de lo que habéis tocado."
+                : "Lo que marquéis como hecho aparecerá aquí."}
+            </p>
+          </div>
+        ) : (
+          <div className="flex flex-col">
+            {lista.map((aviso) => (
+              <AvisoItem
+                key={aviso.id}
+                aviso={aviso}
+                puedeEscribir={puedeEscribir}
+                onCompletar={onCompletar}
+                onReabrir={onReabrir}
+                onEliminar={onEliminar}
+                onMarcarLeido={onMarcarLeido}
+                onNotificar={onNotificar}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/avisos/avisos-widget.tsx
+++ b/components/avisos/avisos-widget.tsx
@@ -1,0 +1,299 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+import { ClipboardList, X } from "lucide-react"
+import { toast } from "sonner"
+import { cn } from "@/lib/utils"
+import { useAuth } from "@/contexts/auth-context"
+import { useDelegationContext } from "@/contexts/delegation-context"
+import { useAvisos } from "@/hooks/use-avisos"
+import { useLocalStorageState } from "@/hooks/use-local-storage"
+import { AVISO_DRAFT_VACIO, type AvisoDraft } from "./aviso-composer"
+import { AvisosPanel } from "./avisos-panel"
+
+const CIERRE_MS = 160
+
+/**
+ * Botón flotante (abajo a la derecha, lejos de la sidebar) con el panel de
+ * avisos y tareas de la delegación activa. Se abre desde cualquier página con
+ * ⌘/Ctrl + I, se cierra con Esc y el borrador aguanta cierres y recargas.
+ */
+export function AvisosWidget() {
+  const { user } = useAuth()
+  const { selectedDelegation, getCurrentDelegation } = useDelegationContext()
+  const {
+    avisos,
+    hechos,
+    loading,
+    loadingHechos,
+    error,
+    contadores,
+    miLado,
+    rolConocido,
+    puedeEscribir,
+    cargarHechos,
+    crear,
+    completar,
+    reabrir,
+    eliminar,
+    marcarLeidos,
+    notificar,
+  } = useAvisos(selectedDelegation)
+
+  const [open, setOpen] = useState(false)
+  const [montado, setMontado] = useState(false)
+  const [enviando, setEnviando] = useState(false)
+  const [esMac, setEsMac] = useState(false)
+
+  const [draft, setDraft] = useLocalStorageState<AvisoDraft>("mcmbank-aviso-draft", AVISO_DRAFT_VACIO)
+
+  const panelRef = useRef<HTMLDivElement | null>(null)
+  const botonRef = useRef<HTMLButtonElement | null>(null)
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+  const cierreTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const destinatarioAplicado = useRef(false)
+
+  const delegacionNombre = getCurrentDelegation()?.nombre ?? "Tu delegación"
+
+  useEffect(() => {
+    if (typeof navigator !== "undefined") {
+      setEsMac(/Mac|iPhone|iPad/.test(navigator.platform || navigator.userAgent))
+    }
+  }, [])
+
+  // Por defecto se escribe "al otro lado": la oficina técnica apunta cosas a la
+  // delegación y los tesoreros a la oficina técnica.
+  useEffect(() => {
+    if (destinatarioAplicado.current) return
+    // Hasta saber el rol, miLado no es fiable (por defecto sería "delegacion").
+    if (!rolConocido) return
+    destinatarioAplicado.current = true
+    if (draft.contenido.trim()) return
+    setDraft((prev) => ({
+      ...prev,
+      destinatario: miLado === "delegacion" ? "oficina_tecnica" : "delegacion",
+    }))
+  }, [miLado, rolConocido, draft.contenido, setDraft])
+
+  const cerrar = useCallback(() => {
+    setOpen(false)
+    if (cierreTimer.current) clearTimeout(cierreTimer.current)
+    cierreTimer.current = setTimeout(() => setMontado(false), CIERRE_MS)
+    botonRef.current?.focus()
+  }, [])
+
+  const abrir = useCallback(() => {
+    if (cierreTimer.current) clearTimeout(cierreTimer.current)
+    setMontado(true)
+    setOpen(true)
+    setTimeout(() => textareaRef.current?.focus(), 90)
+  }, [])
+
+  const alternar = useCallback(() => {
+    if (open) cerrar()
+    else abrir()
+  }, [open, abrir, cerrar])
+
+  useEffect(() => {
+    return () => {
+      if (cierreTimer.current) clearTimeout(cierreTimer.current)
+    }
+  }, [])
+
+  // Atajo global: ⌘/Ctrl + I abre y cierra. Esc cierra.
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && !event.altKey && event.key.toLowerCase() === "i") {
+        event.preventDefault()
+        alternar()
+        return
+      }
+      if (event.key === "Escape" && open) {
+        event.preventDefault()
+        cerrar()
+      }
+    }
+    window.addEventListener("keydown", onKeyDown)
+    return () => window.removeEventListener("keydown", onKeyDown)
+  }, [alternar, cerrar, open])
+
+  // Clic fuera: cerrar sin perder el borrador.
+  useEffect(() => {
+    if (!open) return
+    const onPointerDown = (event: PointerEvent) => {
+      const target = event.target as Node
+      if (panelRef.current?.contains(target)) return
+      if (botonRef.current?.contains(target)) return
+      cerrar()
+    }
+    document.addEventListener("pointerdown", onPointerDown)
+    return () => document.removeEventListener("pointerdown", onPointerDown)
+  }, [open, cerrar])
+
+  const actualizarDraft = useCallback(
+    (cambios: Partial<AvisoDraft>) => setDraft((prev) => ({ ...prev, ...cambios })),
+    [setDraft],
+  )
+
+  const enviar = useCallback(async () => {
+    if (!draft.contenido.trim() || enviando) return
+    setEnviando(true)
+    const avisarPorCorreo = draft.notificar
+    try {
+      await crear({
+        tipo: draft.tipo,
+        contenido: draft.contenido,
+        referencia: draft.referencia.trim() || null,
+        destinatario: draft.destinatario,
+        notificar: avisarPorCorreo,
+      })
+      // Se limpia el texto pero se conservan tipo y destinatario: lo normal es
+      // apuntar varias cosas seguidas para el mismo destinatario.
+      setDraft((prev) => ({ ...prev, contenido: "", referencia: "", referenciaAbierta: false }))
+      toast.success(
+        draft.tipo === "tarea" ? "Tarea apuntada" : "Nota publicada",
+        avisarPorCorreo ? { description: "Y avisada por correo" } : undefined,
+      )
+      textareaRef.current?.focus()
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "No se pudo guardar")
+    } finally {
+      setEnviando(false)
+    }
+  }, [crear, draft, enviando, setDraft])
+
+  const manejarNotificar = useCallback(
+    async (id: string) => {
+      try {
+        const destinatarios = await notificar(id)
+        toast.success(
+          destinatarios.length === 1 ? "Avisado por correo" : `Avisadas ${destinatarios.length} personas`,
+        )
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "No se pudo enviar el correo")
+      }
+    },
+    [notificar],
+  )
+
+  const manejarCompletar = useCallback(
+    async (id: string) => {
+      try {
+        await completar(id)
+      } catch {
+        toast.error("No se pudo marcar como hecha")
+      }
+    },
+    [completar],
+  )
+
+  const manejarEliminar = useCallback(
+    async (id: string) => {
+      try {
+        await eliminar(id)
+      } catch {
+        toast.error("No se pudo borrar")
+      }
+    },
+    [eliminar],
+  )
+
+  const manejarMarcarTodoLeido = useCallback(
+    () => marcarLeidos(avisos.filter((a) => a.noLeido).map((a) => a.id)),
+    [avisos, marcarLeidos],
+  )
+
+  if (!user || !selectedDelegation) return null
+
+  const badgeNoLeidos = contadores.noLeidos > 0
+  const badge = badgeNoLeidos ? contadores.noLeidos : contadores.pendientes
+  const atajo = esMac ? "⌘I" : "Ctrl+I"
+
+  return (
+    <div className="pointer-events-none fixed bottom-4 right-4 z-40 flex flex-col items-end gap-2 sm:bottom-6 sm:right-6 print:hidden">
+      {montado && (
+        <div
+          ref={panelRef}
+          className={cn(
+            "pointer-events-auto w-[min(calc(100vw-2rem),24rem)] sm:w-[24.5rem]",
+            open
+              ? "duration-200 ease-[cubic-bezier(0.2,0,0,1)] animate-in fade-in-0 zoom-in-[0.98] slide-in-from-bottom-3"
+              : "duration-150 ease-out animate-out fade-out-0 slide-out-to-bottom-1",
+          )}
+        >
+          <AvisosPanel
+            delegacionNombre={delegacionNombre}
+            avisos={avisos}
+            hechos={hechos}
+            loading={loading}
+            loadingHechos={loadingHechos}
+            error={error}
+            contadores={contadores}
+            puedeEscribir={puedeEscribir}
+            draft={draft}
+            enviando={enviando}
+            onDraftChange={actualizarDraft}
+            onSubmit={() => void enviar()}
+            onCompletar={manejarCompletar}
+            onReabrir={reabrir}
+            onEliminar={manejarEliminar}
+            onMarcarLeido={(id) => marcarLeidos([id])}
+            onMarcarTodoLeido={manejarMarcarTodoLeido}
+            onNotificar={manejarNotificar}
+            onCargarHechos={cargarHechos}
+            onClose={cerrar}
+            textareaRef={textareaRef}
+          />
+        </div>
+      )}
+
+      <button
+        ref={botonRef}
+        type="button"
+        onClick={alternar}
+        aria-expanded={open}
+        aria-label={`Avisos y tareas (${atajo})`}
+        title={`Avisos y tareas · ${atajo}`}
+        className={cn(
+          "pointer-events-auto relative flex h-11 w-11 items-center justify-center rounded-full",
+          "border border-border/60 bg-card/90 text-foreground/80 backdrop-blur-xl",
+          "shadow-[0_1px_2px_rgba(0,0,0,0.05),0_6px_16px_-4px_rgba(0,0,0,0.18)]",
+          "transition-[background-color,color,box-shadow,transform] duration-150",
+          "hover:text-foreground hover:shadow-[0_1px_2px_rgba(0,0,0,0.05),0_10px_24px_-6px_rgba(0,0,0,0.24)]",
+          "active:scale-[0.96]",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        )}
+      >
+        {/* Los dos iconos conviven y se cruzan con opacidad, escala y desenfoque */}
+        <ClipboardList
+          aria-hidden
+          className={cn(
+            "absolute h-[18px] w-[18px] transition-[opacity,transform,filter] duration-200 ease-[cubic-bezier(0.2,0,0,1)]",
+            open ? "scale-[0.25] opacity-0 blur-[4px]" : "scale-100 opacity-100 blur-0",
+          )}
+        />
+        <X
+          aria-hidden
+          className={cn(
+            "absolute h-[18px] w-[18px] transition-[opacity,transform,filter] duration-200 ease-[cubic-bezier(0.2,0,0,1)]",
+            open ? "scale-100 opacity-100 blur-0" : "scale-[0.25] opacity-0 blur-[4px]",
+          )}
+        />
+
+        {badge > 0 && !open && (
+          <span
+            className={cn(
+              "absolute -right-0.5 -top-0.5 flex h-[17px] min-w-[17px] items-center justify-center rounded-full px-1",
+              "text-[10px] font-semibold leading-none tabular-nums text-white",
+              "ring-2 ring-background duration-200 animate-in fade-in-0 zoom-in-75",
+              badgeNoLeidos ? "bg-primary" : "bg-amber-500",
+            )}
+          >
+            {badge > 9 ? "9+" : badge}
+            <span className="sr-only">{badgeNoLeidos ? " sin leer" : " pendientes para ti"}</span>
+          </span>
+        )}
+      </button>
+    </div>
+  )
+}

--- a/components/avisos/utils.ts
+++ b/components/avisos/utils.ts
@@ -1,0 +1,48 @@
+/** "ahora", "hace 5 min", "hace 3 h", "ayer", "12 jul", "12 jul 2024". */
+export function formatRelativoCorto(value?: string | null): string {
+  if (!value) return ""
+  const fecha = new Date(value)
+  if (Number.isNaN(fecha.getTime())) return ""
+
+  const ahora = new Date()
+  const segundos = Math.max(0, Math.round((ahora.getTime() - fecha.getTime()) / 1000))
+
+  if (segundos < 60) return "ahora"
+  if (segundos < 3600) return `hace ${Math.floor(segundos / 60)} min`
+  if (segundos < 86400) return `hace ${Math.floor(segundos / 3600)} h`
+
+  const mismoDia = (a: Date, b: Date) =>
+    a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate()
+  const ayer = new Date(ahora)
+  ayer.setDate(ayer.getDate() - 1)
+  if (mismoDia(fecha, ayer)) return "ayer"
+
+  const mismoAnio = fecha.getFullYear() === ahora.getFullYear()
+  return fecha.toLocaleDateString("es-ES", {
+    day: "numeric",
+    month: "short",
+    ...(mismoAnio ? {} : { year: "numeric" }),
+  })
+}
+
+/** Fecha completa para el title de los tiempos relativos. */
+export function formatFechaCompleta(value?: string | null): string {
+  if (!value) return ""
+  const fecha = new Date(value)
+  if (Number.isNaN(fecha.getTime())) return ""
+  return fecha.toLocaleString("es-ES", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  })
+}
+
+/** Primer nombre, para que la línea de meta no se haga larga. */
+export function primerNombre(nombre?: string | null): string | null {
+  if (!nombre) return null
+  const limpio = nombre.trim()
+  if (!limpio) return null
+  return limpio.split(/\s+/)[0]
+}

--- a/docs/14-avisos-tareas.md
+++ b/docs/14-avisos-tareas.md
@@ -1,0 +1,76 @@
+# 14. Avisos y tareas
+
+"Te he cuadrado los movimientos de julio, mira las tres facturas de Mercadona" — el sitio para dejar apuntes cortos entre la oficina técnica y cada delegación, sin salir de la app ni abrir el correo.
+
+📸 _Captura del botón flotante y el panel abierto_
+
+## Dónde está
+
+Un botón redondo y discreto, abajo a la derecha, en **todas las pantallas**. También se abre y se cierra con el atajo **⌘I** (Mac) o **Ctrl+I** (Windows), y se cierra con **Esc**.
+
+{% hint style="info" %}
+Lo que escribas se queda guardado aunque cierres el panel o recargues la página: puedes empezar una tarea, atender otra cosa y volver a ella.
+{% endhint %}
+
+## Dos cosas distintas
+
+{% tabs %}
+{% tab title="✅ Tarea" %}
+Algo que hay que hacer. Se queda **pendiente** hasta que alguien la marca como hecha con la casilla de la izquierda.
+
+*"Revisar los movimientos sin categoría de agosto"*
+{% endtab %}
+
+{% tab title="💬 Nota" %}
+Información breve, no hay nada que hacer. Se marca como leída y ya está.
+
+*"Hemos subido 3 facturas de Mercadona en los movimientos de julio"*
+{% endtab %}
+{% endtabs %}
+
+## Cómo se escribe
+
+1. Abre el panel y escribe directamente: el cursor ya está en el sitio.
+2. Elige **Tarea** o **Nota**.
+3. Elige a quién va: **Oficina técnica** (el equipo central) o **Delegación** (los tesoreros de esa delegación). Viene puesto "al otro lado" por defecto.
+4. Si quieres, añade una **referencia** corta con el icono de etiqueta: *"Hablar con David"*, *"Lucía"*, *"Pendiente de la reunión"*.
+5. **Intro** para enviar. **Mayús+Intro** para hacer un salto de línea.
+
+Tras enviar, el texto se limpia pero el tipo y el destinatario se mantienen: puedes apuntar varias cosas seguidas sin volver a configurar nada.
+
+## Los indicadores del botón
+
+| Indicador | Qué significa |
+|---|---|
+| Punto azul con número | Tienes avisos **sin leer** |
+| Punto ámbar con número | Tienes **tareas pendientes** dirigidas a ti |
+| Sin indicador | Nada nuevo ni pendiente |
+
+Dentro del panel, lo que no has leído aparece arriba, con fondo azulado y un punto a la izquierda. **Pulsa el aviso** para marcarlo como leído, o usa **"Marcar leído"** en la cabecera para limpiarlo todo de golpe.
+
+## Avisar por correo
+
+El icono de campana envía además un correo a quien corresponda:
+
+- Aviso dirigido a la **delegación** → a los tesoreros de esa delegación.
+- Aviso dirigido a la **oficina técnica** → a los gestores centrales.
+
+Puedes activar la campana **antes de enviar** (se avisa en el momento) o pulsarla después en cualquier aviso de la lista. Nunca te llega un correo de algo que has escrito tú, y los avisos ya notificados se marcan con "avisado".
+
+## Quién ve qué
+
+{% hint style="warning" %}
+Los avisos viven **dentro de una delegación**. Los tesoreros de MCM Nules solo ven los de MCM Nules; los gestores centrales ven los de cada delegación por separado, según la delegación que tengan seleccionada arriba. Una nota escrita en una delegación no se ve nunca desde otra.
+{% endhint %}
+
+| Rol | Puede |
+|---|---|
+| Tesorero / Gestor central | Leer, escribir, marcar hecho, archivar y avisar por correo |
+| Solo lectura | Leer los avisos de su delegación |
+
+Cada aviso muestra **quién lo escribió** y cuándo. Borrar solo puede hacerlo quien lo creó (dos toques en la papelera, para no borrar sin querer).
+
+## Pendientes y hechas
+
+- **Pendientes**: lo que está vivo. Es lo que se ve al abrir.
+- **Hechas**: el histórico de tareas completadas y notas archivadas. Desde ahí se puede devolver algo a pendiente si se marcó por error.

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -26,3 +26,4 @@
 
 * [12. Configuración](12-configuracion.md)
 * [13. API externa](13-api-externa.md)
+* [14. Avisos y tareas](14-avisos-tareas.md)

--- a/hooks/use-avisos.ts
+++ b/hooks/use-avisos.ts
@@ -1,0 +1,255 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { AvisosService } from "@/lib/services/avisos"
+import { useAuth } from "@/contexts/auth-context"
+import { useDelegationRole } from "@/hooks/use-delegation-role"
+import { useRevalidateOnFocusJitter } from "./use-app-status"
+import { registerAC, unregisterAC } from "@/lib/db/in-flight"
+import type { Aviso, AvisoContadores, AvisoDestinatario, NuevoAviso } from "@/lib/types/avisos"
+
+const QUERY_TIMEOUT_MS = 12_000
+// Sondeo suave: el panel se revalida al enfocar la pestaña; este intervalo solo
+// cubre el caso de tenerla abierta y quieta un buen rato.
+const POLL_MS = 120_000
+
+const ROLES_ESCRITURA = ["tesorero", "gestor_central"]
+
+export interface UseAvisosResult {
+  avisos: Aviso[]
+  hechos: Aviso[]
+  loading: boolean
+  loadingHechos: boolean
+  error: string | null
+  contadores: AvisoContadores
+  /** Lado del usuario en esta delegación (oficina técnica o delegación). */
+  miLado: AvisoDestinatario
+  /** false mientras no se sabe el rol: `miLado` todavía no es fiable. */
+  rolConocido: boolean
+  puedeEscribir: boolean
+  refetch: () => Promise<void>
+  cargarHechos: () => Promise<void>
+  crear: (payload: NuevoAviso) => Promise<Aviso>
+  completar: (id: string) => Promise<void>
+  reabrir: (id: string) => Promise<void>
+  eliminar: (id: string) => Promise<void>
+  marcarLeidos: (ids: string[]) => Promise<void>
+  notificar: (id: string) => Promise<string[]>
+}
+
+export function useAvisos(delegacionId?: string | null): UseAvisosResult {
+  const { user } = useAuth()
+  const { role, loading: roleLoading } = useDelegationRole(delegacionId)
+
+  const [avisos, setAvisos] = useState<Aviso[]>([])
+  const [hechos, setHechos] = useState<Aviso[]>([])
+  const [loading, setLoading] = useState(true)
+  const [loadingHechos, setLoadingHechos] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const abortRef = useRef<AbortController | null>(null)
+  const avisosRef = useRef(avisos)
+  avisosRef.current = avisos
+
+  const usuarioId = user?.id ?? null
+  const miLado: AvisoDestinatario = role === "gestor_central" ? "oficina_tecnica" : "delegacion"
+  const puedeEscribir = role ? ROLES_ESCRITURA.includes(role) : false
+  // Esperamos a conocer el rol: define qué avisos son "para mí".
+  const listo = Boolean(delegacionId && usuarioId && !roleLoading && role)
+
+  const fetchAvisos = useCallback(async () => {
+    if (abortRef.current) {
+      abortRef.current.abort()
+      unregisterAC(abortRef.current)
+      abortRef.current = null
+    }
+
+    if (!listo || !delegacionId || !usuarioId) {
+      if (!delegacionId) setAvisos([])
+      if (!roleLoading) setLoading(false)
+      return
+    }
+
+    const ac = new AbortController()
+    abortRef.current = ac
+    registerAC(ac)
+
+    try {
+      if (avisosRef.current.length === 0) setLoading(true)
+
+      const data = await Promise.race([
+        AvisosService.listar(delegacionId, { usuarioId, miLado }, { signal: ac.signal }),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error("avisos timeout")), QUERY_TIMEOUT_MS),
+        ),
+      ])
+
+      if (ac.signal.aborted) return
+      setAvisos(data)
+      setError(null)
+    } catch (err) {
+      if (ac.signal.aborted) return
+      setError(err instanceof Error ? err.message : "Error cargando los avisos")
+    } finally {
+      unregisterAC(ac)
+      if (!ac.signal.aborted) setLoading(false)
+    }
+  }, [delegacionId, usuarioId, miLado, listo, roleLoading])
+
+  const fetchRef = useRef(fetchAvisos)
+  fetchRef.current = fetchAvisos
+
+  useEffect(() => {
+    fetchRef.current()
+    return () => {
+      if (abortRef.current) {
+        abortRef.current.abort()
+        unregisterAC(abortRef.current)
+        abortRef.current = null
+      }
+    }
+  }, [delegacionId, usuarioId, miLado, listo])
+
+  useRevalidateOnFocusJitter(() => fetchRef.current(), { minMs: 80, maxMs: 220 })
+
+  useEffect(() => {
+    if (!listo) return
+    const id = setInterval(() => {
+      if (typeof document !== "undefined" && document.visibilityState !== "visible") return
+      fetchRef.current()
+    }, POLL_MS)
+    return () => clearInterval(id)
+  }, [listo])
+
+  const cargarHechos = useCallback(async () => {
+    if (!delegacionId || !usuarioId) return
+    setLoadingHechos(true)
+    try {
+      const data = await AvisosService.listar(
+        delegacionId,
+        { usuarioId, miLado },
+        { incluirHechos: true, limite: 60 },
+      )
+      setHechos(data.filter((a) => a.estado === "hecha"))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Error cargando el historial")
+    } finally {
+      setLoadingHechos(false)
+    }
+  }, [delegacionId, usuarioId, miLado])
+
+  const crear = useCallback(
+    async (payload: NuevoAviso) => {
+      if (!delegacionId || !usuarioId) throw new Error("Falta la delegación o el usuario")
+      const creado = await AvisosService.crear(delegacionId, usuarioId, payload)
+      setAvisos((prev) => [creado, ...prev])
+      if (payload.notificar) {
+        try {
+          await AvisosService.notificar(creado.id)
+          setAvisos((prev) =>
+            prev.map((a) => (a.id === creado.id ? { ...a, notificado_en: new Date().toISOString() } : a)),
+          )
+        } catch (err) {
+          // El aviso ya está guardado; el correo es un extra.
+          throw new Error(
+            err instanceof Error
+              ? `Guardado, pero el correo no salió: ${err.message}`
+              : "Guardado, pero el correo no salió",
+          )
+        }
+      }
+      return creado
+    },
+    [delegacionId, usuarioId],
+  )
+
+  const completar = useCallback(
+    async (id: string) => {
+      const previo = avisosRef.current
+      setAvisos((prev) => prev.filter((a) => a.id !== id))
+      try {
+        await AvisosService.cambiarEstado(id, "hecha", usuarioId ?? undefined)
+      } catch (err) {
+        setAvisos(previo)
+        throw err
+      }
+    },
+    [usuarioId],
+  )
+
+  const reabrir = useCallback(async (id: string) => {
+    setHechos((prev) => prev.filter((a) => a.id !== id))
+    await AvisosService.cambiarEstado(id, "pendiente")
+    await fetchRef.current()
+  }, [])
+
+  const eliminar = useCallback(async (id: string) => {
+    const previo = avisosRef.current
+    setAvisos((prev) => prev.filter((a) => a.id !== id))
+    setHechos((prev) => prev.filter((a) => a.id !== id))
+    try {
+      await AvisosService.eliminar(id)
+    } catch (err) {
+      setAvisos(previo)
+      throw err
+    }
+  }, [])
+
+  const marcarLeidos = useCallback(
+    async (ids: string[]) => {
+      if (!usuarioId || ids.length === 0) return
+      const pendientesDeMarcar = ids.filter((id) =>
+        avisosRef.current.some((a) => a.id === id && a.noLeido),
+      )
+      if (pendientesDeMarcar.length === 0) return
+
+      setAvisos((prev) =>
+        prev.map((a) => (pendientesDeMarcar.includes(a.id) ? { ...a, noLeido: false } : a)),
+      )
+      try {
+        await AvisosService.marcarLeidos(pendientesDeMarcar, usuarioId)
+      } catch (err) {
+        console.error("No se pudieron marcar los avisos como leídos", err)
+        await fetchRef.current()
+      }
+    },
+    [usuarioId],
+  )
+
+  const notificar = useCallback(async (id: string) => {
+    const { destinatarios } = await AvisosService.notificar(id)
+    const ahora = new Date().toISOString()
+    setAvisos((prev) => prev.map((a) => (a.id === id ? { ...a, notificado_en: ahora } : a)))
+    return destinatarios
+  }, [])
+
+  const contadores = useMemo<AvisoContadores>(
+    () => ({
+      noLeidos: avisos.filter((a) => a.noLeido).length,
+      pendientes: avisos.filter((a) => a.tipo === "tarea" && a.esParaMi && a.estado === "pendiente").length,
+    }),
+    [avisos],
+  )
+
+  return {
+    avisos,
+    hechos,
+    loading: loading || roleLoading,
+    loadingHechos,
+    error,
+    contadores,
+    miLado,
+    rolConocido: Boolean(role),
+    puedeEscribir,
+    refetch: useCallback(() => fetchRef.current(), []),
+    cargarHechos,
+    crear,
+    completar,
+    reabrir,
+    eliminar,
+    marcarLeidos,
+    notificar,
+  }
+}
+
+export default useAvisos

--- a/lib/services/avisos.ts
+++ b/lib/services/avisos.ts
@@ -1,0 +1,211 @@
+import { supabase } from "@/lib/supabase/client"
+import type {
+  Aviso,
+  AvisoDestinatario,
+  AvisoEstado,
+  AvisoRow,
+  AvisoTipo,
+  AvisoUpdate,
+  NuevoAviso,
+} from "@/lib/types/avisos"
+import { AVISO_MAX_CONTENIDO, AVISO_MAX_REFERENCIA } from "@/lib/types/avisos"
+
+const AVISO_SELECT = `
+  id,
+  delegacion_id,
+  tipo,
+  contenido,
+  referencia,
+  destinatario,
+  estado,
+  completado_por,
+  completado_en,
+  notificado_en,
+  notificado_por,
+  creado_por,
+  creado_en,
+  actualizado_en,
+  lecturas:aviso_lectura ( usuario_id )
+`
+
+type AvisoRowConLecturas = AvisoRow & { lecturas?: { usuario_id: string }[] | null }
+
+export interface ListarAvisosOptions {
+  /** Incluir también los ya hechos/archivados (para la pestaña "Hechos"). */
+  incluirHechos?: boolean
+  limite?: number
+  signal?: AbortSignal
+}
+
+export interface ListarAvisosContexto {
+  /** Usuario actual. */
+  usuarioId: string
+  /** Lado del usuario en esta delegación: define qué avisos son "para mí". */
+  miLado: AvisoDestinatario
+}
+
+/**
+ * Avisos y tareas de una delegación, ya resueltos para la UI (autoría, lecturas
+ * y si me afectan). El aislamiento por delegación lo garantiza RLS; aquí solo
+ * filtramos por delegacion_id para no traer de más.
+ */
+export const AvisosService = {
+  async listar(
+    delegacionId: string,
+    ctx: ListarAvisosContexto,
+    options: ListarAvisosOptions = {},
+  ): Promise<Aviso[]> {
+    const client = supabase as any
+    let query = client
+      .from("aviso")
+      .select(AVISO_SELECT)
+      .eq("delegacion_id", delegacionId)
+      .order("creado_en", { ascending: false })
+      .limit(options.limite ?? 120)
+
+    if (!options.incluirHechos) {
+      query = query.eq("estado", "pendiente")
+    }
+    if (options.signal) {
+      query = query.abortSignal(options.signal)
+    }
+
+    const { data, error } = await query
+    if (error) throw error
+
+    const rows = (data ?? []) as AvisoRowConLecturas[]
+    const nombres = await fetchNombres(rows, options.signal)
+
+    return rows.map((row) => mapAviso(row, ctx, nombres))
+  },
+
+  async crear(delegacionId: string, usuarioId: string, payload: NuevoAviso): Promise<Aviso> {
+    const contenido = payload.contenido.trim()
+    if (!contenido) throw new Error("El aviso no puede estar vacío")
+    if (contenido.length > AVISO_MAX_CONTENIDO) {
+      throw new Error(`El texto no puede pasar de ${AVISO_MAX_CONTENIDO} caracteres`)
+    }
+
+    const referencia = payload.referencia?.trim().slice(0, AVISO_MAX_REFERENCIA) || null
+
+    const client = supabase as any
+    const { data, error } = await client
+      .from("aviso")
+      .insert({
+        delegacion_id: delegacionId,
+        tipo: payload.tipo,
+        contenido,
+        referencia,
+        destinatario: payload.destinatario,
+        creado_por: usuarioId,
+      })
+      .select(AVISO_SELECT)
+      .single()
+
+    if (error) throw error
+
+    const row = data as AvisoRowConLecturas
+    const nombres = await fetchNombres([row])
+    return mapAviso(row, { usuarioId, miLado: payload.destinatario }, nombres)
+  },
+
+  async cambiarEstado(id: string, estado: AvisoEstado, usuarioId?: string): Promise<void> {
+    const client = supabase as any
+    const updates: AvisoUpdate =
+      estado === "hecha" ? { estado, completado_por: usuarioId ?? null } : { estado }
+    const { error } = await client.from("aviso").update(updates).eq("id", id)
+    if (error) throw error
+  },
+
+  async editar(id: string, updates: Pick<AvisoUpdate, "contenido" | "referencia" | "destinatario">): Promise<void> {
+    const client = supabase as any
+    const { error } = await client.from("aviso").update(updates).eq("id", id)
+    if (error) throw error
+  },
+
+  async eliminar(id: string): Promise<void> {
+    const client = supabase as any
+    const { error } = await client.from("aviso").delete().eq("id", id)
+    if (error) throw error
+  },
+
+  /** Marca como leídos los avisos indicados para el usuario actual (idempotente). */
+  async marcarLeidos(avisoIds: string[], usuarioId: string): Promise<void> {
+    if (avisoIds.length === 0) return
+    const client = supabase as any
+    const { error } = await client
+      .from("aviso_lectura")
+      .upsert(
+        avisoIds.map((aviso_id) => ({ aviso_id, usuario_id: usuarioId })),
+        { onConflict: "aviso_id,usuario_id", ignoreDuplicates: true },
+      )
+    if (error) throw error
+  },
+
+  /** Envía el aviso por correo (Resend) a quien corresponda. */
+  async notificar(avisoId: string): Promise<{ destinatarios: string[] }> {
+    const response = await fetch("/api/avisos/notificar", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ avisoId }),
+    })
+    const payload = await response.json().catch(() => ({}))
+    if (!response.ok) {
+      throw new Error(payload?.error || "No se pudo enviar la notificación")
+    }
+    return { destinatarios: payload?.destinatarios ?? [] }
+  },
+}
+
+/** Nombres de perfil de los usuarios implicados (autores y completadores). */
+async function fetchNombres(
+  rows: AvisoRowConLecturas[],
+  signal?: AbortSignal,
+): Promise<Record<string, string>> {
+  const ids = Array.from(
+    new Set(
+      rows.flatMap((row) => [row.creado_por, row.completado_por].filter(Boolean) as string[]),
+    ),
+  )
+  if (ids.length === 0) return {}
+
+  const client = supabase as any
+  let query = client.from("perfil").select("usuario_id, nombre_completo").in("usuario_id", ids)
+  if (signal) query = query.abortSignal(signal)
+
+  const { data, error } = await query
+  if (error) {
+    // Los nombres son decorativos: si fallan, seguimos con el aviso.
+    console.warn("AvisosService: no se pudieron cargar los nombres de perfil", error)
+    return {}
+  }
+
+  return (data ?? []).reduce((acc: Record<string, string>, perfil: any) => {
+    const nombre = perfil?.nombre_completo?.trim()
+    if (nombre) acc[perfil.usuario_id] = nombre
+    return acc
+  }, {})
+}
+
+function mapAviso(
+  row: AvisoRowConLecturas,
+  ctx: ListarAvisosContexto,
+  nombres: Record<string, string>,
+): Aviso {
+  const lecturas = row.lecturas ?? []
+  const esMio = row.creado_por === ctx.usuarioId
+  const loHeLeido = lecturas.some((l) => l.usuario_id === ctx.usuarioId)
+
+  return {
+    ...row,
+    tipo: row.tipo as AvisoTipo,
+    destinatario: row.destinatario as AvisoDestinatario,
+    estado: row.estado as AvisoEstado,
+    autorNombre: nombres[row.creado_por] ?? null,
+    completadoPorNombre: row.completado_por ? nombres[row.completado_por] ?? null : null,
+    esMio,
+    esParaMi: row.destinatario === ctx.miLado,
+    noLeido: !esMio && !loHeLeido,
+    lecturas: lecturas.filter((l) => l.usuario_id !== row.creado_por).length,
+  }
+}

--- a/lib/types/avisos.ts
+++ b/lib/types/avisos.ts
@@ -1,0 +1,72 @@
+import type { Database } from "./database"
+
+/**
+ * Avisos y tareas: apuntes cortos entre la oficina técnica (gestores centrales)
+ * y los tesoreros de cada delegación. Siempre viven dentro de una delegación.
+ */
+export type AvisoRow = Database["public"]["Tables"]["aviso"]["Row"]
+export type AvisoInsert = Database["public"]["Tables"]["aviso"]["Insert"]
+export type AvisoUpdate = Database["public"]["Tables"]["aviso"]["Update"]
+export type AvisoLectura = Database["public"]["Tables"]["aviso_lectura"]["Row"]
+
+// tipo, destinatario y estado son text en la BD; la app los restringe aquí.
+export type AvisoTipo = "tarea" | "nota"
+export type AvisoDestinatario = "oficina_tecnica" | "delegacion"
+export type AvisoEstado = "pendiente" | "hecha"
+
+export const AVISO_TIPOS: readonly AvisoTipo[] = ["tarea", "nota"] as const
+export const AVISO_DESTINATARIOS: readonly AvisoDestinatario[] = ["oficina_tecnica", "delegacion"] as const
+
+export const AVISO_MAX_CONTENIDO = 2000
+export const AVISO_MAX_REFERENCIA = 60
+
+/** Aviso tal y como lo consume la UI: tipos afinados + autoría y lectura resueltas. */
+export type Aviso = Omit<AvisoRow, "tipo" | "destinatario" | "estado"> & {
+  tipo: AvisoTipo
+  destinatario: AvisoDestinatario
+  estado: AvisoEstado
+  /** Nombre del autor (perfil.nombre_completo) o null si no tiene perfil. */
+  autorNombre: string | null
+  /** Nombre de quien la marcó como hecha. */
+  completadoPorNombre: string | null
+  /** true si soy el autor. */
+  esMio: boolean
+  /** true si va dirigido a mi lado (oficina técnica o delegación). */
+  esParaMi: boolean
+  /** true si todavía no lo he marcado como leído (y no lo escribí yo). */
+  noLeido: boolean
+  /** Cuántas personas lo han leído (sin contar al autor). */
+  lecturas: number
+}
+
+export const AVISO_TIPO_LABELS: Record<AvisoTipo, string> = {
+  tarea: "Tarea",
+  nota: "Nota",
+}
+
+export const AVISO_DESTINATARIO_LABELS: Record<AvisoDestinatario, string> = {
+  oficina_tecnica: "Oficina técnica",
+  delegacion: "Delegación",
+}
+
+/** Etiqueta corta para el selector del compositor ("Para: …"). */
+export const AVISO_DESTINATARIO_SHORT: Record<AvisoDestinatario, string> = {
+  oficina_tecnica: "Oficina técnica",
+  delegacion: "Delegación",
+}
+
+export interface AvisoContadores {
+  /** Notas o tareas nuevas que no he leído. */
+  noLeidos: number
+  /** Tareas pendientes dirigidas a mí. */
+  pendientes: number
+}
+
+export interface NuevoAviso {
+  tipo: AvisoTipo
+  contenido: string
+  referencia?: string | null
+  destinatario: AvisoDestinatario
+  /** Enviar además un correo con Resend a quien corresponda. */
+  notificar?: boolean
+}

--- a/lib/types/supabase-generated.ts
+++ b/lib/types/supabase-generated.ts
@@ -76,6 +76,91 @@ export type Database = {
           },
         ]
       }
+      aviso: {
+        Row: {
+          actualizado_en: string
+          completado_en: string | null
+          completado_por: string | null
+          contenido: string
+          creado_en: string
+          creado_por: string
+          delegacion_id: string
+          destinatario: string
+          estado: string
+          id: string
+          notificado_en: string | null
+          notificado_por: string | null
+          referencia: string | null
+          tipo: string
+        }
+        Insert: {
+          actualizado_en?: string
+          completado_en?: string | null
+          completado_por?: string | null
+          contenido: string
+          creado_en?: string
+          creado_por?: string
+          delegacion_id: string
+          destinatario: string
+          estado?: string
+          id?: string
+          notificado_en?: string | null
+          notificado_por?: string | null
+          referencia?: string | null
+          tipo: string
+        }
+        Update: {
+          actualizado_en?: string
+          completado_en?: string | null
+          completado_por?: string | null
+          contenido?: string
+          creado_en?: string
+          creado_por?: string
+          delegacion_id?: string
+          destinatario?: string
+          estado?: string
+          id?: string
+          notificado_en?: string | null
+          notificado_por?: string | null
+          referencia?: string | null
+          tipo?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "aviso_delegacion_id_fkey"
+            columns: ["delegacion_id"]
+            isOneToOne: false
+            referencedRelation: "delegacion"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      aviso_lectura: {
+        Row: {
+          aviso_id: string
+          leido_en: string
+          usuario_id: string
+        }
+        Insert: {
+          aviso_id: string
+          leido_en?: string
+          usuario_id: string
+        }
+        Update: {
+          aviso_id?: string
+          leido_en?: string
+          usuario_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "aviso_lectura_aviso_id_fkey"
+            columns: ["aviso_id"]
+            isOneToOne: false
+            referencedRelation: "aviso"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       banco_conexion: {
         Row: {
           actualizado_en: string

--- a/scripts/051_create_aviso.sql
+++ b/scripts/051_create_aviso.sql
@@ -1,0 +1,197 @@
+-- Avisos y tareas: apuntes cortos entre la oficina técnica (gestores centrales)
+-- y cada delegación. Sirven para dejar constancia de lo que se ha tocado en la
+-- contabilidad o de lo que queda pendiente, sin salir de la app.
+--
+-- Dos tipos:
+--   - tarea  algo que hay que hacer; tiene estado pendiente/hecha
+--   - nota   información breve ("hemos subido 3 facturas de Mercadona en julio")
+--
+-- Destinatario (a quién va dirigido):
+--   - oficina_tecnica  a los gestores centrales
+--   - delegacion       a los tesoreros de esa delegación
+--
+-- Aislamiento: un aviso pertenece SIEMPRE a una delegación. Los miembros de la
+-- delegación A no ven nunca los avisos de la delegación B (ni los gestores
+-- centrales que no sean miembros de esa delegación).
+--
+-- Las lecturas viven en aviso_lectura: una fila por (aviso, usuario) cuando ese
+-- usuario lo ha leído. El indicador de "novedades" se calcula con su ausencia.
+
+CREATE TABLE IF NOT EXISTS public.aviso (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    delegacion_id UUID NOT NULL REFERENCES public.delegacion(id) ON DELETE CASCADE,
+
+    tipo TEXT NOT NULL CHECK (tipo IN ('tarea', 'nota')),
+    contenido TEXT NOT NULL CHECK (char_length(btrim(contenido)) BETWEEN 1 AND 2000),
+    -- Texto libre y corto para situar el aviso: "Hablar con David", "Lucía", ...
+    referencia TEXT CHECK (referencia IS NULL OR char_length(referencia) <= 60),
+
+    destinatario TEXT NOT NULL CHECK (destinatario IN ('oficina_tecnica', 'delegacion')),
+
+    -- Para tareas: pendiente/hecha. Para notas, 'hecha' equivale a archivada.
+    estado TEXT NOT NULL DEFAULT 'pendiente' CHECK (estado IN ('pendiente', 'hecha')),
+    completado_por UUID,
+    completado_en TIMESTAMPTZ,
+
+    -- Aviso por correo (Resend). Se rellena al pulsar "Notificar".
+    notificado_en TIMESTAMPTZ,
+    notificado_por UUID,
+
+    creado_por UUID NOT NULL DEFAULT auth.uid(),
+    creado_en TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now()),
+    actualizado_en TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now())
+);
+
+-- Listado principal del panel: por delegación, pendientes primero, recientes antes.
+CREATE INDEX IF NOT EXISTS idx_aviso_delegacion_estado_creado
+    ON public.aviso(delegacion_id, estado, creado_en DESC);
+
+CREATE TABLE IF NOT EXISTS public.aviso_lectura (
+    aviso_id UUID NOT NULL REFERENCES public.aviso(id) ON DELETE CASCADE,
+    usuario_id UUID NOT NULL,
+    leido_en TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now()),
+    PRIMARY KEY (aviso_id, usuario_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_aviso_lectura_usuario
+    ON public.aviso_lectura(usuario_id);
+
+-- Trigger: actualizado_en + coherencia de los campos de completado.
+CREATE OR REPLACE FUNCTION public.set_aviso_actualizado_en()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.actualizado_en = timezone('utc', now());
+
+    IF NEW.estado = 'hecha' AND OLD.estado <> 'hecha' THEN
+        NEW.completado_en = timezone('utc', now());
+        NEW.completado_por = COALESCE(NEW.completado_por, auth.uid());
+    ELSIF NEW.estado = 'pendiente' AND OLD.estado = 'hecha' THEN
+        NEW.completado_en = NULL;
+        NEW.completado_por = NULL;
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SET search_path = public, pg_temp;
+
+DROP TRIGGER IF EXISTS trg_aviso_actualizado_en ON public.aviso;
+CREATE TRIGGER trg_aviso_actualizado_en
+    BEFORE UPDATE ON public.aviso
+    FOR EACH ROW
+    EXECUTE FUNCTION public.set_aviso_actualizado_en();
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- RLS
+-- ─────────────────────────────────────────────────────────────────────────────
+ALTER TABLE public.aviso ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.aviso_lectura ENABLE ROW LEVEL SECURITY;
+
+-- SELECT: cualquier miembro de la delegación (incluido solo lectura). La
+-- pertenencia es la única puerta: nadie ve avisos de delegaciones ajenas.
+DROP POLICY IF EXISTS "Ver avisos de mis delegaciones" ON public.aviso;
+CREATE POLICY "Ver avisos de mis delegaciones" ON public.aviso
+    FOR SELECT
+    USING (
+        EXISTS (
+            SELECT 1 FROM public.membresia mb
+            WHERE mb.delegacion_id = aviso.delegacion_id
+              AND mb.usuario_id = auth.uid()
+        )
+    );
+
+-- INSERT: tesorero o gestor_central de esa delegación (o gestor_central global),
+-- y siempre firmando con su propio usuario.
+DROP POLICY IF EXISTS "Crear avisos en mis delegaciones" ON public.aviso;
+CREATE POLICY "Crear avisos en mis delegaciones" ON public.aviso
+    FOR INSERT
+    WITH CHECK (
+        creado_por = auth.uid()
+        AND EXISTS (
+            SELECT 1 FROM public.membresia mb
+            WHERE mb.usuario_id = auth.uid()
+              AND (
+                (mb.delegacion_id = aviso.delegacion_id AND mb.rol IN ('tesorero', 'gestor_central'))
+                OR mb.rol = 'gestor_central'
+              )
+        )
+    );
+
+-- UPDATE: mismos roles de escritura (marcar hecha, archivar, editar el texto).
+DROP POLICY IF EXISTS "Actualizar avisos de mis delegaciones" ON public.aviso;
+CREATE POLICY "Actualizar avisos de mis delegaciones" ON public.aviso
+    FOR UPDATE
+    USING (
+        EXISTS (
+            SELECT 1 FROM public.membresia mb
+            WHERE mb.usuario_id = auth.uid()
+              AND (
+                (mb.delegacion_id = aviso.delegacion_id AND mb.rol IN ('tesorero', 'gestor_central'))
+                OR mb.rol = 'gestor_central'
+              )
+        )
+    );
+
+-- DELETE: solo el autor o un gestor central.
+DROP POLICY IF EXISTS "Borrar avisos propios" ON public.aviso;
+CREATE POLICY "Borrar avisos propios" ON public.aviso
+    FOR DELETE
+    USING (
+        (
+            creado_por = auth.uid()
+            AND EXISTS (
+                SELECT 1 FROM public.membresia mb
+                WHERE mb.usuario_id = auth.uid()
+                  AND mb.delegacion_id = aviso.delegacion_id
+            )
+        )
+        OR (
+            (SELECT public.is_gestor_central())
+            AND EXISTS (
+                SELECT 1 FROM public.membresia mb
+                WHERE mb.usuario_id = auth.uid()
+                  AND mb.delegacion_id = aviso.delegacion_id
+            )
+        )
+    );
+
+-- Lecturas: se ven las de cualquier aviso visible (para saber quién lo ha leído),
+-- pero cada usuario solo puede marcar/desmarcar las suyas.
+DROP POLICY IF EXISTS "Ver lecturas de avisos visibles" ON public.aviso_lectura;
+CREATE POLICY "Ver lecturas de avisos visibles" ON public.aviso_lectura
+    FOR SELECT
+    USING (
+        EXISTS (
+            SELECT 1
+            FROM public.aviso a
+            JOIN public.membresia mb ON mb.delegacion_id = a.delegacion_id
+            WHERE a.id = aviso_lectura.aviso_id
+              AND mb.usuario_id = auth.uid()
+        )
+    );
+
+DROP POLICY IF EXISTS "Marcar como leido" ON public.aviso_lectura;
+CREATE POLICY "Marcar como leido" ON public.aviso_lectura
+    FOR INSERT
+    WITH CHECK (
+        usuario_id = auth.uid()
+        AND EXISTS (
+            SELECT 1
+            FROM public.aviso a
+            JOIN public.membresia mb ON mb.delegacion_id = a.delegacion_id
+            WHERE a.id = aviso_lectura.aviso_id
+              AND mb.usuario_id = auth.uid()
+        )
+    );
+
+DROP POLICY IF EXISTS "Desmarcar mis lecturas" ON public.aviso_lectura;
+CREATE POLICY "Desmarcar mis lecturas" ON public.aviso_lectura
+    FOR DELETE
+    USING (usuario_id = auth.uid());
+
+COMMENT ON TABLE public.aviso IS 'Avisos y tareas por delegación: apuntes cortos entre la oficina técnica y los tesoreros.';
+COMMENT ON COLUMN public.aviso.tipo IS 'tarea (con estado pendiente/hecha) | nota (información breve).';
+COMMENT ON COLUMN public.aviso.destinatario IS 'oficina_tecnica (gestores centrales) | delegacion (tesoreros de la delegación).';
+COMMENT ON COLUMN public.aviso.referencia IS 'Texto libre y corto para situar el aviso: "Hablar con David", "Lucía"...';
+COMMENT ON COLUMN public.aviso.estado IS 'pendiente | hecha. En notas, hecha equivale a archivada.';
+COMMENT ON COLUMN public.aviso.notificado_en IS 'Fecha del último aviso por correo enviado con Resend.';
+COMMENT ON TABLE public.aviso_lectura IS 'Una fila por (aviso, usuario) cuando ese usuario lo ha marcado como leído.';


### PR DESCRIPTION
## Summary
Adds a floating widget for quick communication between the technical office (central managers) and delegation treasurers. Notices and tasks can be created, marked as done, and optionally sent via email without leaving the app.

## Key Changes

- **New `aviso` and `aviso_lectura` tables** (`scripts/051_create_aviso.sql`): Database schema for notices/tasks with delegation isolation, read receipts, and RLS policies
- **AvisosWidget component** (`components/avisos/avisos-widget.tsx`): Floating button (bottom-right) that opens a panel with keyboard shortcuts (⌘/Ctrl+I to toggle, Esc to close). Persists draft to localStorage across page reloads
- **AvisosPanel component** (`components/avisos/avisos-panel.tsx`): Two-tab interface showing pending and completed items, with composer for new notices/tasks
- **AvisoComposer component** (`components/avisos/aviso-composer.tsx`): Text input with auto-height, type selector (task/note), recipient selector (technical office/delegation), optional reference field, and email notification toggle
- **AvisoItem component** (`components/avisos/aviso-item.tsx`): Individual notice/task display with completion checkbox, read indicator, author info, and action buttons (complete, notify, delete)
- **useAvisos hook** (`hooks/use-avisos.ts`): Data fetching with soft polling (120s), focus-based revalidation, CRUD operations, and email notification
- **AvisosService** (`lib/services/avisos.ts`): Supabase queries for listing, creating, updating state, deleting, marking as read, and triggering notifications
- **Email notification API** (`app/api/avisos/notificar/route.ts`): Sends notices via Resend to appropriate recipients (treasurers or central managers) based on destination, with HTML email template
- **Type definitions** (`lib/types/avisos.ts`): TypeScript types for notices, tasks, recipients, and UI state
- **Utility functions** (`components/avisos/utils.ts`): Date formatting (relative short format, full format with time)
- **Documentation** (`docs/14-avisos-tareas.md`): User guide covering widget location, keyboard shortcuts, task vs. note distinction, and workflow

## Implementation Details

- **Default recipient**: Automatically set to "the other side" (technical office if user is treasurer, delegation if user is central manager) based on role
- **Draft persistence**: Uses `useLocalStorageState` hook to preserve unsent notices across sessions
- **Read tracking**: Notices marked as read via `aviso_lectura` table; unread count displayed in panel header
- **Email integration**: Resend API key required; gracefully degrades if not configured
- **RLS enforcement**: Database policies ensure users only see notices from their delegations; role-based write access
- **Soft polling**: 120s interval only when tab is visible; focus-based revalidation with jitter for better UX
- **Accessibility**: Proper ARIA labels, keyboard navigation, focus management, and semantic HTML

## Integration
- Added `AvisosWidget` to `app-layout.tsx` for global availability
- Updated Supabase type definitions in `lib/types/supabase-generated.ts`
- Updated project documentation index in `docs/SUMMARY.md`

https://claude.ai/code/session_014zivhLCd27PMZENUxiyHfQ