### PR TITLE
fix(api): correct PostgREST embed-hint syntax for cuenta

### DIFF
--- a/lib/api/movimientos-public.ts
+++ b/lib/api/movimientos-public.ts
@@ -85,7 +85,7 @@ const MOVIMIENTO_SELECT = `
   origen_sync,
   creado_en,
   delegacion_id,
-  cuenta:cuenta_id!movimiento_cuenta_id_fkey (
+  cuenta:cuenta!movimiento_cuenta_id_fkey (
     id,
     nombre,
     tipo,


### PR DESCRIPTION
## Summary
- Follow-up to #167, which merged before this correction landed on the branch.
- `cuenta:cuenta_id!movimiento_cuenta_id_fkey` used the FK *column* (`cuenta_id`) as the embed target, so PostgREST looked for a relationship literally named `cuenta_id` and failed with `Could not find a relationship between 'movimiento' and 'cuenta_id'`.
- Fixed to `cuenta:cuenta!movimiento_cuenta_id_fkey`: the embed target must be the actual referenced table (`cuenta`), with the FK constraint name only as the disambiguation hint. Confirmed against the PostgREST resource embedding docs (`alias:target!hint(columns)`).

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint lib/api/movimientos-public.ts` — clean
- [ ] After merge + redeploy: `curl -H "x-api-key: ..." https://bank.movimientoconsolacion.com/api/v1/movimientos/{id}` returns `{"ok":true,...}`


---
_Generated by [Claude Code](https://claude.ai/code/session_01TZ75ebjqsAW84eymGXfcgP)_