### PR TITLE
perf(dashboard): TanStack Query migration, code-splitting, memo (sección B)

### DIFF
--- a/components/dashboard/activity-balance.tsx
+++ b/components/dashboard/activity-balance.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useMemo, useState } from "react"
+import { memo, useEffect, useMemo, useState } from "react"
 import Link from "next/link"
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
@@ -54,7 +54,13 @@ interface Props {
 
 const MOVEMENTS_PREVIEW_LIMIT = 30
 
-export function ActivityBalanceDashboard({ from, to, resetToken }: Props) {
+// from/to/resetToken son primitivos: memo evita recalcular esta vista pesada
+// cuando el dashboard padre re-renderiza por otro motivo.
+export const ActivityBalanceDashboard = memo(function ActivityBalanceDashboard({
+  from,
+  to,
+  resetToken,
+}: Props) {
   const { selectedDelegation } = useDelegationContext()
   const [isLoaded, setIsLoaded] = useState(false)
 
@@ -455,4 +461,4 @@ export function ActivityBalanceDashboard({ from, to, resetToken }: Props) {
       )}
     </div>
   )
-}
+})

--- a/components/dashboard/category-analysis.tsx
+++ b/components/dashboard/category-analysis.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import React, { useEffect, useMemo, useState } from "react"
+import React, { memo, useEffect, useMemo, useState } from "react"
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { EmptyState } from "@/components/ui/empty-state"
@@ -216,7 +216,13 @@ function CategoryMobileRow({
   )
 }
 
-export function CategoryAnalysisDashboard({ from, to, resetToken }: Props) {
+// from/to/resetToken son primitivos: memo evita recalcular esta tabla pesada
+// cuando el dashboard padre re-renderiza por otro motivo.
+export const CategoryAnalysisDashboard = memo(function CategoryAnalysisDashboard({
+  from,
+  to,
+  resetToken,
+}: Props) {
   const { selectedDelegation } = useDelegationContext()
   const [isLoaded, setIsLoaded] = useState(false)
 
@@ -981,4 +987,4 @@ export function CategoryAnalysisDashboard({ from, to, resetToken }: Props) {
       />
     </div>
   )
-}
+})

--- a/components/dashboard/dashboard-home.tsx
+++ b/components/dashboard/dashboard-home.tsx
@@ -1,16 +1,27 @@
 "use client"
 
 import { useEffect, useMemo, useState } from "react"
+import dynamic from "next/dynamic"
 import { AppLayout } from "@/components/app-layout"
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs"
 import { TimeframeFilter, type Timeframe, getTimeframeRange } from "@/components/dashboard/timeframe-filter"
-import { ActivityBalanceDashboard } from "@/components/dashboard/activity-balance"
-import { CategoryAnalysisDashboard } from "@/components/dashboard/category-analysis"
 import { OverviewDashboard } from "@/components/dashboard/overview-dashboard"
 import { ConsentAlertBanner } from "@/components/dashboard/consent-alert-banner"
 import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
 import { useLocalStorageState } from "@/hooks/use-local-storage"
 import { TrendingUp, PieChart, Home, RotateCcw } from "lucide-react"
+
+// Carga diferida: ambas pestañas importan Recharts; que solo se pida al
+// navegar a la pestaña en vez de ir en el bundle inicial del dashboard.
+const ActivityBalanceDashboard = dynamic(
+  () => import("@/components/dashboard/activity-balance").then((m) => m.ActivityBalanceDashboard),
+  { ssr: false, loading: () => <Skeleton className="h-[420px] w-full rounded-xl" /> },
+)
+const CategoryAnalysisDashboard = dynamic(
+  () => import("@/components/dashboard/category-analysis").then((m) => m.CategoryAnalysisDashboard),
+  { ssr: false, loading: () => <Skeleton className="h-[420px] w-full rounded-xl" /> },
+)
 
 export type DashboardTab = "overview" | "actividad" | "categorias"
 

--- a/components/dashboard/financial-summary.tsx
+++ b/components/dashboard/financial-summary.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { memo } from "react"
 import { Card, CardContent } from "@/components/ui/card"
 import { TrendingUp, TrendingDown, Scale, Wallet, Tag, CheckCircle2 } from "lucide-react"
 import { useFinancialSummary } from "@/hooks/use-financial-summary"
@@ -12,7 +13,9 @@ interface Props {
   to: string
 }
 
-export function FinancialSummary({ from, to }: Props) {
+// from/to son primitivos: memo evita recalcular las 5 tarjetas cuando el
+// dashboard padre re-renderiza por otro motivo (cambio de pestaña, resetToken...).
+export const FinancialSummary = memo(function FinancialSummary({ from, to }: Props) {
   const router = useRouter()
   const { summary } = useFinancialSummary(from, to)
   // Saldo real: balance de TODA la historia (cuentas activas, sin ignorados).
@@ -123,4 +126,4 @@ export function FinancialSummary({ from, to }: Props) {
       </Card>
     </div>
   )
-}
+})

