### PR TITLE
Refactor movimiento delegation embedding and improve error handling

### DIFF
--- a/lib/api/movimientos-public.ts
+++ b/lib/api/movimientos-public.ts
@@ -84,7 +84,8 @@ const MOVIMIENTO_SELECT = `
   value_date,
   origen_sync,
   creado_en,
-  cuenta:cuenta_id (
+  delegacion_id,
+  cuenta:cuenta_id!movimiento_cuenta_id_fkey (
     id,
     nombre,
     tipo,
@@ -98,11 +99,6 @@ const MOVIMIENTO_SELECT = `
     emoji,
     color
   ),
-  delegacion:delegacion_id (
-    id,
-    codigo,
-    nombre
-  ),
   contacto:contacto_id (
     id,
     nombre,
@@ -111,8 +107,32 @@ const MOVIMIENTO_SELECT = `
 `
 
 /**
+ * Convierte un error de Supabase/PostgREST (un objeto plano, no una instancia
+ * de `Error`) en un `Error` real, para que el `catch` de las rutas pueda
+ * mostrar `err.message` en vez de volcar `String(objetoPlano)` como
+ * `"[object Object]"`.
+ */
+function wrapSupabaseError(error: unknown): Error {
+  if (error instanceof Error) return error
+  const message =
+    error && typeof error === "object" && "message" in error
+      ? String((error as { message?: unknown }).message)
+      : "Error desconocido de Supabase."
+  return new Error(message)
+}
+
+/**
  * Obtiene un movimiento por su ID con sus relaciones (cuenta, categoría,
- * delegación, contacto). Devuelve `null` si no existe.
+ * contacto) y la delegación asociada. Devuelve `null` si no existe.
+ *
+ * La cuenta se embebe indicando explícitamente la FK (`!movimiento_cuenta_id_fkey`):
+ * `movimiento` tiene otra FK compuesta hacia `cuenta` (`movimiento_cuenta_deleg_fk`,
+ * que valida que la cuenta pertenezca a la delegación del movimiento) y sin el
+ * hint PostgREST no puede decidir cuál de las dos usar ("ambiguous embedding").
+ *
+ * La delegación no se embebe en el mismo `select`: no existe una FK directa
+ * `movimiento.delegacion_id -> delegacion.id` (solo la compuesta de arriba),
+ * así que se resuelve con una segunda consulta.
  */
 export async function getMovimientoRaw(admin: AdminClient, id: string) {
   const { data, error } = await (admin as any)
@@ -121,7 +141,26 @@ export async function getMovimientoRaw(admin: AdminClient, id: string) {
     .eq("id", id)
     .maybeSingle()
 
-  if (error) throw error
+  if (error) throw wrapSupabaseError(error)
+  if (!data) return null
+
+  const delegacion = await getDelegacionRaw(admin, (data as any).delegacion_id)
+  return { ...(data as object), delegacion }
+}
+
+/**
+ * Obtiene una delegación por su ID en su forma pública mínima.
+ */
+export async function getDelegacionRaw(admin: AdminClient, delegacionId: string | null) {
+  if (!delegacionId) return null
+
+  const { data, error } = await (admin as any)
+    .from("delegacion")
+    .select("id, codigo, nombre")
+    .eq("id", delegacionId)
+    .maybeSingle()
+
+  if (error) throw wrapSupabaseError(error)
   return data ?? null
 }
 
@@ -135,7 +174,7 @@ export async function getArchivosRaw(admin: AdminClient, movimientoId: string) {
     .eq("movimiento_id", movimientoId)
     .order("subido_en", { ascending: true })
 
-  if (error) throw error
+  if (error) throw wrapSupabaseError(error)
   return (data ?? []) as any[]
 }
 


### PR DESCRIPTION
## Summary
Refactors the movimiento query to fix ambiguous foreign key resolution and improves error handling across the API layer. The delegation is now fetched separately instead of being embedded in the main query, and Supabase errors are properly wrapped into Error instances for consistent error reporting.

## Key Changes

- **Fixed ambiguous FK embedding**: Modified `MOVIMIENTO_SELECT` to explicitly specify the FK constraint (`!movimiento_cuenta_id_fkey`) when embedding the `cuenta` relation, resolving PostgREST ambiguity when multiple FKs target the same table
- **Separated delegation fetching**: Removed `delegacion` from the main movimiento select and now fetch it separately via a new `getDelegacionRaw()` function, since no direct FK exists from `movimiento.delegacion_id` to `delegacion.id` (only a composite FK validates account-delegation pairing)
- **Improved error handling**: Added `wrapSupabaseError()` utility to convert plain Supabase/PostgREST error objects into proper Error instances, enabling consistent `.message` access in route error handlers
- **Applied error wrapping**: Updated all error throws in `getMovimientoRaw()`, `getDelegacionRaw()`, and `getArchivosRaw()` to use the new wrapper

## Implementation Details

The `wrapSupabaseError()` function handles three cases:
1. Already an Error instance → return as-is
2. Plain object with `message` property → extract and wrap
3. Unknown error type → return generic "Error desconocido de Supabase"

This ensures route error handlers can safely call `err.message` instead of getting `"[object Object]"` from `String()` coercion.

The delegation is now resolved in a second query after the main movimiento fetch, maintaining the same public API surface while respecting the actual database constraints.

https://claude.ai/code/session_01TZ75ebjqsAW84eymGXfcgP