### PR TITLE
docs(api): 5-minute quick-test guide for MCM_API_KEY

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,8 +30,10 @@ CRON_SECRET=
 # API key de Resend para el envío de emails (avisos y tareas).
 RESEND_API_KEY=
 
-# API key dedicada para la API externa (docs/13-api-externa.md); si no se
-# define, se reutiliza CRON_SECRET como respaldo.
+# API key dedicada para la API externa (docs/manual/21.-api-externa-solo-pros.md,
+# prueba rápida en docs/API_PRUEBA_RAPIDA.md); si no se define, se reutiliza
+# CRON_SECRET como respaldo — mejor ponerla, así una clave filtrada en Google
+# Apps Script no puede disparar también la sincronización bancaria.
 MCM_API_KEY=
 
 # ---------------------------------------------------------------------------

--- a/docs/API_PRUEBA_RAPIDA.md
+++ b/docs/API_PRUEBA_RAPIDA.md
@@ -1,0 +1,52 @@
+# API externa · prueba rápida (5 minutos)
+
+Guía mínima para dejar la API externa funcionando con su propia clave y
+comprobar que responde. Referencia completa: `docs/manual/21.-api-externa-solo-pros.md`.
+
+## 1. Genera una clave
+
+En tu terminal (o pídesela a alguien que tenga una):
+
+```bash
+openssl rand -hex 32
+```
+
+Copia el resultado, algo como `a1b2c3...` (64 caracteres).
+
+## 2. Ponla en Vercel
+
+1. Vercel → tu proyecto → **Settings → Environment Variables**.
+2. Nombre: `MCM_API_KEY`. Valor: la clave del paso 1. Entornos: **Production**
+   (y Preview si quieres probar antes).
+3. **Save** → luego **Deployments → ⋯ → Redeploy** (las env vars no aplican
+   solas, hace falta un redeploy).
+
+{% hint style="warning" %}
+Si no pones `MCM_API_KEY`, la API sigue funcionando pero con la clave del
+cron bancario (`CRON_SECRET`) — mejor tener la suya propia, más aislada.
+{% endhint %}
+
+## 3. Consigue un ID de movimiento para probar
+
+En la app: **Transacciones → clic en cualquier movimiento → pestaña Datos →
+"ID del movimiento (API)" → Copiar**.
+
+## 4. Un curl y ya
+
+```bash
+curl -H "x-api-key: TU_CLAVE" \
+  https://TU-DOMINIO/api/v1/movimientos/EL_ID_QUE_COPIASTE
+```
+
+## 5. ¿Funciona?
+
+| Ves esto | Significa |
+|---|---|
+| `{"ok": true, "movimiento": {...}}` | ✅ Todo correcto, ya puedes construir sobre esto |
+| `{"ok": false, "error": "No autorizado..."}` (401) | Clave mal copiada, o no has hecho redeploy tras guardarla |
+| `{"ok": false, "error": "Movimiento no encontrado."}` (404) | El ID no existe o lo copiaste mal |
+| `{"ok": false, "error": "...no está configurada..."}` (500) | Ni `MCM_API_KEY` ni `CRON_SECRET` están puestas en Vercel |
+
+Con eso confirmado, la referencia completa (`docs/manual/21.-api-externa-solo-pros.md`)
+tiene el resto: todos los campos de la respuesta, el endpoint de solo
+archivos, y un ejemplo listo para pegar en Google Apps Script.


### PR DESCRIPTION
## Summary
- Addresses backlog item 73 (`docs/ANALISIS_MEJORAS.md`): the external API falls back to `CRON_SECRET` when `MCM_API_KEY` isn't set, so a key leaked via Google Apps Script could also trigger a full bank sync. No code change needed (`verifyApiKey()` already prefers `MCM_API_KEY`) — this closes it operationally with a short guide.
- New `docs/API_PRUEBA_RAPIDA.md`: schematic 5-step quick test (generate key → set in Vercel → redeploy → one curl → read response table) so the maintainer can set and verify their own key without reading the full API reference.
- Fixed `.env.example`'s stale pointer to the pre-redesign `docs/13-api-externa.md` (now `docs/manual/21.-api-externa-solo-pros.md`).

## Test plan
- [x] Docs-only change; no app code touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KcnMJ1yn5Db1VpdK5M829R)_