--- a/components/dashboard/monthly-trend.tsx
+++ b/components/dashboard/monthly-trend.tsx
@@ -2,7 +2,7 @@
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { useMonthlyTrendData } from "@/hooks/use-monthly-trend-data"
-import { useMemo } from "react"
+import { memo, useMemo } from "react"
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, ResponsiveContainer } from "recharts"
 import { ChartContainer, ChartTooltip, ChartTooltipContent, type ChartConfig } from "@/components/ui/chart"
 import { parse, format } from "date-fns"
@@ -13,7 +13,9 @@ interface Props {
   to: string
 }
 
-export function MonthlyTrend({ from, to }: Props) {
+// from/to son primitivos: memo evita recalcular el gráfico cuando el
+// dashboard padre re-renderiza por otro motivo.
+export const MonthlyTrend = memo(function MonthlyTrend({ from, to }: Props) {
   const { trend } = useMonthlyTrendData(from, to)
 
   const chartData = useMemo(() => {
@@ -77,4 +79,4 @@ export function MonthlyTrend({ from, to }: Props) {
       </Card>
     </div>
   )
-}
+})

--- a/components/dashboard/overview-dashboard.tsx
+++ b/components/dashboard/overview-dashboard.tsx
@@ -1,9 +1,17 @@
 "use client"
 
+import dynamic from "next/dynamic"
 import { FinancialSummary } from "./financial-summary"
 import { QuickActions } from "./quick-actions"
 import { RecentTransactions } from "./recent-transactions"
-import { MonthlyTrend } from "./monthly-trend"
+import { Skeleton } from "@/components/ui/skeleton"
+
+// Carga diferida: MonthlyTrend importa Recharts, que así queda fuera del
+// bundle inicial del dashboard (la página que ve todo el mundo al entrar).
+const MonthlyTrend = dynamic(() => import("./monthly-trend").then((m) => m.MonthlyTrend), {
+  ssr: false,
+  loading: () => <Skeleton className="h-[340px] w-full rounded-xl" />,
+})
 
 interface Props {
   from: string

--- a/components/dashboard/quick-actions.tsx
+++ b/components/dashboard/quick-actions.tsx
@@ -1,10 +1,13 @@
 "use client"
 
+import { memo } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Plus, Upload, List, Tag, ArrowRight } from "lucide-react"
 import { useRouter } from "next/navigation"
 
-export function QuickActions() {
+// Sin props: memo evita que re-renderice solo porque el padre (dashboard) lo
+// hace por otro motivo (cambio de timeframe, resetToken, etc.).
+export const QuickActions = memo(function QuickActions() {
   const router = useRouter()
 
   const actions = [
@@ -68,4 +71,4 @@ export function QuickActions() {
       ))}
     </div>
   )
-}
+})

--- a/components/dashboard/recent-transactions.tsx
+++ b/components/dashboard/recent-transactions.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { memo } from "react"
 import Link from "next/link"
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
@@ -15,7 +16,10 @@ interface Props {
   limit?: number
 }
 
-export function RecentTransactions({ limit = 5 }: Props) {
+// `limit` es primitivo: memo evita re-renderizar solo porque el dashboard
+// padre re-renderiza por otro motivo (el propio hook useMovimientos ya
+// controla cuándo cambian sus datos).
+export const RecentTransactions = memo(function RecentTransactions({ limit = 5 }: Props) {
   const { selectedDelegation } = useDelegationContext()
   const { movimientos } = useMovimientos(selectedDelegation)
 
@@ -108,4 +112,4 @@ export function RecentTransactions({ limit = 5 }: Props) {
       </CardContent>
     </Card>
   )
-}
+})

--- a/components/transactions/transaction-detail.tsx
+++ b/components/transactions/transaction-detail.tsx
@@ -104,7 +104,15 @@ export function TransactionDetail({
       return false
     }
 
-    return JSON.stringify(formData) !== JSON.stringify(baselineData)
+    return (
+      formData.importe !== baselineData.importe ||
+      formData.fecha !== baselineData.fecha ||
+      formData.concepto !== baselineData.concepto ||
+      (formData.descripcion || "") !== baselineData.descripcion ||
+      formData.categoria_id !== baselineData.categoria_id ||
+      (formData.contacto_id ?? null) !== baselineData.contacto_id ||
+      (formData.factura_pendiente ?? false) !== baselineData.factura_pendiente
+    )
   }, [formData, baselineData])
 
   const account = accounts.find((acc) => acc.id === movement?.cuenta_id)

--- a/components/transactions/transaction-manager.tsx
+++ b/components/transactions/transaction-manager.tsx
@@ -41,7 +41,16 @@ import { toast } from "sonner"
 import { LoadingSpinner } from "@/components/ui/loading-spinner"
 import { exportMovementsToExcel } from "@/lib/utils/export-to-excel"
 import type { MovimientoConRelaciones, Categoria, Cuenta } from "@/lib/types/database"
-import { TransactionImportPanel } from "./transaction-import-panel"
+import dynamic from "next/dynamic"
+
+// Carga diferida: este panel importa xlsx (parser de Excel, pesado) de forma
+// estática; que quede en un chunk aparte en vez del bundle inicial de
+// /transacciones. Solo se muestra cuando `open` es true (Sheet controlado),
+// así que no hace falta loading fallback (nada debería verse mientras tanto).
+const TransactionImportPanel = dynamic(
+  () => import("./transaction-import-panel").then((m) => m.TransactionImportPanel),
+  { ssr: false },
+)
 import {
   Dialog,
   DialogContent,

--- a/docs/ANALISIS_MEJORAS.md
+++ b/docs/ANALISIS_MEJORAS.md
@@ -56,23 +56,23 @@ Optimizaciones que figuraban como pendientes en docs antiguos pero **ya están e
 
 ### Alto impacto
 
-- [ ] **13. Doble consulta de resumen financiero en el dashboard** — sigue así: `components/dashboard/financial-summary.tsx` llama dos veces a `useFinancialSummary`.
+- [x] **13. Doble consulta de resumen financiero en el dashboard** — **[08/2026]** `financial-summary.tsx` sigue llamando a `useFinancialSummary` dos veces (periodo + histórico 1970→hoy para el saldo, son rangos genuinamente distintos, no se pueden fusionar en una llamada sin cambiar la RPC). Lo que se ha corregido es el hook en sí: migrado a TanStack Query (`hooks/use-financial-summary.ts`, mismo patrón que `useCuentas`/`useCategoryBreakdown`), con caché compartida entre instancias/páginas y `staleTime` de 30s — evita relanzar ambas queries en cada remount/cambio de pestaña dentro de ese margen.
 - [x] **14. Patrón N+1 en `getCuentaConMasMovimientos`** — resuelto: ya usa la RPC `get_cuenta_con_mas_movimientos` (una sola llamada), no N queries.
-- [ ] **15. `getContactosByDelegacion` sin paginación** — sigue pendiente.
-- [ ] **16. Recargas de contadores en cada focus** — sigue pendiente (`use-delegation-counts.ts` sin TTL).
-- [ ] **17. `useMonthlyTrendData` sin caché** — sigue pendiente.
-- [ ] **18. Recharts y xlsx en el bundle inicial** — sigue pendiente: cero usos de `next/dynamic` en todo el repo.
+- [ ] **15. `getContactosByDelegacion` sin paginación** — **[verificado 08/2026, no accionado]** revisado en vivo: hoy hay **1 solo contacto** en toda la base (`select count(*) from contacto`), así que no hay ningún problema de volumen real. Forzar paginación ahora sería el mismo tipo de riesgo que el bug de saldo truncado (punto 32b): `useContactos` construye sus contadores por tipo client-side y hace mutaciones optimistas sobre el array completo — paginar rompería ambas cosas sin necesidad. Revisar cuando el volumen real lo justifique.
+- [x] **16. Recargas de contadores en cada focus** — resuelto: `use-delegation-counts.ts` migrado a TanStack Query (antes: `useRevalidateOnFocusJitter` propio disparando las 6 queries en cada focus de pestaña sin importar si los datos seguían frescos).
+- [x] **17. `useMonthlyTrendData` sin caché** — resuelto: migrado a TanStack Query, mismo patrón.
+- [x] **18. Recharts y xlsx en el bundle inicial** — resuelto: `next/dynamic` (con `ssr:false`) en `MonthlyTrend`, `ActivityBalanceDashboard`, `CategoryAnalysisDashboard` (las 3 pestañas del dashboard que importan Recharts) y en `TransactionImportPanel` (importa `xlsx`, se abre desde un botón en `/transacciones`). Compilación verificada (`pnpm build`, `✓ Compiled successfully`); no había ningún uso de `next/dynamic` en el repo antes de esto.
 - [x] **19. Re-renders en cascada desde `DelegationContext`** — resuelto: `setSelectedDelegation` ya es un `useCallback` con dependencias correctas (comprueba `delegationId === selectedDelegation` antes de actualizar).
 
 ### Medio impacto
 
 - [x] **20. Búsquedas O(n×m) en la tabla de transacciones** — sin cambios, sigue hecho.
-- [ ] **21. `hasChanges` con `JSON.stringify` en cada render** — sigue pendiente.
-- [ ] **22. Falta `React.memo` en componentes pesados del dashboard** — sigue pendiente.
-- [ ] **23. Fetches sin `AbortController`** — sigue pendiente en varios hooks (aunque `runQuery` sí centraliza el abort en los que lo usan — ver hallazgo nuevo sobre mensajes de abort más abajo).
-- [ ] **24. Sin virtualización en listas largas de transacciones** — sigue pendiente.
-- [ ] **25. `images.unoptimized: true`** — sigue pendiente.
-- [ ] **26. Sin Suspense/streaming** — sigue pendiente.
+- [x] **21. `hasChanges` con `JSON.stringify` en cada render** — resuelto: `transaction-detail.tsx` comparaba `formData`/`baselineData` con `JSON.stringify` en cada tecleo (el `useMemo` ya evitaba recomputar si las referencias no cambiaban, pero `formData` cambia de referencia en cada tecla). Sustituido por comparación campo a campo de los 7 campos conocidos (mismos que construye `baselineData`), sin serializar.
+- [x] **22. Falta `React.memo` en componentes pesados del dashboard** — resuelto: `React.memo` en `FinancialSummary`, `RecentTransactions`, `QuickActions`, `MonthlyTrend`, `ActivityBalanceDashboard` y `CategoryAnalysisDashboard` — todos reciben solo props primitivas (`from`/`to`/`resetToken`/`limit` o ninguna), así que la comparación superficial por defecto de `memo` es exacta sin necesitar estabilizar referencias en el padre.
+- [x] **23. Fetches sin `AbortController`** — **[verificado 08/2026]** revisado every hook en `hooks/*.ts` que llama a Supabase/RPC: todos usan `abortSignal`, `runQuery` (que centraliza el abort) o `useQuery` de TanStack (que inyecta `signal` automáticamente) — no queda ningún hook haciendo queries sin mecanismo de cancelación. El hallazgo de mensajes de abort visibles al usuario (punto 38b) ya estaba corregido aparte.
+- [ ] **24. Sin virtualización en listas largas de transacciones** — sigue pendiente. *No accionado ahora*: requiere añadir una dependencia nueva (`react-window`/`@tanstack/react-virtual`) e integrarla con la tabla de transacciones existente (selección, expansión de fila, sticky header) — cambio de mayor superficie que un ajuste de rendimiento puntual, mejor como su propio plan.
+- [ ] **25. `images.unoptimized: true`** — sigue pendiente. *No accionado ahora*: activar la optimización de imágenes de Next tiene implicaciones de infraestructura (coste de la Image Optimization API de Vercel, dominios remotos permitidos) — decisión de producto/infra del mantenedor, no un cambio de código aislado.
+- [ ] **26. Sin Suspense/streaming** — sigue pendiente. *No accionado ahora*: cambio arquitectónico (afecta el árbol de carga de rutas enteras), con riesgo de romper estados de loading/error ya establecidos en toda la app — no es un ajuste seguro de hacer "con cuidadito" sin una revisión propia.
 
 ---
 
@@ -150,6 +150,6 @@ Pasada completa por Dashboard (3 pestañas), Cuentas, Categorías, Transacciones
 1. **Lote 0 (crítico, acción manual del mantenedor):** rotar la contraseña del usuario demo en Supabase Auth (punto 12) — las credenciales ya no están en el repo, pero siguen en el historial de git y la cuenta tiene rol `gestor_central` en 17 delegaciones.
 2. **Lote 1 (seguridad, verificar y cerrar):** 4 (dashboard `/` sin proteger), 6 (validación de ficheros), 8 (xlsx desde CDN), 12b/12c (advisors de Supabase), 73 (API key del cron).
 3. **Lote 2 (bugs de datos):** 32b (ya corregido, desplegar la migración `057` si no se ha hecho vía MCP) — verificar que no hay más agregados client-side sin paginar en el resto de la app.
-4. **Lote 3 (rendimiento):** 13, 15-18, 21-26.
+4. **Lote 3 (rendimiento):** ✅ 13, 16-18, 21-23 hechos (08/2026); 15 verificado y deprioritizado (sin volumen real); quedan 24-26, cada uno documentado como cambio de mayor superficie (nueva dependencia, decisión de infra, o arquitectónico) — no se han forzado sin revisión propia.
 5. **Lote 4 (deuda técnica):** 66-71, 74.
 6. **Lote 5 (pulido móvil pendiente):** 60n, 61n.

--- a/hooks/use-delegation-counts.ts
+++ b/hooks/use-delegation-counts.ts
@@ -1,10 +1,8 @@
 "use client"
 
-import { useCallback, useEffect, useRef, useState } from "react"
+import { useQuery } from "@tanstack/react-query"
 import { supabase } from "@/lib/supabase/client"
 import { useDelegationContext } from "@/contexts/delegation-context"
-import { runQuery } from "@/lib/db/query"
-import { useRevalidateOnFocusJitter } from "@/hooks/use-app-status"
 
 export interface DelegationCounts {
   movimientos: number | null
@@ -24,190 +22,99 @@ const INITIAL_COUNTS: DelegationCounts = {
   facturasBandeja: null,
 }
 
-const QUERY_TIMEOUT_MS = 10000
+async function fetchCounts(
+  delegationId: string,
+  organizacionId: string | null,
+  signal: AbortSignal,
+): Promise<DelegationCounts> {
+  const [movimientosRes, cuentasRes, categoriasRes, contactosRes, pagosMcmRes, facturasRes] =
+    await Promise.all([
+      supabase
+        .from("movimiento")
+        .select("id, cuenta:cuenta_id!inner(activa)", { head: true, count: "exact" })
+        .eq("delegacion_id", delegationId)
+        .eq("cuenta.activa", true)
+        .abortSignal(signal),
+      supabase
+        .from("cuenta")
+        .select("id", { head: true, count: "exact" })
+        .eq("delegacion_id", delegationId)
+        .abortSignal(signal),
+      organizacionId
+        ? supabase
+            .from("categoria")
+            .select("id", { head: true, count: "exact" })
+            .eq("organizacion_id", organizacionId)
+            .abortSignal(signal)
+        : Promise.resolve({ count: null, error: null }),
+      supabase
+        .from("contacto")
+        .select("id", { head: true, count: "exact" })
+        .or(`delegacion_id.eq.${delegationId},es_global.is.true`)
+        .eq("archivado", false)
+        .abortSignal(signal),
+      supabase
+        .from("pago_mcm")
+        .select("id", { head: true, count: "exact" })
+        .eq("delegacion_id", delegationId)
+        .eq("estado", "pendiente")
+        .abortSignal(signal),
+      supabase
+        .from("factura")
+        .select("id", { head: true, count: "exact" })
+        .eq("delegacion_id", delegationId)
+        .eq("estado", "bandeja")
+        .abortSignal(signal),
+    ])
 
-export function useDelegationCounts() {
-  const { selectedDelegation, getCurrentDelegation } = useDelegationContext()
+  const errors = [
+    movimientosRes.error,
+    cuentasRes.error,
+    organizacionId ? categoriasRes.error : null,
+    contactosRes.error,
+    pagosMcmRes.error,
+    facturasRes.error,
+  ].filter(Boolean)
 
-  const [counts, setCounts] = useState<DelegationCounts>(INITIAL_COUNTS)
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-
-  const requestRef = useRef(0)
-  const lastDelegationRef = useRef<string | null>(null)
-
-  const fetchCounts = useCallback(async () => {
-    const delegationId = selectedDelegation
-
-    if (!delegationId) {
-      lastDelegationRef.current = null
-      setCounts(INITIAL_COUNTS)
-      setLoading(false)
-      setError(null)
-      return
-    }
-
-    if (lastDelegationRef.current !== delegationId) {
-      lastDelegationRef.current = delegationId
-      setCounts(INITIAL_COUNTS)
-    }
-
-    const fetchId = ++requestRef.current
-    setLoading(true)
-    setError(null)
-
-    const delegation = getCurrentDelegation()
-    const organizacionId = delegation?.organizacion_id ?? null
-
-    try {
-      const [movimientosRes, cuentasRes, categoriasRes, contactosRes, pagosMcmRes, facturasRes] = await Promise.all([
-        runQuery<{ count: number | null }>({
-          label: "count-movimientos",
-          table: "movimiento",
-          timeoutMs: QUERY_TIMEOUT_MS,
-          build: async (signal) => {
-            const { count, error } = await supabase
-              .from("movimiento")
-              .select("id, cuenta:cuenta_id!inner(activa)", { head: true, count: "exact" })
-              .eq("delegacion_id", delegationId)
-              .eq("cuenta.activa", true)
-              .abortSignal(signal)
-            return { data: { count: typeof count === "number" ? count : 0 }, error }
-          },
-        }),
-        runQuery<{ count: number | null }>({
-          label: "count-cuentas",
-          table: "cuenta",
-          timeoutMs: QUERY_TIMEOUT_MS,
-          build: async (signal) => {
-            const { count, error } = await supabase
-              .from("cuenta")
-              .select("id", { head: true, count: "exact" })
-              .eq("delegacion_id", delegationId)
-              .abortSignal(signal)
-            return { data: { count: typeof count === "number" ? count : 0 }, error }
-          },
-        }),
-        organizacionId
-          ? runQuery<{ count: number | null }>({
-              label: "count-categorias",
-              table: "categoria",
-              timeoutMs: QUERY_TIMEOUT_MS,
-              build: async (signal) => {
-                const { count, error } = await supabase
-                  .from("categoria")
-                  .select("id", { head: true, count: "exact" })
-                  .eq("organizacion_id", organizacionId)
-                  .abortSignal(signal)
-                return { data: { count: typeof count === "number" ? count : 0 }, error }
-              },
-            })
-          : Promise.resolve({ data: { count: null }, error: null }),
-        runQuery<{ count: number | null }>({
-          label: "count-contactos",
-          table: "contacto",
-          timeoutMs: QUERY_TIMEOUT_MS,
-          build: async (signal) => {
-            const { count, error } = await supabase
-              .from("contacto")
-              .select("id", { head: true, count: "exact" })
-              .or(`delegacion_id.eq.${delegationId},es_global.is.true`)
-              .eq("archivado", false)
-              .abortSignal(signal)
-            return { data: { count: typeof count === "number" ? count : 0 }, error }
-          },
-        }),
-        runQuery<{ count: number | null }>({
-          label: "count-pagos-mcm-pendientes",
-          table: "pago_mcm",
-          timeoutMs: QUERY_TIMEOUT_MS,
-          build: async (signal) => {
-            const { count, error } = await supabase
-              .from("pago_mcm")
-              .select("id", { head: true, count: "exact" })
-              .eq("delegacion_id", delegationId)
-              .eq("estado", "pendiente")
-              .abortSignal(signal)
-            return { data: { count: typeof count === "number" ? count : 0 }, error }
-          },
-        }),
-        runQuery<{ count: number | null }>({
-          label: "count-facturas-bandeja",
-          table: "factura",
-          timeoutMs: QUERY_TIMEOUT_MS,
-          build: async (signal) => {
-            const { count, error } = await supabase
-              .from("factura")
-              .select("id", { head: true, count: "exact" })
-              .eq("delegacion_id", delegationId)
-              .eq("estado", "bandeja")
-              .abortSignal(signal)
-            return { data: { count: typeof count === "number" ? count : 0 }, error }
-          },
-        }),
-      ])
-
-      if (requestRef.current !== fetchId) return
-
-      const nextCounts: DelegationCounts = {
-        movimientos: movimientosRes.error ? null : movimientosRes.data?.count ?? 0,
-        cuentas: cuentasRes.error ? null : cuentasRes.data?.count ?? 0,
-        categorias:
-          organizacionId === null
-            ? null
-            : categoriasRes.error
-              ? null
-              : categoriasRes.data?.count ?? 0,
-        contactos: contactosRes.error ? null : contactosRes.data?.count ?? 0,
-        pagosMcmPendientes: pagosMcmRes.error ? null : pagosMcmRes.data?.count ?? 0,
-        facturasBandeja: facturasRes.error ? null : facturasRes.data?.count ?? 0,
-      }
-
-      const hasError =
-        Boolean(movimientosRes.error) ||
-        Boolean(cuentasRes.error) ||
-        (organizacionId !== null && Boolean(categoriasRes.error)) ||
-        Boolean(contactosRes.error) ||
-        Boolean(pagosMcmRes.error) ||
-        Boolean(facturasRes.error)
-
-      if (hasError) {
-        console.warn("⚠️ useDelegationCounts: error loading counts", {
-          movimientosError: movimientosRes.error,
-          cuentasError: cuentasRes.error,
-          categoriasError: categoriasRes.error,
-          contactosError: contactosRes.error,
-          pagosMcmError: pagosMcmRes.error,
-        })
-        setError("No se pudieron cargar todos los totales")
-      } else {
-        setError(null)
-      }
-
-      setCounts(nextCounts)
-    } catch (err) {
-      if (requestRef.current !== fetchId) return
-      console.error("❌ useDelegationCounts: unexpected error", err)
-      setCounts(INITIAL_COUNTS)
-      setError(err instanceof Error ? err.message : "No se pudieron cargar los totales")
-    } finally {
-      if (requestRef.current === fetchId) {
-        setLoading(false)
-      }
-    }
-  }, [selectedDelegation, getCurrentDelegation])
-
-  useEffect(() => {
-    fetchCounts()
-  }, [fetchCounts])
-
-  useRevalidateOnFocusJitter(fetchCounts, { minMs: 80, maxMs: 180 })
+  if (errors.length > 0) {
+    console.warn("⚠️ useDelegationCounts: error loading counts", errors)
+  }
 
   return {
-    counts,
-    loading,
-    error,
-    refresh: fetchCounts,
+    movimientos: movimientosRes.error ? null : (movimientosRes.count ?? 0),
+    cuentas: cuentasRes.error ? null : (cuentasRes.count ?? 0),
+    categorias: organizacionId === null ? null : categoriasRes.error ? null : (categoriasRes.count ?? 0),
+    contactos: contactosRes.error ? null : (contactosRes.count ?? 0),
+    pagosMcmPendientes: pagosMcmRes.error ? null : (pagosMcmRes.count ?? 0),
+    facturasBandeja: facturasRes.error ? null : (facturasRes.count ?? 0),
+  }
+}
+
+/**
+ * Contadores por delegación (badges del sidebar/topbar). Migrado a TanStack
+ * Query: caché compartida y revalidación al foco centralizadas por la
+ * librería en vez de un `useRevalidateOnFocusJitter` propio — evita que estos
+ * 6 counts se repitan en cada focus de pestaña si los datos siguen frescos
+ * (`staleTime` global de 30s en `QueryProvider`).
+ *
+ * Mantiene el mismo contrato de salida que la versión anterior (counts,
+ * loading, error, refresh) para no tocar a los consumidores.
+ */
+export function useDelegationCounts() {
+  const { selectedDelegation, getCurrentDelegation } = useDelegationContext()
+  const organizacionId = getCurrentDelegation()?.organizacion_id ?? null
+
+  const query = useQuery<DelegationCounts>({
+    queryKey: ["delegation-counts", selectedDelegation, organizacionId],
+    queryFn: ({ signal }) => fetchCounts(selectedDelegation as string, organizacionId, signal),
+    enabled: Boolean(selectedDelegation),
+  })
+
+  return {
+    counts: query.data ?? INITIAL_COUNTS,
+    loading: query.isPending && query.fetchStatus !== "idle",
+    error: query.error ? "No se pudieron cargar todos los totales" : null,
+    refresh: query.refetch,
   }
 }
 

--- a/hooks/use-financial-summary.ts
+++ b/hooks/use-financial-summary.ts
@@ -1,10 +1,8 @@
 "use client"
 
-import { useCallback, useEffect, useRef, useState } from "react"
+import { useQuery } from "@tanstack/react-query"
 import { useDelegationContext } from "@/contexts/delegation-context"
 import { DatabaseService } from "@/lib/services/database"
-import { runQuery } from "@/lib/db/query"
-import { useRevalidateOnFocusJitter } from "@/hooks/use-app-status"
 import type { FinancialSummary } from "@/lib/types/database"
 
 const EMPTY_SUMMARY: FinancialSummary = {
@@ -15,77 +13,31 @@ const EMPTY_SUMMARY: FinancialSummary = {
   sin_categoria: 0,
 }
 
-const QUERY_TIMEOUT_MS = 15000
-
+/**
+ * Resumen financiero para un rango de fechas. Migrado a TanStack Query (mismo
+ * patrón que `useCategoryBreakdown`/`useCuentas`): caché compartida entre
+ * páginas y llamadas con la misma key (p.ej. el "saldo en cuentas" de todo el
+ * histórico se pide desde varios sitios con from="1970-01-01"), deduplicación
+ * y revalidación al foco centralizadas por la librería en vez de un
+ * `useRevalidateOnFocusJitter` por instancia.
+ *
+ * Mantiene el mismo contrato de salida que la versión anterior (summary,
+ * loading, error, refresh) para no tocar a los consumidores.
+ */
 export function useFinancialSummary(from: string, to: string) {
   const { selectedDelegation } = useDelegationContext()
 
-  const [summary, setSummary] = useState<FinancialSummary>(EMPTY_SUMMARY)
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const query = useQuery<FinancialSummary>({
+    queryKey: ["financial-summary", selectedDelegation, from, to],
+    queryFn: ({ signal }) =>
+      DatabaseService.getFinancialSummary(selectedDelegation as string, from, to, signal),
+    enabled: Boolean(selectedDelegation && from && to),
+  })
 
-  const requestRef = useRef(0)
-  const lastKeyRef = useRef<string | null>(null)
-
-  const fetchSummary = useCallback(async () => {
-    if (!selectedDelegation || !from || !to) {
-      setSummary(EMPTY_SUMMARY)
-      setLoading(false)
-      setError(null)
-      return
-    }
-
-    const key = `${selectedDelegation}|${from}|${to}`
-    if (lastKeyRef.current !== key) {
-      lastKeyRef.current = key
-      setSummary(EMPTY_SUMMARY)
-    }
-
-    const fetchId = ++requestRef.current
-    setLoading(true)
-    setError(null)
-
-    try {
-      const result = await runQuery<FinancialSummary>({
-        label: "financial-summary",
-        table: "movimiento",
-        timeoutMs: QUERY_TIMEOUT_MS,
-        build: async (signal) => {
-          const data = await DatabaseService.getFinancialSummary(
-            selectedDelegation,
-            from,
-            to,
-            signal,
-          )
-          return { data, error: null }
-        },
-      })
-
-      if (requestRef.current !== fetchId) return
-
-      if (result.error) {
-        setError(result.error.message ?? "Error al calcular el resumen financiero")
-        setSummary(EMPTY_SUMMARY)
-      } else {
-        setSummary(result.data ?? EMPTY_SUMMARY)
-        setError(null)
-      }
-    } catch (err) {
-      if (requestRef.current !== fetchId) return
-      setSummary(EMPTY_SUMMARY)
-      setError(err instanceof Error ? err.message : "Error al calcular el resumen financiero")
-    } finally {
-      if (requestRef.current === fetchId) {
-        setLoading(false)
-      }
-    }
-  }, [selectedDelegation, from, to])
-
-  useEffect(() => {
-    fetchSummary()
-  }, [fetchSummary])
-
-  useRevalidateOnFocusJitter(fetchSummary, { minMs: 90, maxMs: 200 })
-
-  return { summary, loading, error, refresh: fetchSummary }
+  return {
+    summary: query.data ?? EMPTY_SUMMARY,
+    loading: query.isPending && query.fetchStatus !== "idle",
+    error: query.error ? (query.error as Error).message : null,
+    refresh: query.refetch,
+  }
 }

--- a/hooks/use-monthly-trend-data.ts
+++ b/hooks/use-monthly-trend-data.ts
@@ -1,83 +1,32 @@
 "use client"
 
-import { useCallback, useEffect, useRef, useState } from "react"
+import { useQuery } from "@tanstack/react-query"
 import { useDelegationContext } from "@/contexts/delegation-context"
 import { DatabaseService } from "@/lib/services/database"
-import { runQuery } from "@/lib/db/query"
-import { useRevalidateOnFocusJitter } from "@/hooks/use-app-status"
 import type { MonthlyTrendRow } from "@/lib/types/database"
 
-const QUERY_TIMEOUT_MS = 15000
-
+/**
+ * Tendencia mensual para un rango de fechas. Migrado a TanStack Query (mismo
+ * patrón que `useCategoryBreakdown`): caché compartida, deduplicación y
+ * revalidación al foco centralizadas por la librería.
+ *
+ * Mantiene el mismo contrato de salida que la versión anterior (trend,
+ * loading, error, refresh) para no tocar a los consumidores.
+ */
 export function useMonthlyTrendData(from: string, to: string) {
   const { selectedDelegation } = useDelegationContext()
 
-  const [trend, setTrend] = useState<MonthlyTrendRow[]>([])
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const query = useQuery<MonthlyTrendRow[]>({
+    queryKey: ["monthly-trend", selectedDelegation, from, to],
+    queryFn: ({ signal }) =>
+      DatabaseService.getMonthlyTrend(selectedDelegation as string, from, to, signal),
+    enabled: Boolean(selectedDelegation && from && to),
+  })
 
-  const requestRef = useRef(0)
-  const lastKeyRef = useRef<string | null>(null)
-
-  const fetchTrend = useCallback(async () => {
-    if (!selectedDelegation || !from || !to) {
-      setTrend([])
-      setLoading(false)
-      setError(null)
-      return
-    }
-
-    const key = `${selectedDelegation}|${from}|${to}`
-    if (lastKeyRef.current !== key) {
-      lastKeyRef.current = key
-      setTrend([])
-    }
-
-    const fetchId = ++requestRef.current
-    setLoading(true)
-    setError(null)
-
-    try {
-      const result = await runQuery<MonthlyTrendRow[]>({
-        label: "monthly-trend",
-        table: "movimiento",
-        timeoutMs: QUERY_TIMEOUT_MS,
-        build: async (signal) => {
-          const data = await DatabaseService.getMonthlyTrend(
-            selectedDelegation,
-            from,
-            to,
-            signal,
-          )
-          return { data, error: null }
-        },
-      })
-
-      if (requestRef.current !== fetchId) return
-
-      if (result.error) {
-        setError(result.error.message ?? "Error al cargar la tendencia mensual")
-        setTrend([])
-      } else {
-        setTrend(result.data ?? [])
-        setError(null)
-      }
-    } catch (err) {
-      if (requestRef.current !== fetchId) return
-      setTrend([])
-      setError(err instanceof Error ? err.message : "Error al cargar la tendencia mensual")
-    } finally {
-      if (requestRef.current === fetchId) {
-        setLoading(false)
-      }
-    }
-  }, [selectedDelegation, from, to])
-
-  useEffect(() => {
-    fetchTrend()
-  }, [fetchTrend])
-
-  useRevalidateOnFocusJitter(fetchTrend, { minMs: 90, maxMs: 200 })
-
-  return { trend, loading, error, refresh: fetchTrend }
+  return {
+    trend: query.data ?? [],
+    loading: query.isPending && query.fetchStatus !== "idle",
+    error: query.error ? (query.error as Error).message : null,
+    refresh: query.refetch,
+  }
 }


### PR DESCRIPTION
## Summary
Addresses `docs/ANALISIS_MEJORAS.md` section B performance items 13, 15-18, 21-23 (recommended earlier this session). Verified against live data and current `main` before implementing — branch was cut from `main`'s tip, no overlap with concurrent work.

- **13/16/17** — migrated `use-financial-summary`, `use-delegation-counts`, `use-monthly-trend-data` to TanStack Query, mirroring the already-established `useCuentas`/`useCategoryBreakdown` pattern (30s `staleTime`, built-in focus revalidation instead of a per-hook `useRevalidateOnFocusJitter`). Same public hook contract — no consumer changes.
- **15** — verified live: only 1 `contacto` row exists today. Forcing pagination now would risk the same truncation-bug class just fixed for account balances and break `useContactos`' client-side counts + optimistic CRUD, which depend on the full list. Documented as deprioritized rather than force-changed.
- **18** — `next/dynamic` (`ssr:false`) for `MonthlyTrend`, `ActivityBalanceDashboard`, `CategoryAnalysisDashboard` (Recharts) and `TransactionImportPanel` (xlsx) — first use of `next/dynamic` in the repo.
- **21** — `transaction-detail.tsx`'s `hasChanges` did `JSON.stringify` on every keystroke; replaced with direct field comparison.
- **22** — `React.memo` on the dashboard's heavy components (`FinancialSummary`, `RecentTransactions`, `QuickActions`, `MonthlyTrend`, `ActivityBalanceDashboard`, `CategoryAnalysisDashboard`) — all take only primitive props, so default shallow comparison is exact.
- **23** — verified: every hook querying Supabase/RPC already has an abort mechanism (`abortSignal`, `runQuery`, or TanStack Query's `signal`). No gaps found.

Deferred with documented reasoning in the doc (bigger surface than a safe perf tweak): 24 (virtualization, new dependency), 25 (`images.unoptimized`, infra/cost decision), 26 (Suspense/streaming, architectural).

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `pnpm lint` clean (3 pre-existing warnings only)
- [x] `pnpm test` 77/77 passing
- [x] `pnpm build` compiles successfully (only the pre-existing env-var prerender error in this sandbox, unrelated to this diff)


---
_Generated by [Claude Code](https://claude.ai/code/session_01KcnMJ1yn5Db1VpdK5M829R)_