### PR TITLE
feat(api): API externa completa y servidor MCP de lectura y escritura

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,11 +30,30 @@ CRON_SECRET=
 # API key de Resend para el envío de emails (avisos y tareas).
 RESEND_API_KEY=
 
-# API key dedicada para la API externa (docs/manual/21.-api-externa-solo-pros.md,
-# prueba rápida en docs/API_PRUEBA_RAPIDA.md); si no se define, se reutiliza
-# CRON_SECRET como respaldo — mejor ponerla, así una clave filtrada en Google
-# Apps Script no puede disparar también la sincronización bancaria.
+# ---------------------------------------------------------------------------
+# API externa y servidor MCP
+# (docs/manual/21.-api-externa-solo-pros.md y 22.-servidor-mcp.md;
+#  prueba rápida en docs/API_PRUEBA_RAPIDA.md)
+# ---------------------------------------------------------------------------
+
+# Clave con permiso de LECTURA Y ESCRITURA. Es la que necesita el servidor MCP
+# para crear avisos, subir facturas o conciliar. Sin ella, la API funciona en
+# modo consulta con CRON_SECRET y toda escritura devuelve 403.
 MCM_API_KEY=
+
+# Clave alternativa de SOLO LECTURA, para integraciones que únicamente
+# consultan (informes, cuadros de mando, Google Apps Script). Opcional, pero
+# recomendable: así una clave pegada en una hoja de cálculo no puede modificar
+# la contabilidad.
+MCM_API_KEY_READONLY=
+
+# Usuario de MCM Bank al que se atribuyen las escrituras hechas por la API
+# cuando quien llama no indica la suya (cabecera x-mcm-usuario-email o campo
+# usuario_email). Sin esto, las escrituras fallan con un mensaje explicándolo:
+# es deliberado, para no firmar notas con la persona equivocada.
+MCM_API_USER_EMAIL=
+# Alternativa al correo, con el UUID del usuario.
+MCM_API_USER_ID=
 
 # ---------------------------------------------------------------------------
 # Enable Banking (sincronización bancaria PSD2) — ver docs/ENABLE_BANKING.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,6 +183,8 @@ components/                 # Reusable React components
 lib/                        # Business logic, utilities, types
   supabase/                 # Supabase clients (client, server, admin, middleware, redirect)
   services/                 # Data service layer (database, server-database, file-service, avisos)
+  api/                      # Shared core of the external API + MCP server (see below)
+  mcp/                      # MCP protocol layer (protocol, args, tools, server)
   types/                    # TypeScript types (database.ts, improvement-proposals.ts)
   utils/                    # Utilities (format, category-colors, export-to-excel, date-input, etc.)
   db/                       # Query execution and telemetry (query.ts, telemetry.ts)
@@ -211,8 +213,56 @@ docs/                       # End-user documentation in Spanish
 | `/api/avisos/notificar` | Sends a notice/task by email via Resend |
 | `/api/admin/users` | Admin user management API |
 | `/api/supabase-sanity` | Supabase health check API |
+| `/api/v1/*` | External REST API (see below) |
+| `/api/mcp` | MCP server (JSON-RPC over HTTP) |
+| `/api/v1/openapi.json`, `/docs/api`, `/llms.txt` | Machine- and human-readable API docs |
 
 All non-auth routes use `<AppLayout>` for consistent navigation (sidebar + topbar).
+
+## External API and MCP server
+
+`/api/v1/*` (REST) and `/api/mcp` (MCP) are two front doors onto the **same**
+core in `lib/api/`. Anything doable through one is doable through the other, and
+neither route handler contains business logic — they parse input, check the key,
+and call the core. Add a capability once, in `lib/api/`, then expose it in both.
+
+Both are aimed at central-office admins who work across **all** delegations, so
+they use the **admin (service role) client** and bypass RLS. Everything is
+scoped explicitly in the query instead: `resolveAmbitoDelegaciones()` returns
+`null` for "all delegations" and a resolved list otherwise.
+
+| Module | Responsibility |
+|--------|----------------|
+| `lib/api/external-auth.ts` | API-key check with two scopes: `MCM_API_KEY` (read+write), `MCM_API_KEY_READONLY` and `CRON_SECRET` (read only) |
+| `lib/api/actor.ts` | Resolves the real user that signs each write (`usuario_email` → `x-mcm-usuario-email` → `MCM_API_USER_EMAIL`). Never picks an arbitrary user |
+| `lib/api/delegaciones.ts` | Natural-language delegation lookup ("Sevilla", "MCM-SEV", UUID); ambiguity returns the candidates |
+| `lib/api/catalogos.ts` | Cached cuenta/categoria/contacto maps, joined in memory instead of embedded in every query |
+| `lib/api/movimientos-public.ts` | Movement search (multi-delegation, with whole-set totals), fetch and update |
+| `lib/api/facturas.ts` | Invoice CRUD, linking, and the scoring used to reconcile invoices against movements |
+| `lib/api/avisos.ts` | Notices and tasks, including the email notification |
+| `lib/api/archivos.ts` | Base64 upload to Storage + registration, signed URLs, deletion |
+| `lib/api/resumen.ts` | Per-delegation financial rollup |
+| `lib/api/errors.ts` | `ApiError` with HTTP status; unexpected errors are logged in full and truncated to one line in the response |
+| `lib/api/route-helpers.ts` | `conApi()` wrapper: auth + query parsing + `{ ok: true, ... }` shape |
+| `lib/mcp/tools.ts` | The 27 MCP tools, each a thin wrapper over `lib/api/` |
+
+Conventions worth keeping:
+
+- **Never write through the aggregation RPCs** (`get_financial_summary`,
+  `get_saldos_por_cuenta`…): they call `assert_delegacion_member`, which checks
+  `auth.uid()` and therefore always fails for the service role. Aggregate in JS
+  (paged, ordered by `id` so pages don't overlap) as `lib/api/resumen.ts` does.
+- **Client-only modules stay out**: `lib/services/database.ts` and
+  `file-service.ts` are `"use client"`. Server equivalents live in `lib/api/`.
+- **Paged aggregation must order by a unique column.** Ordering by `fecha`
+  makes rows repeat or vanish across pages and the totals come out wrong.
+- **Error messages are read by models too.** Say what is missing and put the
+  valid values or the candidates in `detalles` so the caller can self-correct.
+- API-uploaded files cap at 3 MB (Vercel's ~4.5 MB request body, +33% for
+  base64); the app's own limit is still 20 MB.
+
+Docs: `docs/manual/21.-api-externa-solo-pros.md`,
+`docs/manual/22.-servidor-mcp.md`, `docs/API_PRUEBA_RAPIDA.md`.
 
 ## Styling Conventions
 

--- a/app/api/avisos/notificar/route.ts
+++ b/app/api/avisos/notificar/route.ts
@@ -1,17 +1,16 @@
 import { NextResponse } from "next/server"
 import { createClient } from "@/lib/supabase/server"
 import { createAdminClient } from "@/lib/supabase/admin"
-import { AVISO_DESTINATARIO_LABELS } from "@/lib/types/avisos"
-import type { AvisoDestinatario, AvisoTipo } from "@/lib/types/avisos"
+import { enviarNotificacionAviso } from "@/lib/services/aviso-notificaciones"
+import { toErrorPayload } from "@/lib/api/errors"
 
 const ROLES_ESCRITURA = ["tesorero", "gestor_central"]
-const REMITENTE = "MCM Bank <no-reply@movimientoconsolacion.com>"
 
 /**
- * Envía por correo (Resend) un aviso o tarea a quien corresponda:
- *   - destinatario "delegacion"      → tesoreros de esa delegación
- *   - destinatario "oficina_tecnica" → gestores centrales
- * Nunca se envía al propio autor. El aviso queda marcado con notificado_en.
+ * Envía por correo un aviso o tarea a quien corresponda. Esta ruta solo se
+ * ocupa de la autorización del usuario con sesión; el "a quién" y el contenido
+ * del correo viven en `lib/services/aviso-notificaciones.ts`, compartidos con
+ * la API externa y el servidor MCP.
  */
 export async function POST(req: Request) {
   let body: any
@@ -74,216 +73,13 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "Acceso restringido" }, { status: 403 })
   }
 
-  const resendApiKey = process.env.RESEND_API_KEY
-  if (!resendApiKey) {
-    console.error("Falta RESEND_API_KEY: no se puede notificar el aviso.")
-    return NextResponse.json(
-      { error: "El servicio de correo no está configurado. El aviso se ha guardado igualmente." },
-      { status: 503 },
-    )
-  }
-
-  const destinatario = aviso.destinatario as AvisoDestinatario
-  const admin = createAdminClient()
-
-  // Destinatarios: tesoreros de la delegación, o toda la oficina técnica.
-  let membresiasQuery = (admin as any).from("membresia").select("usuario_id, rol")
-  membresiasQuery =
-    destinatario === "delegacion"
-      ? membresiasQuery.eq("delegacion_id", aviso.delegacion_id).eq("rol", "tesorero")
-      : membresiasQuery.eq("rol", "gestor_central")
-
-  const { data: destinatarios, error: destError } = await membresiasQuery
-  if (destError) {
-    console.error("Error resolviendo destinatarios del aviso:", destError)
-    return NextResponse.json({ error: "No se pudieron resolver los destinatarios" }, { status: 500 })
-  }
-
-  const idsDestino = Array.from(
-    new Set<string>((destinatarios ?? []).map((m: any) => String(m.usuario_id))),
-  ).filter((id) => id !== user.id)
-
-  if (idsDestino.length === 0) {
-    return NextResponse.json(
-      {
-        error:
-          destinatario === "delegacion"
-            ? "Esta delegación no tiene ningún tesorero al que avisar."
-            : "No hay nadie en la oficina técnica a quien avisar.",
-      },
-      { status: 409 },
-    )
-  }
-
-  // Emails y nombres
-  const { data: usuarios, error: usuariosError } = await admin.auth.admin.listUsers({ perPage: 1000 })
-  if (usuariosError) {
-    console.error("Error listando usuarios para notificar:", usuariosError)
-    return NextResponse.json({ error: "No se pudieron obtener los correos" }, { status: 500 })
-  }
-
-  const emailPorId = new Map<string, string>()
-  for (const u of usuarios?.users ?? []) {
-    if (u.email) emailPorId.set(u.id, u.email)
-  }
-
-  const emails = idsDestino.map((id) => emailPorId.get(id)).filter(Boolean) as string[]
-  if (emails.length === 0) {
-    return NextResponse.json({ error: "Los destinatarios no tienen correo configurado" }, { status: 409 })
-  }
-
-  const [{ data: delegacion }, { data: perfilAutor }] = await Promise.all([
-    (admin as any).from("delegacion").select("nombre").eq("id", aviso.delegacion_id).maybeSingle(),
-    (admin as any).from("perfil").select("nombre_completo").eq("usuario_id", aviso.creado_por).maybeSingle(),
-  ])
-
-  const autor = perfilAutor?.nombre_completo?.trim() || emailPorId.get(aviso.creado_por) || "Alguien"
-  const delegacionNombre = delegacion?.nombre || "MCM"
-  const tipo = aviso.tipo as AvisoTipo
-  const contenido = String(aviso.contenido ?? "")
-  const referencia = aviso.referencia ? String(aviso.referencia) : null
-
-  const asunto = `${tipo === "tarea" ? "Nueva tarea" : "Aviso"} · ${delegacionNombre} — ${resumen(contenido)}`
-  const enlace = (process.env.NEXT_PUBLIC_SITE_URL || "https://banco.movimientoconsolacion.com").replace(/\/$/, "")
-
-  const html = renderEmail({
-    tipo,
-    contenido,
-    referencia,
-    autor,
-    delegacionNombre,
-    destinatario,
-    enlace,
-  })
-
   try {
-    const response = await fetch("https://api.resend.com/emails", {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${resendApiKey}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        from: REMITENTE,
-        to: emails,
-        subject: asunto,
-        html,
-        text: renderTexto({ tipo, contenido, referencia, autor, delegacionNombre, enlace }),
-        ...(emailPorId.get(aviso.creado_por) ? { reply_to: [emailPorId.get(aviso.creado_por)] } : {}),
-      }),
+    const { destinatarios } = await enviarNotificacionAviso(createAdminClient(), aviso, {
+      marcarNotificadoPor: user.id,
     })
-
-    if (!response.ok) {
-      const detalle = await response.text()
-      console.error("Resend rechazó la notificación del aviso:", detalle)
-      return NextResponse.json({ error: "El correo no se pudo enviar" }, { status: 502 })
-    }
-  } catch (err: any) {
-    console.error("Error enviando la notificación del aviso:", err?.message || err)
-    return NextResponse.json({ error: "El correo no se pudo enviar" }, { status: 502 })
+    return NextResponse.json({ ok: true, destinatarios })
+  } catch (err) {
+    const { status, body: payload } = toErrorPayload(err)
+    return NextResponse.json({ error: payload.error }, { status })
   }
-
-  const { error: updateError } = await (supabase as any)
-    .from("aviso")
-    .update({ notificado_en: new Date().toISOString(), notificado_por: user.id })
-    .eq("id", aviso.id)
-
-  if (updateError) {
-    // El correo ya salió: no hacemos fallar la petición por el sello.
-    console.warn("Aviso notificado pero no se pudo sellar notificado_en:", updateError)
-  }
-
-  return NextResponse.json({ ok: true, destinatarios: emails })
-}
-
-function resumen(texto: string, max = 70): string {
-  const limpio = texto.replace(/\s+/g, " ").trim()
-  return limpio.length > max ? `${limpio.slice(0, max - 1)}…` : limpio
-}
-
-function escapeHtml(texto: string): string {
-  return texto
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;")
-}
-
-interface EmailData {
-  tipo: AvisoTipo
-  contenido: string
-  referencia: string | null
-  autor: string
-  delegacionNombre: string
-  destinatario: AvisoDestinatario
-  enlace: string
-}
-
-function renderEmail({ tipo, contenido, referencia, autor, delegacionNombre, destinatario, enlace }: EmailData) {
-  const esTarea = tipo === "tarea"
-  const etiqueta = esTarea ? "Tarea pendiente" : "Nota informativa"
-  const acento = esTarea ? "#b45309" : "#2563eb"
-  const acentoFondo = esTarea ? "#fffbeb" : "#eff6ff"
-
-  return `<!doctype html>
-<html lang="es">
-  <body style="margin:0;padding:32px 16px;background:#f6f7f9;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;color:#111827;">
-    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:520px;margin:0 auto;">
-      <tr>
-        <td style="background:#ffffff;border:1px solid #e5e7eb;border-radius:16px;padding:28px;">
-          <p style="margin:0 0 18px;font-size:12px;font-weight:600;letter-spacing:.04em;text-transform:uppercase;color:${acento};">
-            ${etiqueta}
-          </p>
-          <p style="margin:0 0 20px;font-size:17px;line-height:1.55;color:#111827;white-space:pre-wrap;">${escapeHtml(contenido)}</p>
-          ${
-            referencia
-              ? `<p style="margin:0 0 20px;"><span style="display:inline-block;background:${acentoFondo};color:${acento};border-radius:999px;padding:5px 12px;font-size:13px;">${escapeHtml(referencia)}</span></p>`
-              : ""
-          }
-          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border-top:1px solid #f3f4f6;margin-top:4px;">
-            <tr>
-              <td style="padding-top:16px;font-size:13px;line-height:1.6;color:#6b7280;">
-                <strong style="color:#374151;">${escapeHtml(autor)}</strong> lo ha anotado en
-                <strong style="color:#374151;">${escapeHtml(delegacionNombre)}</strong><br />
-                Dirigido a: ${escapeHtml(AVISO_DESTINATARIO_LABELS[destinatario])}
-              </td>
-            </tr>
-          </table>
-          <p style="margin:24px 0 0;">
-            <a href="${enlace}" style="display:inline-block;background:#2563eb;color:#ffffff;text-decoration:none;font-size:14px;font-weight:600;padding:11px 20px;border-radius:10px;">
-              Abrir en MCM Bank
-            </a>
-          </p>
-        </td>
-      </tr>
-      <tr>
-        <td style="padding:16px 4px 0;text-align:center;font-size:12px;color:#9ca3af;">
-          Avisos y tareas de MCM Bank · no respondas a este correo si no hace falta
-        </td>
-      </tr>
-    </table>
-  </body>
-</html>`
-}
-
-function renderTexto({
-  tipo,
-  contenido,
-  referencia,
-  autor,
-  delegacionNombre,
-  enlace,
-}: Omit<EmailData, "destinatario">) {
-  return [
-    tipo === "tarea" ? "TAREA PENDIENTE" : "NOTA INFORMATIVA",
-    "",
-    contenido,
-    referencia ? `\nReferencia: ${referencia}` : "",
-    "",
-    `${autor} · ${delegacionNombre}`,
-    enlace,
-  ]
-    .filter((linea) => linea !== "")
-    .join("\n")
 }

--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -1,0 +1,115 @@
+import { NextResponse } from "next/server"
+import { verifyApiKey } from "@/lib/api/external-auth"
+import { JSONRPC_ERRORES, fallo, type JsonRpcRequest } from "@/lib/mcp/protocol"
+import { procesarMensaje, SERVIDOR } from "@/lib/mcp/server"
+
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+
+/**
+ * Servidor MCP de MCM Bank (transporte Streamable HTTP, sin estado).
+ *
+ *   POST /api/mcp   →  mensajes JSON-RPC del protocolo MCP
+ *
+ * Autenticación: la misma clave que la API externa, en `Authorization: Bearer`
+ * o en `x-api-key`. Una clave de solo lectura puede consultar pero no escribir.
+ *
+ * Autoría de las escrituras: se puede fijar por conexión con las cabeceras
+ * `x-mcm-usuario-email` o `x-mcm-usuario-id`, o por llamada con el argumento
+ * `usuario_email` de cada herramienta. Si no llega ninguna, se usa la cuenta
+ * configurada en el servidor (`MCM_API_USER_EMAIL` / `MCM_API_USER_ID`).
+ *
+ * Para conectarlo desde Claude Code:
+ *   claude mcp add --transport http mcm-bank https://TU-DOMINIO/api/mcp \
+ *     --header "Authorization: Bearer TU_CLAVE"
+ */
+
+const CABECERAS_CORS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "POST, GET, DELETE, OPTIONS",
+  "Access-Control-Allow-Headers":
+    "Content-Type, Authorization, x-api-key, mcp-session-id, mcp-protocol-version, x-mcm-usuario-email, x-mcm-usuario-id",
+  "Access-Control-Expose-Headers": "mcp-session-id, mcp-protocol-version",
+  "Access-Control-Max-Age": "86400",
+}
+
+export async function OPTIONS() {
+  return new Response(null, { status: 204, headers: CABECERAS_CORS })
+}
+
+export async function POST(request: Request) {
+  const auth = verifyApiKey(request)
+  if (!auth.ok) {
+    return NextResponse.json(
+      fallo(null, JSONRPC_ERRORES.INVALID_REQUEST, auth.error),
+      {
+        status: auth.status,
+        headers: {
+          ...CABECERAS_CORS,
+          ...(auth.status === 401 ? { "WWW-Authenticate": 'Bearer realm="MCM Bank MCP"' } : {}),
+        },
+      },
+    )
+  }
+
+  let cuerpo: unknown
+  try {
+    cuerpo = await request.json()
+  } catch {
+    return NextResponse.json(
+      fallo(null, JSONRPC_ERRORES.PARSE_ERROR, "El cuerpo de la petición no es JSON válido."),
+      { status: 400, headers: CABECERAS_CORS },
+    )
+  }
+
+  const url = new URL(request.url)
+  const opciones = {
+    scope: auth.scope,
+    baseUrl: `${url.protocol}//${url.host}`,
+    actorHint: {
+      usuario_email: request.headers.get("x-mcm-usuario-email"),
+      usuario_id: request.headers.get("x-mcm-usuario-id"),
+    },
+  }
+
+  // Los lotes desaparecieron de la especificación en 2025-06-18, pero clientes
+  // antiguos los siguen enviando y cuestan cuatro líneas de soporte.
+  const mensajes = Array.isArray(cuerpo) ? cuerpo : [cuerpo]
+  const respuestas = []
+  for (const mensaje of mensajes) {
+    const respuesta = await procesarMensaje(mensaje as JsonRpcRequest, opciones)
+    if (respuesta) respuestas.push(respuesta)
+  }
+
+  // Solo había notificaciones: el protocolo pide 202 sin cuerpo.
+  if (respuestas.length === 0) {
+    return new Response(null, { status: 202, headers: CABECERAS_CORS })
+  }
+
+  const payload = Array.isArray(cuerpo) ? respuestas : respuestas[0]
+  return NextResponse.json(payload, {
+    headers: { ...CABECERAS_CORS, "mcp-protocol-version": "2025-06-18" },
+  })
+}
+
+/**
+ * El transporte Streamable HTTP usa GET para abrir un canal SSE en el que el
+ * servidor empuja mensajes por su cuenta. Este servidor solo responde a lo que
+ * se le pregunta, así que no lo necesita: se responde 405, que es justo lo que
+ * la especificación dice que haga un servidor sin ese canal.
+ */
+export async function GET() {
+  return NextResponse.json(
+    fallo(
+      null,
+      JSONRPC_ERRORES.METHOD_NOT_FOUND,
+      `${SERVIDOR.title} no ofrece canal SSE: envía los mensajes JSON-RPC por POST a esta misma URL.`,
+    ),
+    { status: 405, headers: { ...CABECERAS_CORS, Allow: "POST, OPTIONS" } },
+  )
+}
+
+/** Cierre de sesión: este servidor no guarda ninguna, así que siempre va bien. */
+export async function DELETE() {
+  return new Response(null, { status: 204, headers: CABECERAS_CORS })
+}

--- a/app/api/v1/archivos/[id]/descargar/route.ts
+++ b/app/api/v1/archivos/[id]/descargar/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server"
+import { createAdminClient } from "@/lib/supabase/admin"
+import { verifyApiKey } from "@/lib/api/external-auth"
+import { errorResponse } from "@/lib/api/errors"
+import { localizarArchivo, urlFirmada } from "@/lib/api/archivos"
+
+export const runtime = "nodejs"
+
+/**
+ * GET /api/v1/archivos/{id}/descargar
+ *
+ * Redirige (302) a una URL firmada del fichero. Es la URL que aparece como
+ * `url_descarga` en los adjuntos: se puede abrir en el navegador o pasar a
+ * `curl -L`, y a diferencia de la firmada no caduca en la propia respuesta
+ * —cada visita genera una nueva—.
+ *
+ * La clave de API va en la cabecera, igual que en el resto de la API.
+ */
+export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const auth = verifyApiKey(request, "read")
+  if (!auth.ok) {
+    return NextResponse.json({ ok: false, error: auth.error }, { status: auth.status })
+  }
+
+  try {
+    const { id } = await params
+    const admin = createAdminClient()
+    const { fila } = await localizarArchivo(admin, id)
+    const url = await urlFirmada(admin, fila.bucket, fila.path_storage, 300)
+    return NextResponse.redirect(url, 302)
+  } catch (err) {
+    return errorResponse(err)
+  }
+}

--- a/app/api/v1/archivos/[id]/route.ts
+++ b/app/api/v1/archivos/[id]/route.ts
@@ -1,0 +1,30 @@
+import { createAdminClient } from "@/lib/supabase/admin"
+import { eliminarArchivo, localizarArchivo } from "@/lib/api/archivos"
+import { serializeArchivo } from "@/lib/api/movimientos-public"
+import { conApi } from "@/lib/api/route-helpers"
+
+export const runtime = "nodejs"
+
+/** GET /api/v1/archivos/{id} — metadatos del archivo y a qué está asociado. */
+export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  return conApi(request, "read", async ({ baseUrl }) => {
+    const { id } = await params
+    const { fila, origen } = await localizarArchivo(createAdminClient(), id)
+    return {
+      archivo: serializeArchivo(fila, { baseUrl }),
+      asociado_a:
+        origen === "movimiento"
+          ? { tipo: "movimiento", id: fila.movimiento_id }
+          : { tipo: fila.entidad, id: fila.entidad_id },
+    }
+  })
+}
+
+/** DELETE /api/v1/archivos/{id} — borra el registro y el fichero. Irreversible. */
+export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  return conApi(request, "write", async () => {
+    const { id } = await params
+    await eliminarArchivo(createAdminClient(), id)
+    return { eliminado: true, id }
+  })
+}

--- a/app/api/v1/archivos/[id]/url/route.ts
+++ b/app/api/v1/archivos/[id]/url/route.ts
@@ -1,0 +1,30 @@
+import { createAdminClient } from "@/lib/supabase/admin"
+import { localizarArchivo, urlFirmada } from "@/lib/api/archivos"
+import { conApi, qNumero } from "@/lib/api/route-helpers"
+
+export const runtime = "nodejs"
+
+/**
+ * GET /api/v1/archivos/{id}/url?segundos=300
+ *
+ * Devuelve una URL firmada temporal para descargar el archivo. Útil cuando
+ * quien consume la API necesita el enlace (para pasárselo a otro sistema) en
+ * vez de la descarga directa de `/descargar`.
+ */
+export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  return conApi(request, "read", async ({ params: query }) => {
+    const { id } = await params
+    const admin = createAdminClient()
+    const { fila } = await localizarArchivo(admin, id)
+
+    const segundos = Math.min(Math.max(qNumero(query, "segundos") ?? 300, 30), 3600)
+    const url = await urlFirmada(admin, fila.bucket, fila.path_storage, segundos)
+
+    return {
+      url,
+      nombre: fila.nombre_original,
+      tipo_mime: fila.tipo_mime,
+      caduca_en_segundos: segundos,
+    }
+  })
+}

--- a/app/api/v1/avisos/[id]/notificar/route.ts
+++ b/app/api/v1/avisos/[id]/notificar/route.ts
@@ -1,0 +1,23 @@
+import { createAdminClient } from "@/lib/supabase/admin"
+import { resolveActor } from "@/lib/api/actor"
+import { notificarAviso, obtenerAviso } from "@/lib/api/avisos"
+import { conApi } from "@/lib/api/route-helpers"
+
+export const runtime = "nodejs"
+
+/**
+ * POST /api/v1/avisos/{id}/notificar
+ *
+ * Envía (o reenvía) el aviso por correo: a los tesoreros de su delegación o a
+ * la oficina técnica, según a quién vaya dirigido. Nunca a su autor.
+ */
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  return conApi(request, "write", async ({ actorHint }) => {
+    const { id } = await params
+    const admin = createAdminClient()
+    const actor = await resolveActor(admin, actorHint)
+
+    const { destinatarios } = await notificarAviso(admin, id, actor.id)
+    return { aviso: await obtenerAviso(admin, id), notificados: destinatarios }
+  })
+}

--- a/app/api/v1/avisos/[id]/route.ts
+++ b/app/api/v1/avisos/[id]/route.ts
@@ -1,0 +1,56 @@
+import { createAdminClient } from "@/lib/supabase/admin"
+import { resolveActor } from "@/lib/api/actor"
+import { actualizarAviso, eliminarAviso, obtenerAviso } from "@/lib/api/avisos"
+import type { AvisoDestinatario, AvisoEstado } from "@/lib/types/avisos"
+import { conApi, cuerpoJson } from "@/lib/api/route-helpers"
+
+export const runtime = "nodejs"
+
+/** GET /api/v1/avisos/{id} */
+export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  return conApi(request, "read", async () => {
+    const { id } = await params
+    return { aviso: await obtenerAviso(createAdminClient(), id) }
+  })
+}
+
+/**
+ * PATCH /api/v1/avisos/{id}
+ *
+ * Edita el texto o cierra la tarea: `{ estado: "hecha" }` la marca como hecha
+ * y anota quién lo hizo.
+ */
+export async function PATCH(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  return conApi(request, "write", async ({ actorHint }) => {
+    const { id } = await params
+    const cuerpo = await cuerpoJson(request)
+    const admin = createAdminClient()
+
+    const actor = await resolveActor(admin, {
+      usuario_id: (cuerpo.usuario_id as string) ?? actorHint.usuario_id,
+      usuario_email: (cuerpo.usuario_email as string) ?? actorHint.usuario_email,
+    })
+
+    const aviso = await actualizarAviso(
+      admin,
+      id,
+      {
+        contenido: cuerpo.contenido as string | null,
+        referencia: "referencia" in cuerpo ? (cuerpo.referencia as string | null) : undefined,
+        destinatario: cuerpo.destinatario as AvisoDestinatario | null,
+        estado: cuerpo.estado as AvisoEstado | null,
+      },
+      actor.id,
+    )
+    return { aviso }
+  })
+}
+
+/** DELETE /api/v1/avisos/{id} — borra la nota o tarea. Irreversible. */
+export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  return conApi(request, "write", async () => {
+    const { id } = await params
+    await eliminarAviso(createAdminClient(), id)
+    return { eliminado: true, id }
+  })
+}

--- a/app/api/v1/avisos/route.ts
+++ b/app/api/v1/avisos/route.ts
@@ -1,0 +1,75 @@
+import { createAdminClient } from "@/lib/supabase/admin"
+import { resolveActor } from "@/lib/api/actor"
+import { crearAviso, listarAvisos } from "@/lib/api/avisos"
+import type { AvisoDestinatario, AvisoEstado, AvisoTipo } from "@/lib/types/avisos"
+import {
+  conApi,
+  cuerpoJson,
+  qLista,
+  qNumero,
+  qOpcion,
+  qTexto,
+} from "@/lib/api/route-helpers"
+
+export const runtime = "nodejs"
+
+/**
+ * GET /api/v1/avisos?delegaciones=Sevilla&estado=pendiente
+ *
+ * Notas y tareas del canal entre la oficina técnica y los tesoreros. Sin
+ * `delegaciones`, las de todas; sin `estado`, solo las pendientes.
+ */
+export async function GET(request: Request) {
+  return conApi(request, "read", async ({ params }) =>
+    listarAvisos(createAdminClient(), {
+      delegaciones: qLista(params, "delegaciones") ?? null,
+      estado: qOpcion(params, "estado", ["pendiente", "hecha", "todas"] as const) as
+        | AvisoEstado
+        | "todas"
+        | undefined,
+      tipo: qOpcion(params, "tipo", ["tarea", "nota"] as const) as AvisoTipo | undefined,
+      destinatario: qOpcion(params, "destinatario", [
+        "oficina_tecnica",
+        "delegacion",
+      ] as const) as AvisoDestinatario | undefined,
+      texto: qTexto(params, "texto"),
+      limite: qNumero(params, "limite"),
+    }),
+  )
+}
+
+/**
+ * POST /api/v1/avisos
+ *
+ * Deja una nota o una tarea en una delegación.
+ *
+ * Cuerpo: `{ delegacion, contenido, tipo?, destinatario?, referencia?,
+ * notificar?, usuario_email? }`. Con `notificar: true` se envía además por
+ * correo (tesoreros de la delegación o gestores centrales, según el
+ * destinatario). Si el correo falla, el aviso ya está guardado y la respuesta
+ * lo explica en `aviso_notificacion`.
+ */
+export async function POST(request: Request) {
+  return conApi(request, "write", async ({ actorHint }) => {
+    const cuerpo = await cuerpoJson(request)
+    const admin = createAdminClient()
+
+    const actor = await resolveActor(admin, {
+      usuario_id: (cuerpo.usuario_id as string) ?? actorHint.usuario_id,
+      usuario_email: (cuerpo.usuario_email as string) ?? actorHint.usuario_email,
+    })
+
+    return crearAviso(
+      admin,
+      {
+        delegacion: String(cuerpo.delegacion ?? ""),
+        contenido: String(cuerpo.contenido ?? ""),
+        tipo: cuerpo.tipo as AvisoTipo | null,
+        destinatario: cuerpo.destinatario as AvisoDestinatario | null,
+        referencia: cuerpo.referencia as string | null,
+        notificar: Boolean(cuerpo.notificar),
+      },
+      actor.id,
+    )
+  })
+}

--- a/app/api/v1/categorias/route.ts
+++ b/app/api/v1/categorias/route.ts
@@ -1,0 +1,22 @@
+import { createAdminClient } from "@/lib/supabase/admin"
+import { listCategorias } from "@/lib/api/catalogos"
+import { conApi, qBooleano, qLista } from "@/lib/api/route-helpers"
+
+export const runtime = "nodejs"
+
+/**
+ * GET /api/v1/categorias?delegaciones=Sevilla
+ *
+ * Categorías visibles para las delegaciones indicadas: las globales de MCM más
+ * las propias de cada delegación. Cuando se pide una sola delegación se aplica
+ * además su orden y visibilidad personalizados.
+ */
+export async function GET(request: Request) {
+  return conApi(request, "read", async ({ params }) => {
+    const categorias = await listCategorias(createAdminClient(), {
+      delegaciones: qLista(params, "delegaciones") ?? null,
+      incluirInactivas: qBooleano(params, "incluir_inactivas"),
+    })
+    return { total: categorias.length, categorias }
+  })
+}

--- a/app/api/v1/conciliacion/route.ts
+++ b/app/api/v1/conciliacion/route.ts
@@ -1,0 +1,93 @@
+import { NextResponse } from "next/server"
+import { createAdminClient } from "@/lib/supabase/admin"
+import { badRequest, errorResponse } from "@/lib/api/errors"
+import { resolveActor } from "@/lib/api/actor"
+import { conciliarLote, type ItemConciliacion } from "@/lib/api/facturas"
+import { verifyApiKey } from "@/lib/api/external-auth"
+
+export const runtime = "nodejs"
+
+/**
+ * POST /api/v1/conciliacion
+ *
+ * Cuadra un lote de facturas contra los movimientos bancarios: se envía una
+ * lista de importes (con fecha, proveedor o número si se conocen) y se devuelve,
+ * para cada uno, los movimientos que mejor encajan, con su puntuación y los
+ * motivos en texto.
+ *
+ * ```json
+ * {
+ *   "facturas": [
+ *     { "referencia": "linea-1", "importe": 128.40, "fecha": "2026-03-04", "proveedor": "Mercadona" }
+ *   ],
+ *   "delegaciones": ["Sevilla"],
+ *   "aplicar": false,
+ *   "crear_facturas": false
+ * }
+ * ```
+ *
+ * Por defecto solo propone (basta clave de lectura). Con `aplicar: true` —que
+ * exige clave de escritura— vincula automáticamente los casos claros (importe
+ * exacto y ventaja clara sobre el segundo candidato) y deja los dudosos para
+ * que los revise una persona.
+ */
+export async function POST(request: Request) {
+  // El permiso necesario depende del cuerpo (`aplicar`), así que primero se
+  // valida la clave para lectura —y así no se lee el cuerpo de una petición
+  // anónima— y después se exige escritura si toca.
+  const auth = verifyApiKey(request, "read")
+  if (!auth.ok) {
+    return NextResponse.json({ ok: false, error: auth.error }, { status: auth.status })
+  }
+
+  try {
+    const cuerpo = await request.json().catch(() => null)
+    if (!cuerpo || typeof cuerpo !== "object" || Array.isArray(cuerpo)) {
+      throw badRequest("El cuerpo de la petición debe ser un objeto JSON.")
+    }
+
+    const datos = cuerpo as Record<string, unknown>
+    const aplicar = Boolean(datos.aplicar)
+
+    if (aplicar && auth.scope !== "write") {
+      return NextResponse.json(
+        {
+          ok: false,
+          error:
+            "'aplicar: true' modifica datos y tu clave es de solo lectura. Llama sin 'aplicar' para ver las propuestas.",
+        },
+        { status: 403 },
+      )
+    }
+
+    if (!Array.isArray(datos.facturas)) {
+      throw badRequest("Falta la lista 'facturas'.")
+    }
+
+    const admin = createAdminClient()
+    const actor = aplicar
+      ? await resolveActor(admin, {
+          usuario_id: (datos.usuario_id as string) ?? request.headers.get("x-mcm-usuario-id"),
+          usuario_email:
+            (datos.usuario_email as string) ?? request.headers.get("x-mcm-usuario-email"),
+        })
+      : null
+
+    const resultado = await conciliarLote(
+      admin,
+      {
+        items: datos.facturas as ItemConciliacion[],
+        delegaciones: (datos.delegaciones as string[] | string | null) ?? null,
+        ventanaDias: datos.ventana_dias as number | undefined,
+        maxCandidatos: datos.max_candidatos as number | undefined,
+        aplicar,
+        crearFacturas: Boolean(datos.crear_facturas),
+      },
+      actor?.id ?? null,
+    )
+
+    return NextResponse.json({ ok: true, ...resultado })
+  } catch (err) {
+    return errorResponse(err)
+  }
+}

--- a/app/api/v1/contactos/route.ts
+++ b/app/api/v1/contactos/route.ts
@@ -1,0 +1,22 @@
+import { createAdminClient } from "@/lib/supabase/admin"
+import { listContactos } from "@/lib/api/catalogos"
+import { conApi, qBooleano, qLista, qTexto } from "@/lib/api/route-helpers"
+
+export const runtime = "nodejs"
+
+/**
+ * GET /api/v1/contactos?delegaciones=Sevilla&texto=merca
+ *
+ * Proveedores y personas. Solo lectura: el alta se hace desde la aplicación.
+ */
+export async function GET(request: Request) {
+  return conApi(request, "read", async ({ params }) => {
+    const contactos = await listContactos(createAdminClient(), {
+      delegaciones: qLista(params, "delegaciones") ?? null,
+      texto: qTexto(params, "texto"),
+      tipos: qLista(params, "tipos"),
+      incluirArchivados: qBooleano(params, "incluir_archivados"),
+    })
+    return { total: contactos.length, contactos }
+  })
+}

--- a/app/api/v1/cuentas/route.ts
+++ b/app/api/v1/cuentas/route.ts
@@ -1,0 +1,20 @@
+import { createAdminClient } from "@/lib/supabase/admin"
+import { listCuentas } from "@/lib/api/catalogos"
+import { conApi, qBooleano, qLista } from "@/lib/api/route-helpers"
+
+export const runtime = "nodejs"
+
+/**
+ * GET /api/v1/cuentas?delegaciones=Sevilla&incluir_inactivas=true
+ *
+ * Cuentas bancarias y cajas. Sin `delegaciones`, las de todas.
+ */
+export async function GET(request: Request) {
+  return conApi(request, "read", async ({ params }) => {
+    const cuentas = await listCuentas(createAdminClient(), {
+      delegaciones: qLista(params, "delegaciones") ?? null,
+      incluirInactivas: qBooleano(params, "incluir_inactivas"),
+    })
+    return { total: cuentas.length, cuentas }
+  })
+}

--- a/app/api/v1/delegaciones/route.ts
+++ b/app/api/v1/delegaciones/route.ts
@@ -1,0 +1,18 @@
+import { createAdminClient } from "@/lib/supabase/admin"
+import { listDelegaciones } from "@/lib/api/delegaciones"
+import { conApi } from "@/lib/api/route-helpers"
+
+export const runtime = "nodejs"
+
+/**
+ * GET /api/v1/delegaciones
+ *
+ * Todas las delegaciones con su id, código y nombre. Es el punto de partida
+ * para cualquier integración que trabaje sobre varias delegaciones.
+ */
+export async function GET(request: Request) {
+  return conApi(request, "read", async () => {
+    const delegaciones = await listDelegaciones(createAdminClient())
+    return { total: delegaciones.length, delegaciones }
+  })
+}

--- a/app/api/v1/facturas/[id]/archivos/route.ts
+++ b/app/api/v1/facturas/[id]/archivos/route.ts
@@ -1,0 +1,49 @@
+import { createAdminClient } from "@/lib/supabase/admin"
+import { resolveActor } from "@/lib/api/actor"
+import { listarArchivosFactura, subirArchivoAFactura } from "@/lib/api/archivos"
+import { conApi, cuerpoJson } from "@/lib/api/route-helpers"
+
+export const runtime = "nodejs"
+
+/** GET /api/v1/facturas/{id}/archivos — archivos de la factura. */
+export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  return conApi(request, "read", async ({ baseUrl }) => {
+    const { id } = await params
+    const archivos = await listarArchivosFactura(createAdminClient(), id, { baseUrl })
+    return { factura_id: id, total: archivos.length, archivos }
+  })
+}
+
+/**
+ * POST /api/v1/facturas/{id}/archivos
+ *
+ * Adjunta un archivo a la factura. Si la factura ya está conciliada, el archivo
+ * se replica en sus movimientos para que se vea desde ambos lados.
+ *
+ * Cuerpo: `{ nombre, contenido_base64, tipo_mime?, descripcion?, bucket? }`
+ */
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  return conApi(request, "write", async ({ baseUrl, actorHint }) => {
+    const { id } = await params
+    const cuerpo = await cuerpoJson(request)
+    const admin = createAdminClient()
+
+    const actor = await resolveActor(admin, {
+      usuario_id: (cuerpo.usuario_id as string) ?? actorHint.usuario_id,
+      usuario_email: (cuerpo.usuario_email as string) ?? actorHint.usuario_email,
+    })
+
+    return subirArchivoAFactura(admin, {
+      facturaId: id,
+      archivo: {
+        nombre: String(cuerpo.nombre ?? ""),
+        contenido_base64: String(cuerpo.contenido_base64 ?? ""),
+        tipo_mime: (cuerpo.tipo_mime as string) ?? null,
+        descripcion: (cuerpo.descripcion as string) ?? null,
+        bucket: (cuerpo.bucket as "facturas" | "documentos") ?? null,
+      },
+      actorId: actor.id,
+      baseUrl,
+    })
+  })
+}

--- a/app/api/v1/facturas/[id]/route.ts
+++ b/app/api/v1/facturas/[id]/route.ts
@@ -1,0 +1,55 @@
+import { createAdminClient } from "@/lib/supabase/admin"
+import {
+  actualizarFactura,
+  eliminarFactura,
+  obtenerFactura,
+  type FacturaEstadoApi,
+} from "@/lib/api/facturas"
+import { conApi, cuerpoJson } from "@/lib/api/route-helpers"
+
+export const runtime = "nodejs"
+
+/** GET /api/v1/facturas/{id} — factura con sus movimientos y archivos. */
+export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  return conApi(request, "read", async ({ baseUrl }) => {
+    const { id } = await params
+    return { factura: await obtenerFactura(createAdminClient(), id, { baseUrl }) }
+  })
+}
+
+/** PATCH /api/v1/facturas/{id} — corrige número, concepto, importe, fecha, estado… */
+export async function PATCH(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  return conApi(request, "write", async ({ baseUrl }) => {
+    const { id } = await params
+    const cuerpo = await cuerpoJson(request)
+    const factura = await actualizarFactura(
+      createAdminClient(),
+      id,
+      {
+        numero: cuerpo.numero as string | null,
+        concepto: cuerpo.concepto as string | null,
+        importe: cuerpo.importe as number | null,
+        fecha_emision: cuerpo.fecha_emision as string | null,
+        estado: cuerpo.estado as FacturaEstadoApi | null,
+        notas: cuerpo.notas as string | null,
+        contacto_id: cuerpo.contacto_id as string | null,
+      },
+      { baseUrl },
+    )
+    return { factura }
+  })
+}
+
+/**
+ * DELETE /api/v1/facturas/{id}
+ *
+ * Borra la factura y sus archivos, y desvincula los movimientos que tuviera
+ * (los movimientos no se tocan). Irreversible.
+ */
+export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  return conApi(request, "write", async () => {
+    const { id } = await params
+    await eliminarFactura(createAdminClient(), id)
+    return { eliminada: true, id }
+  })
+}

--- a/app/api/v1/facturas/[id]/vincular/route.ts
+++ b/app/api/v1/facturas/[id]/vincular/route.ts
@@ -1,0 +1,55 @@
+import { createAdminClient } from "@/lib/supabase/admin"
+import { badRequest } from "@/lib/api/errors"
+import { resolveActor } from "@/lib/api/actor"
+import {
+  desvincularFacturaDeMovimiento,
+  obtenerFactura,
+  vincularFacturaAMovimiento,
+} from "@/lib/api/facturas"
+import { conApi, cuerpoJson, qTexto } from "@/lib/api/route-helpers"
+
+export const runtime = "nodejs"
+
+/**
+ * POST /api/v1/facturas/{id}/vincular
+ *
+ * Concilia la factura con un movimiento bancario (`{ movimiento_id }`). Una
+ * factura admite varios movimientos (pago en plazos); un movimiento, como mucho
+ * una factura. El estado de la factura lo recalcula la base de datos.
+ */
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  return conApi(request, "write", async ({ baseUrl, actorHint }) => {
+    const { id } = await params
+    const cuerpo = await cuerpoJson(request)
+    const movimientoId = cuerpo.movimiento_id
+    if (typeof movimientoId !== "string" || !movimientoId) {
+      throw badRequest("Falta 'movimiento_id'.")
+    }
+
+    const admin = createAdminClient()
+    const actor = await resolveActor(admin, {
+      usuario_id: (cuerpo.usuario_id as string) ?? actorHint.usuario_id,
+      usuario_email: (cuerpo.usuario_email as string) ?? actorHint.usuario_email,
+    })
+
+    await vincularFacturaAMovimiento(admin, id, movimientoId, actor.id)
+    return { factura: await obtenerFactura(admin, id, { baseUrl }) }
+  })
+}
+
+/**
+ * DELETE /api/v1/facturas/{id}/vincular?movimiento_id=...
+ *
+ * Deshace el vínculo con un movimiento concreto.
+ */
+export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  return conApi(request, "write", async ({ baseUrl, params: query }) => {
+    const { id } = await params
+    const movimientoId = qTexto(query, "movimiento_id")
+    if (!movimientoId) throw badRequest("Falta 'movimiento_id' en la query.")
+
+    const admin = createAdminClient()
+    await desvincularFacturaDeMovimiento(admin, id, movimientoId)
+    return { factura: await obtenerFactura(admin, id, { baseUrl }) }
+  })
+}

--- a/app/api/v1/facturas/route.ts
+++ b/app/api/v1/facturas/route.ts
@@ -1,0 +1,79 @@
+import { createAdminClient } from "@/lib/supabase/admin"
+import { resolveActor } from "@/lib/api/actor"
+import { buscarFacturas, crearFactura, type FacturaEstadoApi } from "@/lib/api/facturas"
+import {
+  conApi,
+  cuerpoJson,
+  qBooleano,
+  qLista,
+  qNumero,
+  qTexto,
+} from "@/lib/api/route-helpers"
+
+export const runtime = "nodejs"
+
+/**
+ * GET /api/v1/facturas
+ *
+ * Bandeja de facturas de una, varias o todas las delegaciones. Cada factura
+ * trae cuánto lleva pagado, cuánto le queda y sus archivos.
+ */
+export async function GET(request: Request) {
+  return conApi(request, "read", async ({ params, baseUrl }) =>
+    buscarFacturas(createAdminClient(), {
+      delegaciones: qLista(params, "delegaciones") ?? null,
+      estados: qLista(params, "estados"),
+      texto: qTexto(params, "texto"),
+      numero: qTexto(params, "numero"),
+      importeMin: qNumero(params, "importe_min"),
+      importeMax: qNumero(params, "importe_max"),
+      fechaDesde: qTexto(params, "fecha_desde"),
+      fechaHasta: qTexto(params, "fecha_hasta"),
+      contactoIds: qLista(params, "contactos"),
+      sinConciliar: qBooleano(params, "sin_conciliar"),
+      limite: qNumero(params, "limite"),
+      offset: qNumero(params, "offset"),
+      baseUrl,
+    }),
+  )
+}
+
+/**
+ * POST /api/v1/facturas
+ *
+ * Registra una factura en la bandeja de una delegación. Admite subir el
+ * archivo en la misma llamada (`archivo: { nombre, contenido_base64 }`) y
+ * conciliarla con un movimiento (`movimiento_id`).
+ */
+export async function POST(request: Request) {
+  return conApi(request, "write", async ({ baseUrl, actorHint }) => {
+    const cuerpo = await cuerpoJson(request)
+    const admin = createAdminClient()
+
+    const actor = await resolveActor(admin, {
+      usuario_id: (cuerpo.usuario_id as string) ?? actorHint.usuario_id,
+      usuario_email: (cuerpo.usuario_email as string) ?? actorHint.usuario_email,
+    })
+
+    const factura = await crearFactura(
+      admin,
+      {
+        delegacion: String(cuerpo.delegacion ?? ""),
+        numero: cuerpo.numero as string | null,
+        concepto: cuerpo.concepto as string | null,
+        importe: cuerpo.importe as number | null,
+        fecha_emision: cuerpo.fecha_emision as string | null,
+        moneda: cuerpo.moneda as string | null,
+        estado: cuerpo.estado as FacturaEstadoApi | null,
+        notas: cuerpo.notas as string | null,
+        contacto_id: cuerpo.contacto_id as string | null,
+        movimiento_id: cuerpo.movimiento_id as string | null,
+        archivo: (cuerpo.archivo as any) ?? null,
+      },
+      actor.id,
+      { baseUrl },
+    )
+
+    return { factura }
+  })
+}

--- a/app/api/v1/movimientos/[id]/archivos/route.ts
+++ b/app/api/v1/movimientos/[id]/archivos/route.ts
@@ -1,63 +1,71 @@
-import { NextResponse } from "next/server"
 import { createAdminClient } from "@/lib/supabase/admin"
-import { verifyApiKey } from "@/lib/api/external-auth"
+import { notFound } from "@/lib/api/errors"
+import { resolveActor } from "@/lib/api/actor"
+import { subirArchivoAMovimiento } from "@/lib/api/archivos"
 import {
-  getMovimientoRaw,
   getArchivosRaw,
+  getMovimientoRaw,
   serializeArchivo,
 } from "@/lib/api/movimientos-public"
+import { conApi, cuerpoJson } from "@/lib/api/route-helpers"
 
 export const runtime = "nodejs"
 
 /**
  * GET /api/v1/movimientos/{id}/archivos
  *
- * API externa: devuelve únicamente los archivos adjuntos de un movimiento, con
- * su URL pública de descarga. Pensado para flujos que solo necesitan los
- * ficheros (p.ej. descargar facturas desde Google Apps Script).
- *
- * Autenticación: cabecera `Authorization: Bearer <clave>` o `x-api-key: <clave>`.
+ * Solo los archivos adjuntos de un movimiento. Cada uno trae `url_descarga`,
+ * un endpoint autenticado que redirige a una URL firmada; `url` es la URL
+ * pública heredada y está vacía en los archivos subidos recientemente.
  */
-export async function GET(
-  request: Request,
-  { params }: { params: Promise<{ id: string }> },
-) {
-  const auth = verifyApiKey(request)
-  if (!auth.ok) {
-    return NextResponse.json({ ok: false, error: auth.error }, { status: auth.status })
-  }
-
-  const { id } = await params
-  if (!id) {
-    return NextResponse.json({ ok: false, error: "Falta el ID del movimiento." }, { status: 400 })
-  }
-
-  try {
+export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  return conApi(request, "read", async ({ baseUrl }) => {
+    const { id } = await params
     const admin = createAdminClient()
 
-    // Verificamos que el movimiento exista para distinguir "sin archivos" de
+    // Se comprueba que el movimiento exista para distinguir "sin archivos" de
     // "movimiento inexistente".
     const movimiento = await getMovimientoRaw(admin, id)
-    if (!movimiento) {
-      return NextResponse.json(
-        { ok: false, error: "Movimiento no encontrado." },
-        { status: 404 },
-      )
-    }
+    if (!movimiento) throw notFound("Movimiento no encontrado.")
 
-    const archivosRaw = await getArchivosRaw(admin, id)
-    const archivos = archivosRaw.map(serializeArchivo)
+    const archivos = (await getArchivosRaw(admin, id)).map((a) => serializeArchivo(a, { baseUrl }))
+    return { movimiento_id: id, total: archivos.length, archivos }
+  })
+}
 
-    return NextResponse.json({
-      ok: true,
-      movimiento_id: id,
-      total: archivos.length,
-      archivos,
+/**
+ * POST /api/v1/movimientos/{id}/archivos
+ *
+ * Adjunta un archivo (en base64) al movimiento. Si va al bucket `facturas`
+ * —el predeterminado— también se registra en la sección Facturas ya conciliado
+ * con este movimiento, igual que al subirlo desde la aplicación.
+ *
+ * Cuerpo: `{ nombre, contenido_base64, tipo_mime?, descripcion?, bucket?,
+ * crear_factura?, usuario_email? }`
+ */
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  return conApi(request, "write", async ({ baseUrl, actorHint }) => {
+    const { id } = await params
+    const cuerpo = await cuerpoJson(request)
+    const admin = createAdminClient()
+
+    const actor = await resolveActor(admin, {
+      usuario_id: (cuerpo.usuario_id as string) ?? actorHint.usuario_id,
+      usuario_email: (cuerpo.usuario_email as string) ?? actorHint.usuario_email,
     })
-  } catch (err) {
-    return NextResponse.json(
-      { ok: false, error: err instanceof Error ? err.message : String(err) },
-      { status: 500 },
-    )
-  }
+
+    return subirArchivoAMovimiento(admin, {
+      movimientoId: id,
+      archivo: {
+        nombre: String(cuerpo.nombre ?? ""),
+        contenido_base64: String(cuerpo.contenido_base64 ?? ""),
+        tipo_mime: (cuerpo.tipo_mime as string) ?? null,
+        descripcion: (cuerpo.descripcion as string) ?? null,
+        bucket: (cuerpo.bucket as "facturas" | "documentos") ?? null,
+      },
+      crearFactura: cuerpo.crear_factura as boolean | undefined,
+      actorId: actor.id,
+      baseUrl,
+    })
+  })
 }

--- a/app/api/v1/movimientos/[id]/facturas-candidatas/route.ts
+++ b/app/api/v1/movimientos/[id]/facturas-candidatas/route.ts
@@ -1,0 +1,23 @@
+import { createAdminClient } from "@/lib/supabase/admin"
+import { buscarFacturasParaMovimiento } from "@/lib/api/facturas"
+import { conApi, qNumero } from "@/lib/api/route-helpers"
+
+export const runtime = "nodejs"
+
+/**
+ * GET /api/v1/movimientos/{id}/facturas-candidatas
+ *
+ * Facturas de la bandeja que podrían corresponder a este movimiento, comparando
+ * contra el importe que a cada una le queda por pagar (para que funcione
+ * también con pagos en varios plazos).
+ */
+export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  return conApi(request, "read", async ({ baseUrl, params: query }) => {
+    const { id } = await params
+    const candidatas = await buscarFacturasParaMovimiento(createAdminClient(), id, {
+      limite: qNumero(query, "limite"),
+      baseUrl,
+    })
+    return { movimiento_id: id, total: candidatas.length, candidatas }
+  })
+}

--- a/app/api/v1/movimientos/[id]/route.ts
+++ b/app/api/v1/movimientos/[id]/route.ts
@@ -1,61 +1,38 @@
-import { NextResponse } from "next/server"
 import { createAdminClient } from "@/lib/supabase/admin"
-import { verifyApiKey } from "@/lib/api/external-auth"
-import {
-  getMovimientoRaw,
-  getArchivosRaw,
-  serializeArchivo,
-  serializeMovimiento,
-} from "@/lib/api/movimientos-public"
+import { notFound } from "@/lib/api/errors"
+import { actualizarMovimiento, obtenerMovimiento } from "@/lib/api/movimientos-public"
+import { conApi, cuerpoJson } from "@/lib/api/route-helpers"
 
 export const runtime = "nodejs"
 
 /**
  * GET /api/v1/movimientos/{id}
  *
- * API externa (Google Apps Script u otras apps internas). Devuelve un movimiento
- * por su ID, con sus relaciones (cuenta, categoría, delegación, contacto) y la
- * lista de archivos adjuntos embebida.
- *
- * Autenticación: cabecera `Authorization: Bearer <clave>` o `x-api-key: <clave>`.
- * El ID es único en toda la base de datos, así que no hace falta indicar la
- * delegación.
+ * Devuelve un movimiento por su ID, con sus relaciones (cuenta, categoría,
+ * delegación, contacto) y la lista de archivos adjuntos embebida. El ID es
+ * único en toda la base de datos, así que no hace falta indicar la delegación.
  */
-export async function GET(
-  request: Request,
-  { params }: { params: Promise<{ id: string }> },
-) {
-  const auth = verifyApiKey(request)
-  if (!auth.ok) {
-    return NextResponse.json({ ok: false, error: auth.error }, { status: auth.status })
-  }
+export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  return conApi(request, "read", async ({ baseUrl }) => {
+    const { id } = await params
+    const movimiento = await obtenerMovimiento(createAdminClient(), id, { baseUrl })
+    if (!movimiento) throw notFound("Movimiento no encontrado.")
+    return { movimiento }
+  })
+}
 
-  const { id } = await params
-  if (!id) {
-    return NextResponse.json({ ok: false, error: "Falta el ID del movimiento." }, { status: 400 })
-  }
-
-  try {
-    const admin = createAdminClient()
-    const movimiento = await getMovimientoRaw(admin, id)
-    if (!movimiento) {
-      return NextResponse.json(
-        { ok: false, error: "Movimiento no encontrado." },
-        { status: 404 },
-      )
-    }
-
-    const archivosRaw = await getArchivosRaw(admin, id)
-    const archivos = archivosRaw.map(serializeArchivo)
-
-    return NextResponse.json({
-      ok: true,
-      movimiento: serializeMovimiento(movimiento, archivos),
-    })
-  } catch (err) {
-    return NextResponse.json(
-      { ok: false, error: err instanceof Error ? err.message : String(err) },
-      { status: 500 },
-    )
-  }
+/**
+ * PATCH /api/v1/movimientos/{id}
+ *
+ * Modifica los campos editables: categoría, contacto, notas, descripción,
+ * contraparte, método, `ignorado` y `factura_pendiente`. Importe, fecha, cuenta
+ * y delegación no se tocan desde la API: vienen del banco.
+ */
+export async function PATCH(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  return conApi(request, "write", async ({ baseUrl }) => {
+    const { id } = await params
+    const cuerpo = await cuerpoJson(request)
+    const movimiento = await actualizarMovimiento(createAdminClient(), id, cuerpo, { baseUrl })
+    return { movimiento }
+  })
 }

--- a/app/api/v1/movimientos/route.ts
+++ b/app/api/v1/movimientos/route.ts
@@ -1,0 +1,62 @@
+import { createAdminClient } from "@/lib/supabase/admin"
+import { buscarMovimientos, type OrdenMovimientos } from "@/lib/api/movimientos-public"
+import { resolveAmbitoDelegaciones } from "@/lib/api/delegaciones"
+import { resolveCategorias, resolveCuentas } from "@/lib/api/catalogos"
+import {
+  conApi,
+  qBooleano,
+  qLista,
+  qNumero,
+  qOpcion,
+  qTexto,
+} from "@/lib/api/route-helpers"
+
+export const runtime = "nodejs"
+
+const ORDENES = ["fecha_desc", "fecha_asc", "importe_desc", "importe_asc"] as const
+
+/**
+ * GET /api/v1/movimientos
+ *
+ * Búsqueda de movimientos en una, varias o todas las delegaciones, con el
+ * resumen económico del conjunto encontrado (no solo de la página).
+ *
+ * Ejemplo: todos los gastos de Mercadona por encima de 50 € en cualquier
+ * delegación durante 2026:
+ *
+ *   /api/v1/movimientos?texto=mercadona&tipo=gasto&importe_min=50
+ *     &fecha_desde=2026-01-01&fecha_hasta=2026-12-31
+ *
+ * Los importes se filtran por valor absoluto; `tipo` decide el signo.
+ */
+export async function GET(request: Request) {
+  return conApi(request, "read", async ({ params, baseUrl }) => {
+    const admin = createAdminClient()
+
+    const delegaciones = await resolveAmbitoDelegaciones(admin, qLista(params, "delegaciones"))
+    const categorias = await resolveCategorias(admin, qLista(params, "categorias"), delegaciones)
+    const cuentas = await resolveCuentas(admin, qLista(params, "cuentas"), delegaciones)
+
+    return buscarMovimientos(admin, {
+      delegaciones,
+      texto: qTexto(params, "texto"),
+      tipo: qOpcion(params, "tipo", ["ingreso", "gasto"] as const),
+      importeMin: qNumero(params, "importe_min"),
+      importeMax: qNumero(params, "importe_max"),
+      fechaDesde: qTexto(params, "fecha_desde"),
+      fechaHasta: qTexto(params, "fecha_hasta"),
+      categoriaIds: categorias?.map((c) => c.id) ?? null,
+      sinCategoria: qBooleano(params, "sin_categoria"),
+      cuentaIds: cuentas?.map((c) => c.id) ?? null,
+      conFactura: qBooleano(params, "con_factura") ?? null,
+      facturaPendiente: qBooleano(params, "factura_pendiente"),
+      incluirIgnorados: qBooleano(params, "incluir_ignorados"),
+      incluirCuentasInactivas: qBooleano(params, "incluir_cuentas_inactivas"),
+      orden: qOpcion(params, "orden", ORDENES) as OrdenMovimientos | undefined,
+      limite: qNumero(params, "limite"),
+      offset: qNumero(params, "offset"),
+      incluirArchivos: qBooleano(params, "incluir_archivos") ?? true,
+      baseUrl,
+    })
+  })
+}

--- a/app/api/v1/openapi.json/route.ts
+++ b/app/api/v1/openapi.json/route.ts
@@ -12,6 +12,60 @@ export const runtime = "nodejs"
  * Pública (no contiene secretos). El servidor se calcula a partir del origen de
  * la petición para que el "try it out" apunte al dominio correcto.
  */
+
+const RESPUESTAS_ERROR = {
+  "400": { $ref: "#/components/responses/Error" },
+  "401": { $ref: "#/components/responses/Error" },
+  "403": { $ref: "#/components/responses/Error" },
+  "404": { $ref: "#/components/responses/Error" },
+  "500": { $ref: "#/components/responses/Error" },
+}
+
+/** Envuelve un esquema en la forma `{ ok: true, ...datos }` de las respuestas. */
+function respuestaOk(descripcion: string, propiedades: Record<string, unknown>) {
+  return {
+    "200": {
+      description: descripcion,
+      content: {
+        "application/json": {
+          schema: {
+            type: "object",
+            properties: { ok: { type: "boolean", const: true }, ...propiedades },
+            required: ["ok"],
+          },
+        },
+      },
+    },
+    ...RESPUESTAS_ERROR,
+  }
+}
+
+const PARAM_DELEGACIONES = {
+  name: "delegaciones",
+  in: "query",
+  description:
+    "Delegaciones por nombre, código o id. Se admite repetir el parámetro o separarlo por comas. Si se omite, TODAS las delegaciones.",
+  schema: { type: "string" },
+  example: "Sevilla,Madrid",
+}
+
+const PARAM_ID = (que: string) => ({
+  name: "id",
+  in: "path",
+  required: true,
+  description: `Id (UUID) ${que}.`,
+  schema: { type: "string", format: "uuid" },
+})
+
+const CUERPO_ARCHIVO = {
+  required: true,
+  content: {
+    "application/json": {
+      schema: { $ref: "#/components/schemas/ArchivoEntrante" },
+    },
+  },
+}
+
 export async function GET(request: Request) {
   const url = new URL(request.url)
   const origin = `${url.protocol}//${url.host}`
@@ -20,102 +74,757 @@ export async function GET(request: Request) {
     openapi: "3.1.0",
     info: {
       title: "MCM Bank API externa",
-      version: "1.0.0",
+      version: "2.0.0",
       description:
-        "API de solo lectura para consultar movimientos de MCM Bank desde " +
-        "aplicaciones internas (p.ej. Google Apps Script). El ID de un " +
-        "movimiento es único en toda la base de datos, así que no hace falta " +
-        "indicar la delegación.\n\n" +
-        "**Autenticación:** envía la clave en la cabecera `Authorization: " +
-        "Bearer <clave>` o `x-api-key: <clave>`.",
+        "API de MCM Bank para aplicaciones internas y agentes de IA. Cubre movimientos, " +
+        "facturas, conciliación, avisos y archivos de **todas las delegaciones** a la vez: " +
+        "está pensada para la oficina técnica, que las revisa todas.\n\n" +
+        "**Autenticación:** envía la clave en `Authorization: Bearer <clave>` o `x-api-key: <clave>`. " +
+        "`MCM_API_KEY` da lectura y escritura; `MCM_API_KEY_READONLY` (y el histórico `CRON_SECRET`) " +
+        "solo lectura.\n\n" +
+        "**Delegaciones, categorías y cuentas por su nombre:** donde se pide una delegación puedes " +
+        "escribir `Sevilla`, `MCM-SEV` o su UUID. Si el nombre es ambiguo, el error 400 devuelve los " +
+        "candidatos.\n\n" +
+        "**Signos:** el `importe` de un movimiento es negativo en los gastos y positivo en los " +
+        "ingresos; el de una factura siempre positivo. Los filtros `importe_min`/`importe_max` " +
+        "trabajan con el valor absoluto.\n\n" +
+        "**Autoría de las escrituras:** cada escritura queda firmada por un usuario real. Se indica " +
+        "con `usuario_email` en el cuerpo, con la cabecera `x-mcm-usuario-email`, o en el servidor con " +
+        "`MCM_API_USER_EMAIL` / `MCM_API_USER_ID`.\n\n" +
+        `**MCP:** este mismo backend expone un servidor MCP en \`${origin}/api/mcp\` para usarlo desde ` +
+        "Claude en lenguaje natural.",
     },
     servers: [{ url: origin, description: "Servidor actual" }],
-    tags: [{ name: "Movimientos", description: "Consulta de movimientos y sus archivos" }],
+    tags: [
+      { name: "Referencia", description: "Delegaciones, cuentas, categorías y contactos" },
+      { name: "Movimientos", description: "Consulta y edición de movimientos y sus archivos" },
+      { name: "Facturas", description: "Bandeja de facturas y conciliación con movimientos" },
+      { name: "Avisos", description: "Notas y tareas entre la oficina técnica y las delegaciones" },
+      { name: "Archivos", description: "Descarga y borrado de adjuntos" },
+      { name: "Informes", description: "Resumen económico" },
+    ],
     security: [{ apiKeyHeader: [] }, { bearerAuth: [] }],
     paths: {
+      // ------------------------------------------------------------ Referencia
+      "/api/v1/delegaciones": {
+        get: {
+          tags: ["Referencia"],
+          summary: "Listar todas las delegaciones",
+          operationId: "listarDelegaciones",
+          responses: respuestaOk("Delegaciones de la organización.", {
+            total: { type: "integer" },
+            delegaciones: { type: "array", items: { $ref: "#/components/schemas/Delegacion" } },
+          }),
+        },
+      },
+      "/api/v1/cuentas": {
+        get: {
+          tags: ["Referencia"],
+          summary: "Listar cuentas bancarias y cajas",
+          operationId: "listarCuentas",
+          parameters: [
+            PARAM_DELEGACIONES,
+            {
+              name: "incluir_inactivas",
+              in: "query",
+              schema: { type: "boolean" },
+              description: "Incluir cuentas desactivadas.",
+            },
+          ],
+          responses: respuestaOk("Cuentas.", {
+            total: { type: "integer" },
+            cuentas: { type: "array", items: { type: "object" } },
+          }),
+        },
+      },
+      "/api/v1/categorias": {
+        get: {
+          tags: ["Referencia"],
+          summary: "Listar categorías",
+          description:
+            "Categorías globales de MCM más las propias de cada delegación. Pidiendo una sola delegación se aplican además su orden y visibilidad personalizados.",
+          operationId: "listarCategorias",
+          parameters: [
+            PARAM_DELEGACIONES,
+            { name: "incluir_inactivas", in: "query", schema: { type: "boolean" } },
+          ],
+          responses: respuestaOk("Categorías.", {
+            total: { type: "integer" },
+            categorias: { type: "array", items: { type: "object" } },
+          }),
+        },
+      },
+      "/api/v1/contactos": {
+        get: {
+          tags: ["Referencia"],
+          summary: "Listar proveedores y personas",
+          operationId: "listarContactos",
+          parameters: [
+            PARAM_DELEGACIONES,
+            { name: "texto", in: "query", schema: { type: "string" }, description: "Filtra por nombre." },
+            { name: "tipos", in: "query", schema: { type: "string" }, example: "proveedor" },
+            { name: "incluir_archivados", in: "query", schema: { type: "boolean" } },
+          ],
+          responses: respuestaOk("Contactos.", {
+            total: { type: "integer" },
+            contactos: { type: "array", items: { type: "object" } },
+          }),
+        },
+      },
+
+      // ----------------------------------------------------------- Movimientos
+      "/api/v1/movimientos": {
+        get: {
+          tags: ["Movimientos"],
+          summary: "Buscar movimientos en una, varias o todas las delegaciones",
+          description:
+            "Devuelve la página de resultados y, además, el resumen económico de **todo** el conjunto encontrado, desglosado por delegación.\n\n" +
+            "Ejemplo — gastos de Mercadona de más de 50 € en cualquier delegación durante 2026:\n\n" +
+            "`/api/v1/movimientos?texto=mercadona&tipo=gasto&importe_min=50&fecha_desde=2026-01-01&fecha_hasta=2026-12-31`",
+          operationId: "buscarMovimientos",
+          parameters: [
+            {
+              name: "texto",
+              in: "query",
+              schema: { type: "string" },
+              description:
+                "Busca en concepto, descripción, contraparte y notas. Con varias palabras, deben aparecer todas.",
+            },
+            PARAM_DELEGACIONES,
+            {
+              name: "tipo",
+              in: "query",
+              schema: { type: "string", enum: ["ingreso", "gasto"] },
+              description: "Quedarse solo con ingresos o con gastos.",
+            },
+            {
+              name: "importe_min",
+              in: "query",
+              schema: { type: "number" },
+              description: "Importe mínimo en valor absoluto.",
+            },
+            { name: "importe_max", in: "query", schema: { type: "number" } },
+            { name: "fecha_desde", in: "query", schema: { type: "string", format: "date" } },
+            { name: "fecha_hasta", in: "query", schema: { type: "string", format: "date" } },
+            {
+              name: "categorias",
+              in: "query",
+              schema: { type: "string" },
+              description: "Categorías por nombre o id, separadas por comas.",
+            },
+            { name: "sin_categoria", in: "query", schema: { type: "boolean" } },
+            {
+              name: "cuentas",
+              in: "query",
+              schema: { type: "string" },
+              description: "Cuentas por nombre, IBAN o id.",
+            },
+            {
+              name: "con_factura",
+              in: "query",
+              schema: { type: "boolean" },
+              description: "true = solo con factura vinculada; false = solo sin ella.",
+            },
+            { name: "factura_pendiente", in: "query", schema: { type: "boolean" } },
+            {
+              name: "incluir_ignorados",
+              in: "query",
+              schema: { type: "boolean" },
+              description: "Por defecto se excluyen, igual que en la aplicación.",
+            },
+            { name: "incluir_cuentas_inactivas", in: "query", schema: { type: "boolean" } },
+            {
+              name: "orden",
+              in: "query",
+              schema: {
+                type: "string",
+                enum: ["fecha_desc", "fecha_asc", "importe_desc", "importe_asc"],
+              },
+              description: "Los gastos son negativos: para los mayores gastos, importe_asc.",
+            },
+            {
+              name: "limite",
+              in: "query",
+              schema: { type: "integer", default: 50, maximum: 200 },
+            },
+            { name: "offset", in: "query", schema: { type: "integer" } },
+            { name: "incluir_archivos", in: "query", schema: { type: "boolean", default: true } },
+          ],
+          responses: respuestaOk("Movimientos encontrados y resumen del conjunto.", {
+            total: { type: "integer", description: "Movimientos que cumplen los filtros." },
+            limite: { type: "integer" },
+            offset: { type: "integer" },
+            hay_mas: { type: "boolean" },
+            resumen: { $ref: "#/components/schemas/ResumenBusqueda" },
+            movimientos: { type: "array", items: { $ref: "#/components/schemas/Movimiento" } },
+          }),
+        },
+      },
       "/api/v1/movimientos/{id}": {
         get: {
           tags: ["Movimientos"],
           summary: "Obtener un movimiento por su ID (datos + archivos)",
           description:
-            "Devuelve el movimiento con sus relaciones (cuenta, categoría, " +
-            "delegación, contacto) y la lista de archivos adjuntos embebida.",
+            "El ID es único en toda la base de datos, así que no hace falta indicar la delegación.",
           operationId: "getMovimiento",
-          parameters: [
-            {
-              name: "id",
-              in: "path",
-              required: true,
-              description: "ID (UUID) del movimiento.",
-              schema: { type: "string", format: "uuid" },
-            },
-          ],
-          responses: {
-            "200": {
-              description: "Movimiento encontrado.",
-              content: {
-                "application/json": {
-                  schema: {
-                    type: "object",
-                    properties: {
-                      ok: { type: "boolean", const: true },
-                      movimiento: { $ref: "#/components/schemas/Movimiento" },
-                    },
-                    required: ["ok", "movimiento"],
+          parameters: [PARAM_ID("del movimiento")],
+          responses: respuestaOk("Movimiento encontrado.", {
+            movimiento: { $ref: "#/components/schemas/Movimiento" },
+          }),
+        },
+        patch: {
+          tags: ["Movimientos"],
+          summary: "Editar un movimiento",
+          description:
+            "Solo campos editables por personas. Importe, fecha, cuenta y delegación no se tocan desde la API: vienen del banco.",
+          operationId: "actualizarMovimiento",
+          parameters: [PARAM_ID("del movimiento")],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    categoria_id: { type: ["string", "null"], format: "uuid" },
+                    contacto_id: { type: ["string", "null"], format: "uuid" },
+                    notas: { type: ["string", "null"] },
+                    descripcion: { type: ["string", "null"] },
+                    contraparte: { type: ["string", "null"] },
+                    metodo: { type: ["string", "null"] },
+                    ignorado: { type: "boolean" },
+                    factura_pendiente: { type: "boolean" },
                   },
                 },
               },
             },
-            "400": { $ref: "#/components/responses/Error" },
-            "401": { $ref: "#/components/responses/Error" },
-            "404": { $ref: "#/components/responses/Error" },
-            "500": { $ref: "#/components/responses/Error" },
           },
+          responses: respuestaOk("Movimiento actualizado.", {
+            movimiento: { $ref: "#/components/schemas/Movimiento" },
+          }),
         },
       },
       "/api/v1/movimientos/{id}/archivos": {
         get: {
           tags: ["Movimientos"],
           summary: "Obtener solo los archivos de un movimiento",
-          description:
-            "Devuelve únicamente los archivos adjuntos del movimiento, con su " +
-            "URL pública de descarga.",
           operationId: "getMovimientoArchivos",
+          parameters: [PARAM_ID("del movimiento")],
+          responses: respuestaOk("Archivos del movimiento.", {
+            movimiento_id: { type: "string", format: "uuid" },
+            total: { type: "integer" },
+            archivos: { type: "array", items: { $ref: "#/components/schemas/Archivo" } },
+          }),
+        },
+        post: {
+          tags: ["Movimientos"],
+          summary: "Adjuntar un archivo a un movimiento",
+          description:
+            "Sube el fichero en base64. Si va al bucket `facturas` (el predeterminado), también se registra en la sección Facturas ya conciliado con este movimiento, igual que al subirlo desde la aplicación.",
+          operationId: "subirArchivoMovimiento",
+          parameters: [PARAM_ID("del movimiento")],
+          requestBody: CUERPO_ARCHIVO,
+          responses: respuestaOk("Archivo subido.", {
+            archivo: { $ref: "#/components/schemas/Archivo" },
+            factura_id: { type: ["string", "null"], format: "uuid" },
+            aviso: { type: "string", description: "Presente si algo secundario falló." },
+          }),
+        },
+      },
+      "/api/v1/movimientos/{id}/facturas-candidatas": {
+        get: {
+          tags: ["Facturas"],
+          summary: "Facturas que podrían corresponder a este movimiento",
+          description:
+            "Compara contra el importe que a cada factura le queda por pagar, de modo que funciona también con pagos en varios plazos.",
+          operationId: "facturasCandidatas",
+          parameters: [PARAM_ID("del movimiento"), { name: "limite", in: "query", schema: { type: "integer" } }],
+          responses: respuestaOk("Facturas candidatas ordenadas de mejor a peor.", {
+            movimiento_id: { type: "string", format: "uuid" },
+            total: { type: "integer" },
+            candidatas: { type: "array", items: { type: "object" } },
+          }),
+        },
+      },
+
+      // -------------------------------------------------------------- Facturas
+      "/api/v1/facturas": {
+        get: {
+          tags: ["Facturas"],
+          summary: "Buscar facturas",
+          operationId: "buscarFacturas",
           parameters: [
+            PARAM_DELEGACIONES,
             {
-              name: "id",
-              in: "path",
-              required: true,
-              description: "ID (UUID) del movimiento.",
-              schema: { type: "string", format: "uuid" },
+              name: "estados",
+              in: "query",
+              schema: { type: "string" },
+              description: "bandeja, sin_pagar, pagada_parcial, pagada, pagada_fuera.",
             },
+            { name: "texto", in: "query", schema: { type: "string" } },
+            { name: "numero", in: "query", schema: { type: "string" } },
+            { name: "importe_min", in: "query", schema: { type: "number" } },
+            { name: "importe_max", in: "query", schema: { type: "number" } },
+            { name: "fecha_desde", in: "query", schema: { type: "string", format: "date" } },
+            { name: "fecha_hasta", in: "query", schema: { type: "string", format: "date" } },
+            {
+              name: "sin_conciliar",
+              in: "query",
+              schema: { type: "boolean" },
+              description: "Solo las que no tienen ningún movimiento vinculado.",
+            },
+            { name: "limite", in: "query", schema: { type: "integer", default: 50, maximum: 200 } },
+            { name: "offset", in: "query", schema: { type: "integer" } },
           ],
-          responses: {
-            "200": {
-              description: "Lista de archivos del movimiento.",
-              content: {
-                "application/json": {
-                  schema: {
-                    type: "object",
-                    properties: {
-                      ok: { type: "boolean", const: true },
-                      movimiento_id: { type: "string", format: "uuid" },
-                      total: { type: "integer" },
-                      archivos: {
-                        type: "array",
-                        items: { $ref: "#/components/schemas/Archivo" },
-                      },
+          responses: respuestaOk("Facturas encontradas.", {
+            total: { type: "integer" },
+            limite: { type: "integer" },
+            offset: { type: "integer" },
+            hay_mas: { type: "boolean" },
+            facturas: { type: "array", items: { $ref: "#/components/schemas/Factura" } },
+          }),
+        },
+        post: {
+          tags: ["Facturas"],
+          summary: "Registrar una factura",
+          description: "Admite subir el archivo y conciliarla con un movimiento en la misma llamada.",
+          operationId: "crearFactura",
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    delegacion: { type: "string", description: "Nombre, código o id." },
+                    concepto: { type: "string" },
+                    numero: { type: "string" },
+                    importe: { type: "number", description: "En positivo." },
+                    fecha_emision: { type: "string", format: "date" },
+                    moneda: { type: "string", default: "EUR" },
+                    estado: {
+                      type: "string",
+                      enum: ["bandeja", "sin_pagar", "pagada_parcial", "pagada", "pagada_fuera"],
                     },
-                    required: ["ok", "movimiento_id", "total", "archivos"],
+                    notas: { type: "string" },
+                    contacto_id: { type: "string", format: "uuid" },
+                    movimiento_id: { type: "string", format: "uuid" },
+                    archivo: { $ref: "#/components/schemas/ArchivoEntrante" },
+                    usuario_email: { type: "string", format: "email" },
+                  },
+                  required: ["delegacion"],
+                },
+              },
+            },
+          },
+          responses: respuestaOk("Factura creada.", {
+            factura: { $ref: "#/components/schemas/Factura" },
+          }),
+        },
+      },
+      "/api/v1/facturas/{id}": {
+        get: {
+          tags: ["Facturas"],
+          summary: "Obtener una factura",
+          operationId: "getFactura",
+          parameters: [PARAM_ID("de la factura")],
+          responses: respuestaOk("Factura.", { factura: { $ref: "#/components/schemas/Factura" } }),
+        },
+        patch: {
+          tags: ["Facturas"],
+          summary: "Editar una factura",
+          operationId: "actualizarFactura",
+          parameters: [PARAM_ID("de la factura")],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    numero: { type: ["string", "null"] },
+                    concepto: { type: ["string", "null"] },
+                    importe: { type: ["number", "null"] },
+                    fecha_emision: { type: ["string", "null"], format: "date" },
+                    estado: { type: "string" },
+                    notas: { type: ["string", "null"] },
+                    contacto_id: { type: ["string", "null"], format: "uuid" },
                   },
                 },
               },
             },
-            "400": { $ref: "#/components/responses/Error" },
-            "401": { $ref: "#/components/responses/Error" },
-            "404": { $ref: "#/components/responses/Error" },
-            "500": { $ref: "#/components/responses/Error" },
           },
+          responses: respuestaOk("Factura actualizada.", {
+            factura: { $ref: "#/components/schemas/Factura" },
+          }),
+        },
+        delete: {
+          tags: ["Facturas"],
+          summary: "Borrar una factura",
+          description:
+            "Borra la factura y sus archivos y desvincula sus movimientos (los movimientos no se borran). Irreversible.",
+          operationId: "eliminarFactura",
+          parameters: [PARAM_ID("de la factura")],
+          responses: respuestaOk("Factura eliminada.", {
+            eliminada: { type: "boolean", const: true },
+            id: { type: "string", format: "uuid" },
+          }),
+        },
+      },
+      "/api/v1/facturas/{id}/archivos": {
+        get: {
+          tags: ["Facturas"],
+          summary: "Archivos de una factura",
+          operationId: "getFacturaArchivos",
+          parameters: [PARAM_ID("de la factura")],
+          responses: respuestaOk("Archivos.", {
+            factura_id: { type: "string", format: "uuid" },
+            total: { type: "integer" },
+            archivos: { type: "array", items: { $ref: "#/components/schemas/Archivo" } },
+          }),
+        },
+        post: {
+          tags: ["Facturas"],
+          summary: "Adjuntar un archivo a una factura",
+          description:
+            "Si la factura ya está conciliada, el archivo se replica en sus movimientos para verse desde ambos lados.",
+          operationId: "subirArchivoFactura",
+          parameters: [PARAM_ID("de la factura")],
+          requestBody: CUERPO_ARCHIVO,
+          responses: respuestaOk("Archivo subido.", {
+            archivo: { $ref: "#/components/schemas/Archivo" },
+            factura_id: { type: "string", format: "uuid" },
+          }),
+        },
+      },
+      "/api/v1/facturas/{id}/vincular": {
+        post: {
+          tags: ["Facturas"],
+          summary: "Conciliar una factura con un movimiento",
+          description:
+            "Una factura admite varios movimientos (pago en plazos); un movimiento, como mucho una factura. El estado de la factura lo recalcula la base de datos.",
+          operationId: "vincularFactura",
+          parameters: [PARAM_ID("de la factura")],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    movimiento_id: { type: "string", format: "uuid" },
+                    usuario_email: { type: "string", format: "email" },
+                  },
+                  required: ["movimiento_id"],
+                },
+              },
+            },
+          },
+          responses: respuestaOk("Factura conciliada.", {
+            factura: { $ref: "#/components/schemas/Factura" },
+          }),
+        },
+        delete: {
+          tags: ["Facturas"],
+          summary: "Deshacer una conciliación",
+          operationId: "desvincularFactura",
+          parameters: [
+            PARAM_ID("de la factura"),
+            {
+              name: "movimiento_id",
+              in: "query",
+              required: true,
+              schema: { type: "string", format: "uuid" },
+            },
+          ],
+          responses: respuestaOk("Vínculo deshecho.", {
+            factura: { $ref: "#/components/schemas/Factura" },
+          }),
+        },
+      },
+      "/api/v1/conciliacion": {
+        post: {
+          tags: ["Facturas"],
+          summary: "Cuadrar un lote de facturas contra los movimientos",
+          description:
+            "Recibe una lista de importes (con fecha, proveedor o número si se conocen) y devuelve, para cada uno, los movimientos que mejor encajan con su puntuación y motivos.\n\n" +
+            "Por defecto solo propone (basta clave de lectura). Con `aplicar: true` —que exige clave de escritura— vincula los casos claros y deja los dudosos para revisión humana.",
+          operationId: "conciliarLote",
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    facturas: {
+                      type: "array",
+                      maxItems: 100,
+                      items: {
+                        type: "object",
+                        properties: {
+                          referencia: { type: "string", description: "Etiqueta libre para reconocer la línea." },
+                          importe: { type: "number", description: "En positivo." },
+                          fecha: { type: "string", format: "date" },
+                          proveedor: { type: "string" },
+                          numero: { type: "string" },
+                          delegacion: { type: "string" },
+                          factura_id: { type: "string", format: "uuid" },
+                        },
+                        required: ["importe"],
+                      },
+                    },
+                    delegaciones: { type: "array", items: { type: "string" } },
+                    ventana_dias: { type: "integer", default: 90 },
+                    max_candidatos: { type: "integer", default: 5 },
+                    aplicar: { type: "boolean", default: false },
+                    crear_facturas: { type: "boolean", default: false },
+                    usuario_email: { type: "string", format: "email" },
+                  },
+                  required: ["facturas"],
+                },
+                example: {
+                  facturas: [
+                    { referencia: "linea-1", importe: 128.4, fecha: "2026-03-04", proveedor: "Mercadona" },
+                    { referencia: "linea-2", importe: 56.9, proveedor: "Endesa" },
+                  ],
+                  delegaciones: ["Sevilla"],
+                },
+              },
+            },
+          },
+          responses: respuestaOk("Propuestas de conciliación.", {
+            total: { type: "integer" },
+            con_match_directo: { type: "integer" },
+            sin_candidatos: { type: "integer" },
+            vinculados: { type: "integer" },
+            resultados: { type: "array", items: { type: "object" } },
+          }),
+        },
+      },
+
+      // ---------------------------------------------------------------- Avisos
+      "/api/v1/avisos": {
+        get: {
+          tags: ["Avisos"],
+          summary: "Listar avisos y tareas",
+          description: "Sin filtros, las pendientes de todas las delegaciones.",
+          operationId: "listarAvisos",
+          parameters: [
+            PARAM_DELEGACIONES,
+            {
+              name: "estado",
+              in: "query",
+              schema: { type: "string", enum: ["pendiente", "hecha", "todas"], default: "pendiente" },
+            },
+            { name: "tipo", in: "query", schema: { type: "string", enum: ["tarea", "nota"] } },
+            {
+              name: "destinatario",
+              in: "query",
+              schema: { type: "string", enum: ["oficina_tecnica", "delegacion"] },
+            },
+            { name: "texto", in: "query", schema: { type: "string" } },
+            { name: "limite", in: "query", schema: { type: "integer", default: 100 } },
+          ],
+          responses: respuestaOk("Avisos.", {
+            total: { type: "integer" },
+            avisos: { type: "array", items: { $ref: "#/components/schemas/Aviso" } },
+          }),
+        },
+        post: {
+          tags: ["Avisos"],
+          summary: "Dejar una nota o tarea en una delegación",
+          operationId: "crearAviso",
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    delegacion: { type: "string" },
+                    contenido: { type: "string", maxLength: 2000 },
+                    tipo: { type: "string", enum: ["tarea", "nota"], default: "nota" },
+                    destinatario: {
+                      type: "string",
+                      enum: ["delegacion", "oficina_tecnica"],
+                      default: "delegacion",
+                    },
+                    referencia: { type: "string", maxLength: 60 },
+                    notificar: { type: "boolean", description: "Enviarlo además por correo." },
+                    usuario_email: { type: "string", format: "email" },
+                  },
+                  required: ["delegacion", "contenido"],
+                },
+              },
+            },
+          },
+          responses: respuestaOk("Aviso creado.", {
+            aviso: { $ref: "#/components/schemas/Aviso" },
+            notificados: { type: "array", items: { type: "string" } },
+            aviso_notificacion: {
+              type: "string",
+              description: "Presente si el aviso se guardó pero el correo no pudo salir.",
+            },
+          }),
+        },
+      },
+      "/api/v1/avisos/{id}": {
+        get: {
+          tags: ["Avisos"],
+          summary: "Obtener un aviso",
+          operationId: "getAviso",
+          parameters: [PARAM_ID("del aviso")],
+          responses: respuestaOk("Aviso.", { aviso: { $ref: "#/components/schemas/Aviso" } }),
+        },
+        patch: {
+          tags: ["Avisos"],
+          summary: "Editar un aviso o marcarlo como hecho",
+          operationId: "actualizarAviso",
+          parameters: [PARAM_ID("del aviso")],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    contenido: { type: "string" },
+                    referencia: { type: ["string", "null"] },
+                    destinatario: { type: "string", enum: ["delegacion", "oficina_tecnica"] },
+                    estado: { type: "string", enum: ["pendiente", "hecha"] },
+                    usuario_email: { type: "string", format: "email" },
+                  },
+                },
+              },
+            },
+          },
+          responses: respuestaOk("Aviso actualizado.", { aviso: { $ref: "#/components/schemas/Aviso" } }),
+        },
+        delete: {
+          tags: ["Avisos"],
+          summary: "Borrar un aviso",
+          operationId: "eliminarAviso",
+          parameters: [PARAM_ID("del aviso")],
+          responses: respuestaOk("Aviso eliminado.", {
+            eliminado: { type: "boolean", const: true },
+            id: { type: "string", format: "uuid" },
+          }),
+        },
+      },
+      "/api/v1/avisos/{id}/notificar": {
+        post: {
+          tags: ["Avisos"],
+          summary: "Enviar el aviso por correo",
+          description:
+            "A los tesoreros de su delegación o a la oficina técnica, según a quién vaya dirigido. Nunca a su autor.",
+          operationId: "notificarAviso",
+          parameters: [PARAM_ID("del aviso")],
+          responses: respuestaOk("Correo enviado.", {
+            aviso: { $ref: "#/components/schemas/Aviso" },
+            notificados: { type: "array", items: { type: "string", format: "email" } },
+          }),
+        },
+      },
+
+      // -------------------------------------------------------------- Archivos
+      "/api/v1/archivos/{id}": {
+        get: {
+          tags: ["Archivos"],
+          summary: "Metadatos de un archivo",
+          operationId: "getArchivo",
+          parameters: [PARAM_ID("del archivo")],
+          responses: respuestaOk("Archivo.", {
+            archivo: { $ref: "#/components/schemas/Archivo" },
+            asociado_a: { type: "object" },
+          }),
+        },
+        delete: {
+          tags: ["Archivos"],
+          summary: "Borrar un archivo",
+          operationId: "eliminarArchivo",
+          parameters: [PARAM_ID("del archivo")],
+          responses: respuestaOk("Archivo eliminado.", {
+            eliminado: { type: "boolean", const: true },
+            id: { type: "string", format: "uuid" },
+          }),
+        },
+      },
+      "/api/v1/archivos/{id}/url": {
+        get: {
+          tags: ["Archivos"],
+          summary: "URL firmada de descarga",
+          operationId: "urlArchivo",
+          parameters: [
+            PARAM_ID("del archivo"),
+            {
+              name: "segundos",
+              in: "query",
+              schema: { type: "integer", default: 300, minimum: 30, maximum: 3600 },
+            },
+          ],
+          responses: respuestaOk("URL temporal.", {
+            url: { type: "string", format: "uri" },
+            nombre: { type: "string" },
+            tipo_mime: { type: "string" },
+            caduca_en_segundos: { type: "integer" },
+          }),
+        },
+      },
+      "/api/v1/archivos/{id}/descargar": {
+        get: {
+          tags: ["Archivos"],
+          summary: "Descargar el archivo (redirección)",
+          description: "Responde 302 hacia una URL firmada. Es el valor de `url_descarga` de cada adjunto.",
+          operationId: "descargarArchivo",
+          parameters: [PARAM_ID("del archivo")],
+          responses: {
+            "302": { description: "Redirección a la URL firmada del fichero." },
+            ...RESPUESTAS_ERROR,
+          },
+        },
+      },
+
+      // -------------------------------------------------------------- Informes
+      "/api/v1/resumen": {
+        get: {
+          tags: ["Informes"],
+          summary: "Resumen económico por delegación",
+          description:
+            "Ingresos, gastos, neto y saldo por delegación, desglose por categoría y pendientes de cada una.\n\n" +
+            "El saldo suma todo el histórico de las cuentas activas (incluidos los movimientos ignorados, porque refleja el extracto del banco); los ingresos y gastos respetan el rango de fechas y excluyen los ignorados.",
+          operationId: "resumenEconomico",
+          parameters: [
+            PARAM_DELEGACIONES,
+            { name: "desde", in: "query", schema: { type: "string", format: "date" } },
+            { name: "hasta", in: "query", schema: { type: "string", format: "date" } },
+            { name: "incluir_ignorados", in: "query", schema: { type: "boolean" } },
+          ],
+          responses: respuestaOk("Resumen.", {
+            desde: { type: ["string", "null"], format: "date" },
+            hasta: { type: ["string", "null"], format: "date" },
+            totales: { type: "object" },
+            por_delegacion: { type: "array", items: { type: "object" } },
+            por_categoria: { type: "array", items: { type: "object" } },
+          }),
+        },
+      },
+      "/api/v1/pagos-mcm": {
+        get: {
+          tags: ["Informes"],
+          summary: "Listar pagos MCM (reembolsos a personas)",
+          description: "Solo lectura: el alta se hace desde la aplicación.",
+          operationId: "listarPagosMcm",
+          parameters: [
+            PARAM_DELEGACIONES,
+            { name: "estados", in: "query", schema: { type: "string" } },
+            { name: "limite", in: "query", schema: { type: "integer" } },
+            { name: "offset", in: "query", schema: { type: "integer" } },
+          ],
+          responses: respuestaOk("Pagos MCM.", {
+            total: { type: "integer" },
+            pagos: { type: "array", items: { type: "object" } },
+          }),
         },
       },
     },
@@ -135,7 +844,8 @@ export async function GET(request: Request) {
       },
       responses: {
         Error: {
-          description: "Error.",
+          description:
+            "Error. El campo `error` está escrito para leerse; `detalles` trae, cuando aplica, los valores válidos o los candidatos entre los que elegir.",
           content: {
             "application/json": {
               schema: {
@@ -143,6 +853,7 @@ export async function GET(request: Request) {
                 properties: {
                   ok: { type: "boolean", const: false },
                   error: { type: "string" },
+                  detalles: { type: "object" },
                 },
                 required: ["ok", "error"],
               },
@@ -151,6 +862,33 @@ export async function GET(request: Request) {
         },
       },
       schemas: {
+        Delegacion: {
+          type: "object",
+          properties: {
+            id: { type: "string", format: "uuid" },
+            codigo: { type: ["string", "null"] },
+            nombre: { type: "string" },
+          },
+          required: ["id", "nombre"],
+        },
+        ArchivoEntrante: {
+          type: "object",
+          description: "Fichero a subir, codificado en base64 (máximo 3 MB por API).",
+          properties: {
+            nombre: { type: "string", description: "Nombre con extensión, p. ej. 'factura-octubre.pdf'." },
+            contenido_base64: { type: "string", description: "Contenido del fichero en base64 (admite data URL)." },
+            tipo_mime: { type: "string", description: "Si se omite, se deduce de la extensión." },
+            descripcion: { type: "string" },
+            bucket: { type: "string", enum: ["facturas", "documentos"], default: "facturas" },
+            crear_factura: {
+              type: "boolean",
+              default: true,
+              description: "Solo al adjuntar a un movimiento en el bucket 'facturas'.",
+            },
+            usuario_email: { type: "string", format: "email" },
+          },
+          required: ["nombre", "contenido_base64"],
+        },
         Archivo: {
           type: "object",
           properties: {
@@ -163,21 +901,33 @@ export async function GET(request: Request) {
             bucket: { type: "string", examples: ["facturas", "documentos"] },
             url: {
               type: "string",
-              format: "uri",
-              description: "URL pública directa de descarga (sin autenticación).",
+              description:
+                "URL pública heredada. Vacía en los archivos subidos desde que se pasó a URLs firmadas: usa `url_descarga`.",
             },
+            url_descarga: {
+              type: "string",
+              format: "uri",
+              description: "Endpoint autenticado que redirige a una URL firmada de descarga.",
+            },
+            path_storage: { type: "string" },
             subido_en: { type: "string", format: "date-time" },
           },
-          required: [
-            "id",
-            "nombre_original",
-            "tipo_mime",
-            "tamano_bytes",
-            "es_factura",
-            "bucket",
-            "url",
-            "subido_en",
-          ],
+          required: ["id", "nombre_original", "tipo_mime", "tamano_bytes", "es_factura", "bucket", "subido_en"],
+        },
+        ResumenBusqueda: {
+          type: "object",
+          description: "Agregado de TODO el conjunto que cumple los filtros, no solo de la página.",
+          properties: {
+            movimientos: { type: "integer" },
+            ingresos: { type: "number" },
+            gastos: { type: "number", description: "Negativo." },
+            neto: { type: "number" },
+            truncado: {
+              type: "boolean",
+              description: "true si había más filas de las que se pudieron agregar.",
+            },
+            por_delegacion: { type: "array", items: { type: "object" } },
+          },
         },
         Movimiento: {
           type: "object",
@@ -192,6 +942,8 @@ export async function GET(request: Request) {
             metodo: { type: ["string", "null"] },
             notas: { type: ["string", "null"] },
             ignorado: { type: "boolean" },
+            factura_id: { type: ["string", "null"], format: "uuid" },
+            factura_pendiente: { type: "boolean" },
             booking_date: { type: ["string", "null"], format: "date" },
             value_date: { type: ["string", "null"], format: "date" },
             origen_sync: { type: ["string", "null"] },
@@ -216,14 +968,7 @@ export async function GET(request: Request) {
                 color: { type: ["string", "null"] },
               },
             },
-            delegacion: {
-              type: ["object", "null"],
-              properties: {
-                id: { type: "string", format: "uuid" },
-                codigo: { type: ["string", "null"] },
-                nombre: { type: "string" },
-              },
-            },
+            delegacion: { anyOf: [{ $ref: "#/components/schemas/Delegacion" }, { type: "null" }] },
             contacto: {
               type: ["object", "null"],
               properties: {
@@ -232,12 +977,56 @@ export async function GET(request: Request) {
                 tipo: { type: ["string", "null"] },
               },
             },
-            archivos: {
-              type: "array",
-              items: { $ref: "#/components/schemas/Archivo" },
-            },
+            archivos: { type: "array", items: { $ref: "#/components/schemas/Archivo" } },
           },
           required: ["id", "fecha", "concepto", "importe", "tipo", "creado_en", "archivos"],
+        },
+        Factura: {
+          type: "object",
+          properties: {
+            id: { type: "string", format: "uuid" },
+            numero: { type: ["string", "null"] },
+            concepto: { type: ["string", "null"] },
+            importe: { type: ["number", "null"], description: "Siempre positivo." },
+            moneda: { type: "string" },
+            fecha_emision: { type: ["string", "null"], format: "date" },
+            estado: {
+              type: "string",
+              enum: ["bandeja", "sin_pagar", "pagada_parcial", "pagada", "pagada_fuera"],
+            },
+            origen: { type: "string", enum: ["subida", "movimiento", "email"] },
+            notas: { type: ["string", "null"] },
+            email_remitente: { type: ["string", "null"] },
+            delegacion: { anyOf: [{ $ref: "#/components/schemas/Delegacion" }, { type: "null" }] },
+            contacto: { type: ["object", "null"] },
+            importe_pagado: { type: "number", description: "Suma de los movimientos vinculados." },
+            importe_pendiente: { type: ["number", "null"] },
+            movimientos: { type: "array", items: { type: "object" } },
+            archivos: { type: "array", items: { $ref: "#/components/schemas/Archivo" } },
+            creado_en: { type: "string", format: "date-time" },
+            actualizado_en: { type: "string", format: "date-time" },
+          },
+          required: ["id", "estado", "origen", "importe_pagado", "movimientos", "archivos"],
+        },
+        Aviso: {
+          type: "object",
+          properties: {
+            id: { type: "string", format: "uuid" },
+            tipo: { type: "string", enum: ["tarea", "nota"] },
+            contenido: { type: "string" },
+            referencia: { type: ["string", "null"] },
+            destinatario: { type: "string", enum: ["oficina_tecnica", "delegacion"] },
+            estado: { type: "string", enum: ["pendiente", "hecha"] },
+            delegacion: { anyOf: [{ $ref: "#/components/schemas/Delegacion" }, { type: "null" }] },
+            autor: { type: "object" },
+            completado_por: { type: ["object", "null"] },
+            completado_en: { type: ["string", "null"], format: "date-time" },
+            notificado_en: { type: ["string", "null"], format: "date-time" },
+            lecturas: { type: "integer" },
+            creado_en: { type: "string", format: "date-time" },
+            actualizado_en: { type: "string", format: "date-time" },
+          },
+          required: ["id", "tipo", "contenido", "destinatario", "estado"],
         },
       },
     },

--- a/app/api/v1/pagos-mcm/route.ts
+++ b/app/api/v1/pagos-mcm/route.ts
@@ -1,0 +1,23 @@
+import { createAdminClient } from "@/lib/supabase/admin"
+import { listarPagosMcm } from "@/lib/api/pagos"
+import { conApi, qLista, qNumero } from "@/lib/api/route-helpers"
+
+export const runtime = "nodejs"
+
+/**
+ * GET /api/v1/pagos-mcm?delegaciones=Sevilla
+ *
+ * Reembolsos a personas del movimiento (kilometraje, gastos adelantados).
+ * Solo lectura: el alta tiene reglas propias (cálculo de gasolina, contacto
+ * obligatorio) que se hacen desde la aplicación.
+ */
+export async function GET(request: Request) {
+  return conApi(request, "read", async ({ params }) =>
+    listarPagosMcm(createAdminClient(), {
+      delegaciones: qLista(params, "delegaciones") ?? null,
+      estados: qLista(params, "estados"),
+      limite: qNumero(params, "limite"),
+      offset: qNumero(params, "offset"),
+    }),
+  )
+}

--- a/app/api/v1/resumen/route.ts
+++ b/app/api/v1/resumen/route.ts
@@ -1,0 +1,27 @@
+import { createAdminClient } from "@/lib/supabase/admin"
+import { resumenGeneral } from "@/lib/api/resumen"
+import { conApi, qBooleano, qLista, qTexto } from "@/lib/api/route-helpers"
+
+export const runtime = "nodejs"
+
+/**
+ * GET /api/v1/resumen?desde=2026-01-01&hasta=2026-12-31
+ *
+ * Foto económica de una, varias o todas las delegaciones: ingresos, gastos,
+ * neto y saldo por delegación, desglose por categoría, y facturas y avisos
+ * pendientes de cada una.
+ *
+ * El saldo suma todo el histórico de las cuentas activas (incluidos los
+ * movimientos ignorados, porque el saldo refleja el extracto del banco); los
+ * ingresos y gastos sí respetan el rango de fechas y excluyen los ignorados.
+ */
+export async function GET(request: Request) {
+  return conApi(request, "read", async ({ params }) =>
+    resumenGeneral(createAdminClient(), {
+      delegaciones: qLista(params, "delegaciones") ?? null,
+      desde: qTexto(params, "desde"),
+      hasta: qTexto(params, "hasta"),
+      incluirIgnorados: qBooleano(params, "incluir_ignorados"),
+    }),
+  )
+}

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -4,18 +4,25 @@ export const runtime = "nodejs"
  * GET /llms.txt
  *
  * Punto de entrada para agentes de IA (convención llms.txt). Markdown plano,
- * público, que describe la API externa y enlaza a la spec OpenAPI y a la
- * documentación interactiva, con URLs absolutas al dominio actual.
+ * público, que describe la API externa y el servidor MCP y enlaza a la spec
+ * OpenAPI y a la documentación interactiva, con URLs absolutas al dominio
+ * actual.
  */
 export async function GET(request: Request) {
   const url = new URL(request.url)
   const origin = `${url.protocol}//${url.host}`
 
-  const body = `# MCM Bank — API externa
+  const body = `# MCM Bank — API externa y servidor MCP
 
-> API de solo lectura para consultar movimientos (transacciones) de MCM Bank
-> desde aplicaciones internas como Google Apps Script. El ID de un movimiento es
-> único en toda la base de datos: no hace falta indicar la delegación.
+> MCM Bank es la aplicación de tesorería del Movimiento Consolación para el Mundo,
+> organizada en delegaciones. Esta API está pensada para la oficina técnica, que
+> revisa TODAS las delegaciones a la vez: movimientos bancarios, facturas y su
+> conciliación, avisos y tareas, y archivos adjuntos.
+
+## Dos formas de usarla
+
+- **API REST** en \`${origin}/api/v1\` — para scripts, Google Apps Script, integraciones.
+- **Servidor MCP** en \`${origin}/api/mcp\` — para hablarle en lenguaje natural desde Claude.
 
 ## Autenticación
 
@@ -24,38 +31,96 @@ Todas las peticiones requieren una clave de API en una cabecera:
 - \`Authorization: Bearer <clave>\`  — o bien
 - \`x-api-key: <clave>\`
 
-La clave la configura el administrador del servidor (variable de entorno
-\`MCM_API_KEY\`, con respaldo en \`CRON_SECRET\`).
+Hay dos niveles: \`MCM_API_KEY\` da lectura y escritura; \`MCM_API_KEY_READONLY\`
+(y el histórico \`CRON_SECRET\`) solo lectura.
 
 ## Recursos
 
 - Especificación OpenAPI 3.1 (fuente de verdad legible por máquinas): ${origin}/api/v1/openapi.json
 - Documentación interactiva (Scalar): ${origin}/docs/api
+- Servidor MCP (JSON-RPC sobre HTTP, POST): ${origin}/api/mcp
 
-## Endpoints
+## Conexión MCP desde Claude Code
 
-### GET ${origin}/api/v1/movimientos/{id}
-Devuelve un movimiento por su ID con sus relaciones (cuenta, categoría,
-delegación, contacto) y la lista de archivos adjuntos embebida.
+\`\`\`bash
+claude mcp add --transport http mcm-bank ${origin}/api/mcp \\
+  --header "Authorization: Bearer TU_CLAVE"
+\`\`\`
 
-### GET ${origin}/api/v1/movimientos/{id}/archivos
-Devuelve únicamente los archivos adjuntos del movimiento, con su URL pública de
-descarga directa (la descarga del fichero no requiere autenticación).
+Herramientas disponibles: buscar_movimientos, obtener_movimiento,
+actualizar_movimiento, resumen_economico, listar_delegaciones, listar_cuentas,
+listar_categorias, listar_contactos, buscar_facturas, obtener_factura,
+crear_factura, actualizar_factura, eliminar_factura, vincular_factura,
+desvincular_factura, buscar_movimiento_de_factura, buscar_factura_de_movimiento,
+conciliar_facturas, subir_archivo, obtener_url_archivo, eliminar_archivo,
+listar_avisos, crear_aviso, actualizar_aviso, eliminar_aviso, notificar_aviso,
+listar_pagos_mcm.
+
+## Endpoints REST principales
+
+### GET ${origin}/api/v1/movimientos
+Busca movimientos en una, varias o todas las delegaciones y devuelve además el
+resumen económico del conjunto completo. Filtros: \`texto\`, \`delegaciones\`,
+\`tipo\` (ingreso|gasto), \`importe_min\`, \`importe_max\`, \`fecha_desde\`,
+\`fecha_hasta\`, \`categorias\`, \`cuentas\`, \`sin_categoria\`, \`con_factura\`,
+\`factura_pendiente\`, \`orden\`, \`limite\`, \`offset\`.
+
+### GET / PATCH ${origin}/api/v1/movimientos/{id}
+Movimiento completo con relaciones y archivos; PATCH edita categoría, contacto,
+notas, descripción, contraparte, método, \`ignorado\` y \`factura_pendiente\`.
+
+### GET / POST ${origin}/api/v1/movimientos/{id}/archivos
+Lista los adjuntos, o sube uno nuevo en base64. Al subir una factura se registra
+también en la sección Facturas, ya conciliada con el movimiento.
+
+### GET / POST ${origin}/api/v1/facturas
+Bandeja de facturas con lo pagado y lo pendiente de cada una; POST registra una
+nueva (opcionalmente con su archivo y ya vinculada a un movimiento).
+
+### POST ${origin}/api/v1/facturas/{id}/vincular
+Concilia una factura con el movimiento que la pagó.
+
+### POST ${origin}/api/v1/conciliacion
+Cuadra un lote de facturas: se envía una lista de importes y devuelve, para cada
+uno, los movimientos que mejor encajan. Con \`aplicar: true\` vincula los casos
+claros.
+
+### GET / POST ${origin}/api/v1/avisos
+Notas y tareas entre la oficina técnica y los tesoreros de cada delegación.
+POST admite \`notificar: true\` para enviarlo además por correo.
+
+### GET ${origin}/api/v1/resumen
+Ingresos, gastos, neto y saldo por delegación, con desglose por categoría.
+
+### GET ${origin}/api/v1/delegaciones · /cuentas · /categorias · /contactos · /pagos-mcm
+Catálogos de referencia.
+
+### GET ${origin}/api/v1/archivos/{id}/descargar
+Redirige a una URL firmada del fichero.
 
 ## Ejemplo
 
 \`\`\`bash
 curl -H "x-api-key: TU_CLAVE" \\
-  ${origin}/api/v1/movimientos/00000000-0000-0000-0000-000000000000
+  "${origin}/api/v1/movimientos?texto=mercadona&tipo=gasto&importe_min=50"
 \`\`\`
 
 ## Notas
 
-- El campo \`importe\` es positivo para ingresos y negativo para gastos; \`tipo\`
-  ('ingreso' | 'gasto') refleja ese signo.
-- Códigos de error: 400 (falta ID), 401 (clave inválida), 404 (no existe),
-  500 (error de servidor o API no configurada).
-- Formato de error: \`{ "ok": false, "error": "..." }\`.
+- Donde se pide una delegación, categoría o cuenta se admite su nombre normal
+  ("Sevilla", "Alimentación"), su código o su UUID. Si el nombre es ambiguo, el
+  error 400 devuelve los candidatos.
+- El campo \`importe\` de un movimiento es positivo en los ingresos y negativo en
+  los gastos; \`tipo\` refleja ese signo. El importe de una factura es siempre
+  positivo. Los filtros por importe usan el valor absoluto.
+- Una factura puede tener varios movimientos vinculados (pago en plazos); un
+  movimiento, como mucho una factura.
+- Las escrituras se firman con un usuario real: \`usuario_email\` en el cuerpo,
+  la cabecera \`x-mcm-usuario-email\`, o \`MCM_API_USER_EMAIL\` en el servidor.
+- Códigos de error: 400 (petición mal formada), 401 (clave inválida), 403 (clave
+  de solo lectura en una operación de escritura), 404 (no existe), 409
+  (conflicto), 500 (error de servidor o API sin configurar).
+- Formato de error: \`{ "ok": false, "error": "...", "detalles": { ... } }\`.
 `
 
   return new Response(body, {

--- a/docs/API_PRUEBA_RAPIDA.md
+++ b/docs/API_PRUEBA_RAPIDA.md
@@ -1,7 +1,8 @@
-# API externa · prueba rápida (5 minutos)
+# API externa y MCP · prueba rápida (5 minutos)
 
-Guía mínima para dejar la API externa funcionando con su propia clave y
-comprobar que responde. Referencia completa: `docs/manual/21.-api-externa-solo-pros.md`.
+Guía mínima para dejar la API externa (y el servidor MCP, que usa la misma
+clave) funcionando y comprobar que responde. Referencia completa:
+`docs/manual/21.-api-externa-solo-pros.md` y `docs/manual/22.-servidor-mcp.md`.
 
 ## 1. Genera una clave
 
@@ -18,35 +19,73 @@ Copia el resultado, algo como `a1b2c3...` (64 caracteres).
 1. Vercel → tu proyecto → **Settings → Environment Variables**.
 2. Nombre: `MCM_API_KEY`. Valor: la clave del paso 1. Entornos: **Production**
    (y Preview si quieres probar antes).
-3. **Save** → luego **Deployments → ⋯ → Redeploy** (las env vars no aplican
+3. Si además vas a **escribir** desde fuera (crear avisos, subir facturas,
+   conciliar), añade `MCM_API_USER_EMAIL` con el correo de la cuenta de MCM Bank
+   que debe figurar como autora.
+4. **Save** → luego **Deployments → ⋯ → Redeploy** (las env vars no aplican
    solas, hace falta un redeploy).
 
 {% hint style="warning" %}
-Si no pones `MCM_API_KEY`, la API sigue funcionando pero con la clave del
-cron bancario (`CRON_SECRET`) — mejor tener la suya propia, más aislada.
+Si no pones `MCM_API_KEY`, la API sigue respondiendo consultas con la clave del
+cron bancario (`CRON_SECRET`), pero **cualquier escritura devolverá 403**.
+Mejor tener la suya propia, más aislada.
 {% endhint %}
 
-## 3. Consigue un ID de movimiento para probar
+## 3. Comprueba que lee
 
-En la app: **Transacciones → clic en cualquier movimiento → pestaña Datos →
-"ID del movimiento (API)" → Copiar**.
-
-## 4. Un curl y ya
+Nada que copiar de la app: pide la lista de delegaciones.
 
 ```bash
-curl -H "x-api-key: TU_CLAVE" \
-  https://TU-DOMINIO/api/v1/movimientos/EL_ID_QUE_COPIASTE
+curl -H "x-api-key: TU_CLAVE" https://TU-DOMINIO/api/v1/delegaciones
 ```
-
-## 5. ¿Funciona?
 
 | Ves esto | Significa |
 |---|---|
-| `{"ok": true, "movimiento": {...}}` | ✅ Todo correcto, ya puedes construir sobre esto |
+| `{"ok": true, "total": 18, "delegaciones": [...]}` | ✅ Todo correcto |
 | `{"ok": false, "error": "No autorizado..."}` (401) | Clave mal copiada, o no has hecho redeploy tras guardarla |
-| `{"ok": false, "error": "Movimiento no encontrado."}` (404) | El ID no existe o lo copiaste mal |
 | `{"ok": false, "error": "...no está configurada..."}` (500) | Ni `MCM_API_KEY` ni `CRON_SECRET` están puestas en Vercel |
 
-Con eso confirmado, la referencia completa (`docs/manual/21.-api-externa-solo-pros.md`)
-tiene el resto: todos los campos de la respuesta, el endpoint de solo
-archivos, y un ejemplo listo para pegar en Google Apps Script.
+## 4. Comprueba que busca
+
+```bash
+curl -H "x-api-key: TU_CLAVE" \
+  "https://TU-DOMINIO/api/v1/movimientos?tipo=gasto&importe_min=100&limite=5"
+```
+
+Debe devolver hasta 5 gastos de más de 100 € de **todas** las delegaciones, más
+un bloque `resumen` con el total del conjunto completo.
+
+## 5. Comprueba el MCP
+
+```bash
+curl -s -X POST https://TU-DOMINIO/api/mcp \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer TU_CLAVE" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | head -c 300
+```
+
+Si sale una lista de herramientas (`buscar_movimientos`, `crear_aviso`…), ya
+puedes conectarlo a Claude:
+
+```bash
+claude mcp add --transport http mcm-bank https://TU-DOMINIO/api/mcp \
+  --header "Authorization: Bearer TU_CLAVE"
+```
+
+## 6. Y si quieres escribir
+
+```bash
+curl -X POST -H "x-api-key: TU_CLAVE" -H "Content-Type: application/json" \
+  -d '{"delegacion":"NOMBRE_DE_UNA_DELEGACION","contenido":"Prueba de la API"}' \
+  https://TU-DOMINIO/api/v1/avisos
+```
+
+| Ves esto | Significa |
+|---|---|
+| `{"ok": true, "aviso": {...}}` | ✅ La escritura funciona (borra el aviso desde la app) |
+| `403 ... clave es de solo lectura` | Estás usando `CRON_SECRET` o la clave de solo lectura |
+| `500 ... Define la variable de entorno MCM_API_USER_ID` | Falta `MCM_API_USER_EMAIL` en Vercel (paso 2.3) |
+
+Con eso confirmado, la referencia completa
+(`docs/manual/21.-api-externa-solo-pros.md`) tiene el resto: todos los
+endpoints, la conciliación en bloque y ejemplos para Google Apps Script.

--- a/docs/manual/21.-api-externa-solo-pros.md
+++ b/docs/manual/21.-api-externa-solo-pros.md
@@ -4,12 +4,14 @@ icon: panel-fire
 
 # 21. API externa \[solo pros]
 
-## 13. API externa (consulta de movimientos)
-
-MCM Bank expone una pequeña API de solo lectura para consultar movimientos desde otras aplicaciones internas (por ejemplo, un **Google Apps Script**).
+MCM Bank expone una API para consultar y modificar sus datos desde fuera de la aplicación: hojas de cálculo, **Google Apps Script**, scripts propios o cualquier integración interna.
 
 {% hint style="info" %}
-La idea es simple: copias el **ID de un movimiento** desde la aplicación y lo consultas desde fuera para recibir toda su información y sus archivos adjuntos. Como el ID es único en toda la base de datos, **no hace falta indicar la delegación**.
+Está pensada para la **oficina técnica**, que revisa todas las delegaciones a la vez. Por eso casi todos los endpoints trabajan sobre varias delegaciones de golpe: si no dices en cuál buscar, busca en **todas**.
+{% endhint %}
+
+{% hint style="success" %}
+Si lo que quieres es hablarle a MCM Bank en lenguaje natural desde Claude, no necesitas nada de esto: mira **[22. Servidor MCP](22.-servidor-mcp.md)**, que usa este mismo motor.
 {% endhint %}
 
 ### Documentación interactiva y recursos para agentes de IA
@@ -19,6 +21,7 @@ La idea es simple: copias el **ID de un movimiento** desde la aplicación y lo c
 | **Documentación interactiva** | `https://TU-DOMINIO/docs/api`            | Página web (Scalar) con "try it out".                            |
 | **OpenAPI 3.1**               | `https://TU-DOMINIO/api/v1/openapi.json` | Spec legible por máquinas (agentes IA, generadores de clientes). |
 | **llms.txt**                  | `https://TU-DOMINIO/llms.txt`            | Punto de entrada estándar para agentes de IA.                    |
+| **Servidor MCP**              | `https://TU-DOMINIO/api/mcp`             | El mismo motor, hablado en lenguaje natural.                     |
 
 Todos son públicos (no contienen secretos) y se sirven con URLs absolutas al dominio actual.
 
@@ -36,13 +39,38 @@ o bien:
 x-api-key: TU_CLAVE
 ```
 
-La clave se configura en el servidor mediante variables de entorno:
+Hay **dos niveles de permiso**, para que una clave pegada en una hoja de cálculo no pueda además modificar la contabilidad:
 
-* `MCM_API_KEY` — variable dedicada (recomendada si quieres una clave separada).
-* Si no está definida, se reutiliza `CRON_SECRET` (el secreto que ya usa el cron de sincronización bancaria).
+| Variable de entorno     | Permiso              | Para qué                                      |
+| ----------------------- | -------------------- | --------------------------------------------- |
+| `MCM_API_KEY`           | lectura y escritura  | La clave "buena": crear avisos, subir facturas, conciliar. |
+| `MCM_API_KEY_READONLY`  | solo lectura         | Informes, cuadros de mando, scripts que solo consultan. |
+| `CRON_SECRET`           | solo lectura         | Respaldo histórico. **Nunca da escritura.**   |
 
 {% hint style="warning" %}
-Para rotar la clave, cambia el valor en las variables de entorno del proyecto (Vercel) y vuelve a desplegar.
+Si no defines `MCM_API_KEY`, la API sigue funcionando en modo consulta con `CRON_SECRET`, pero **cualquier operación de escritura devolverá 403**. Para escribir hay que definir `MCM_API_KEY`.
+
+Para rotar una clave, cambia el valor en las variables de entorno de Vercel y vuelve a desplegar.
+{% endhint %}
+
+### Quién firma las escrituras
+
+La base de datos exige un autor en cada nota, archivo o factura, y las personas que las leen quieren ver un nombre, no "sistema". Por eso toda escritura se atribuye a un usuario real de MCM Bank, que se determina así (el primero que exista):
+
+1. `usuario_email` (o `usuario_id`) en el cuerpo de la petición.
+2. La cabecera `x-mcm-usuario-email` (o `x-mcm-usuario-id`), útil para fijarlo por integración.
+3. Las variables de entorno `MCM_API_USER_EMAIL` o `MCM_API_USER_ID` del servidor.
+
+Si no hay ninguna, la escritura falla con un mensaje que explica exactamente qué configurar. Nunca se elige un usuario "cualquiera": una nota firmada por la persona equivocada es peor que una nota que no se guarda.
+
+### Cosas que conviene saber antes de empezar
+
+{% hint style="info" %}
+**Nombres en vez de UUIDs.** Donde se pide una delegación, categoría o cuenta puedes escribir su nombre normal (`Sevilla`, `Alimentación`), su código (`MCM-SEV`) o su UUID. Si el nombre es ambiguo, el error `400` te devuelve los candidatos en `detalles` para que reintentes.
+
+**Signos.** El `importe` de un movimiento es **negativo en los gastos** y positivo en los ingresos. El de una factura es **siempre positivo** (es lo facturado). Los filtros `importe_min` / `importe_max` trabajan con el **valor absoluto**: `importe_min=50` encuentra tanto `+50` como `-50`; usa `tipo=gasto` para quedarte con unos u otros.
+
+**Una factura, varios pagos.** Una factura puede tener varios movimientos vinculados (pago en plazos); un movimiento, como mucho una factura. El estado de la factura (`pagada_parcial`, `pagada`…) lo recalcula sola la base de datos comparando importes.
 {% endhint %}
 
 ### Cómo obtener el ID de un movimiento
@@ -51,162 +79,291 @@ Para rotar la clave, cambia el valor en las variables de entorno del proyecto (V
 2. Haz clic en un movimiento para abrir su detalle.
 3. En la pestaña **Datos**, al final, verás **«ID del movimiento (API)»** con un botón **Copiar**.
 
-### Endpoints
+También puedes buscarlo con `GET /api/v1/movimientos?texto=...`, que es lo habitual desde un script.
 
-Base: `https://TU-DOMINIO/api/v1`
+## Endpoints
 
-#### 1. Movimiento completo (datos + archivos)
+Base: `https://TU-DOMINIO/api/v1`. La referencia completa, campo a campo, está en `/docs/api`; aquí va lo esencial.
+
+### Referencia
+
+| Método | Ruta            | Qué hace                                             |
+| ------ | --------------- | ---------------------------------------------------- |
+| `GET`  | `/delegaciones` | Todas las delegaciones con id, código y nombre.      |
+| `GET`  | `/cuentas`      | Cuentas y cajas. `?delegaciones=`, `?incluir_inactivas=` |
+| `GET`  | `/categorias`   | Categorías globales + las de cada delegación.        |
+| `GET`  | `/contactos`    | Proveedores y personas. `?texto=`, `?tipos=`         |
+| `GET`  | `/pagos-mcm`    | Reembolsos a personas (solo lectura).                |
+
+### Movimientos
+
+#### Buscar movimientos
 
 ```
-GET /api/v1/movimientos/{id}
+GET /api/v1/movimientos
 ```
 
-Respuesta `200`:
+Filtros: `texto`, `delegaciones`, `tipo` (`ingreso`|`gasto`), `importe_min`, `importe_max`, `fecha_desde`, `fecha_hasta`, `categorias`, `cuentas`, `sin_categoria`, `con_factura`, `factura_pendiente`, `incluir_ignorados`, `orden`, `limite`, `offset`.
+
+En `texto`, si escribes varias palabras deben aparecer **todas** (en concepto, descripción, contraparte o notas).
+
+```bash
+# Gastos de Mercadona de más de 50 € en todas las delegaciones, en 2026
+curl -H "x-api-key: TU_CLAVE" \
+  "https://TU-DOMINIO/api/v1/movimientos?texto=mercadona&tipo=gasto&importe_min=50&fecha_desde=2026-01-01&fecha_hasta=2026-12-31"
+```
+
+Además de la página de resultados, la respuesta trae el **resumen de todo el conjunto** encontrado, no solo de la página:
 
 ```json
 {
   "ok": true,
-  "movimiento": {
-    "id": "9f1c...",
-    "fecha": "2026-05-21",
-    "concepto": "Compra material oficina",
-    "descripcion": null,
-    "contraparte": "PAPELERIA XYZ",
-    "importe": -42.5,
-    "tipo": "gasto",
-    "metodo": "tarjeta",
-    "notas": null,
-    "ignorado": false,
-    "booking_date": "2026-05-21",
-    "value_date": "2026-05-22",
-    "origen_sync": "enablebanking",
-    "creado_en": "2026-05-22T08:10:00.000Z",
-    "cuenta": {
-      "id": "...",
-      "nombre": "Cuenta principal",
-      "tipo": "banco",
-      "banco_nombre": "CaixaBank",
-      "iban": "ES12 ...."
-    },
-    "categoria": {
-      "id": "...",
-      "nombre": "Material oficina",
-      "tipo": "gasto",
-      "emoji": "📎",
-      "color": "blue"
-    },
-    "delegacion": { "id": "...", "codigo": "MAD", "nombre": "Madrid" },
-    "contacto": { "id": "...", "nombre": "Papelería XYZ", "tipo": "proveedor" },
-    "archivos": [
-      {
-        "id": "...",
-        "nombre_original": "factura.pdf",
-        "tipo_mime": "application/pdf",
-        "tamano_bytes": 102400,
-        "es_factura": true,
-        "descripcion": null,
-        "bucket": "facturas",
-        "url": "https://....supabase.co/storage/v1/object/public/facturas/...",
-        "subido_en": "2026-05-22T08:12:00.000Z"
-      }
+  "total": 37,
+  "limite": 50,
+  "offset": 0,
+  "hay_mas": false,
+  "resumen": {
+    "movimientos": 37,
+    "ingresos": 0,
+    "gastos": -3482.19,
+    "neto": -3482.19,
+    "truncado": false,
+    "por_delegacion": [
+      { "delegacion": { "nombre": "Sevilla" }, "movimientos": 21, "gastos": -2104.5, "neto": -2104.5 }
     ]
-  }
+  },
+  "movimientos": [ /* … */ ]
 }
 ```
 
-#### 2. Solo archivos de un movimiento
+{% hint style="info" %}
+Por defecto se excluyen los movimientos marcados como **ignorados** y los de **cuentas desactivadas**, igual que hace la aplicación, para que los números cuadren con lo que se ve en pantalla.
+{% endhint %}
+
+#### Un movimiento concreto
 
 ```
-GET /api/v1/movimientos/{id}/archivos
+GET   /api/v1/movimientos/{id}
+PATCH /api/v1/movimientos/{id}
 ```
 
-Respuesta `200`:
+`GET` devuelve el movimiento con cuenta, categoría, delegación, contacto y sus archivos.
+
+`PATCH` cambia solo lo editable por personas: `categoria_id`, `contacto_id`, `notas`, `descripcion`, `contraparte`, `metodo`, `ignorado`, `factura_pendiente`.
+
+{% hint style="warning" %}
+Importe, fecha, cuenta y delegación **no se pueden cambiar** desde la API: vienen del banco, y tocarlos desde fuera sería una forma silenciosa de descuadrar la contabilidad.
+{% endhint %}
+
+#### Archivos de un movimiento
+
+```
+GET  /api/v1/movimientos/{id}/archivos
+POST /api/v1/movimientos/{id}/archivos
+```
+
+Para subir, el fichero va en base64:
+
+```bash
+curl -X POST -H "x-api-key: TU_CLAVE" -H "Content-Type: application/json" \
+  -d "{\"nombre\":\"factura-octubre.pdf\",\"contenido_base64\":\"$(base64 -w0 factura.pdf)\"}" \
+  https://TU-DOMINIO/api/v1/movimientos/EL_ID/archivos
+```
+
+{% hint style="success" %}
+Al subir una **factura** a un movimiento (bucket `facturas`, el predeterminado) también se crea la entidad factura en la sección Facturas, ya conciliada con ese movimiento y con sus datos — exactamente lo mismo que pasa al subirla desde la app. Si no lo quieres, manda `"crear_factura": false`.
+{% endhint %}
+
+{% hint style="warning" %}
+El máximo por API son **3 MB** de archivo real (el límite de cuerpo de petición de Vercel, y en base64 un fichero ocupa un 33 % más). Desde la aplicación el límite sigue siendo 20 MB.
+{% endhint %}
+
+### Facturas
+
+| Método   | Ruta                            | Qué hace                                          |
+| -------- | ------------------------------- | ------------------------------------------------- |
+| `GET`    | `/facturas`                     | Bandeja, con lo pagado y lo pendiente de cada una. |
+| `POST`   | `/facturas`                     | Registra una (opcionalmente con archivo y ya vinculada). |
+| `GET`    | `/facturas/{id}`                | Una factura con sus movimientos y archivos.       |
+| `PATCH`  | `/facturas/{id}`                | Corrige número, concepto, importe, fecha, estado… |
+| `DELETE` | `/facturas/{id}`                | La borra y desvincula sus movimientos.            |
+| `GET`    | `/facturas/{id}/archivos`       | Sus archivos.                                     |
+| `POST`   | `/facturas/{id}/archivos`       | Adjunta un archivo.                               |
+| `POST`   | `/facturas/{id}/vincular`       | La concilia con un movimiento.                    |
+| `DELETE` | `/facturas/{id}/vincular?movimiento_id=` | Deshace la conciliación.                 |
+
+### Conciliar un montón de facturas de golpe
+
+Este es el endpoint que resuelve el caso real: *"tengo estas doce facturas con estos importes, dime de qué movimiento es cada una"*.
+
+```
+POST /api/v1/conciliacion
+```
 
 ```json
 {
-  "ok": true,
-  "movimiento_id": "9f1c...",
-  "total": 1,
-  "archivos": [
-    {
-      "id": "...",
-      "nombre_original": "factura.pdf",
-      "tipo_mime": "application/pdf",
-      "tamano_bytes": 102400,
-      "es_factura": true,
-      "descripcion": null,
-      "bucket": "facturas",
-      "url": "https://....supabase.co/storage/v1/object/public/facturas/...",
-      "subido_en": "2026-05-22T08:12:00.000Z"
-    }
-  ]
+  "facturas": [
+    { "referencia": "linea-1", "importe": 128.40, "fecha": "2026-03-04", "proveedor": "Mercadona" },
+    { "referencia": "linea-2", "importe": 56.90, "proveedor": "Endesa" }
+  ],
+  "delegaciones": ["Sevilla"],
+  "aplicar": false
 }
 ```
 
-El campo `url` es una URL pública directa: puedes descargar el archivo con un `GET` normal (sin cabecera de autenticación).
+Para cada línea devuelve los movimientos candidatos ordenados, con su puntuación y los **motivos en texto** ("importe exacto", "fecha muy cercana", "el concepto menciona Mercadona"), y si hay un **match directo**.
 
-#### Errores
+{% hint style="warning" %}
+Por defecto solo **propone** (basta clave de lectura). Con `"aplicar": true` —que exige clave de escritura— vincula automáticamente los casos claros (importe exacto y con ventaja clara sobre el segundo candidato) y deja los dudosos para que los revise una persona. Añade `"crear_facturas": true` si las facturas todavía no están en MCM Bank y quieres que se registren en la bandeja al vincularlas.
+{% endhint %}
 
-| Código | Significado                                        |
-| ------ | -------------------------------------------------- |
-| `400`  | Falta el ID del movimiento.                        |
-| `401`  | Falta la clave o no es válida.                     |
-| `404`  | El movimiento no existe.                           |
-| `500`  | Error del servidor (o la API no está configurada). |
+Los dos caminos de uno en uno también están:
+
+* `GET /api/v1/movimientos/{id}/facturas-candidatas` — qué facturas podrían ser de este movimiento.
+* En MCP, `buscar_movimiento_de_factura` hace el camino inverso.
+
+### Avisos y tareas
+
+El canal entre la oficina técnica y los tesoreros de cada delegación (ver **[11. Avisos y tareas](11.-avisos-y-tareas.md)**).
+
+| Método   | Ruta                       | Qué hace                                              |
+| -------- | -------------------------- | ----------------------------------------------------- |
+| `GET`    | `/avisos`                  | Sin filtros: las pendientes de **todas** las delegaciones. |
+| `POST`   | `/avisos`                  | Deja una nota o tarea en una delegación.              |
+| `GET`    | `/avisos/{id}`             | Un aviso.                                             |
+| `PATCH`  | `/avisos/{id}`             | Edita el texto o lo marca como hecho.                 |
+| `DELETE` | `/avisos/{id}`             | Lo borra.                                             |
+| `POST`   | `/avisos/{id}/notificar`   | Lo envía (o reenvía) por correo.                      |
+
+```bash
+curl -X POST -H "x-api-key: TU_CLAVE" -H "Content-Type: application/json" \
+  -d '{"delegacion":"Sevilla","tipo":"tarea","contenido":"Falta la factura de la luz de octubre","notificar":true}' \
+  https://TU-DOMINIO/api/v1/avisos
+```
+
+Con `"notificar": true` se envía además por correo a quien corresponda (tesoreros de la delegación o gestores centrales, según el destinatario), nunca al autor. Si el correo falla, **el aviso ya está guardado** y la respuesta lo explica en `aviso_notificacion`.
+
+### Archivos
+
+| Método   | Ruta                          | Qué hace                                    |
+| -------- | ----------------------------- | ------------------------------------------- |
+| `GET`    | `/archivos/{id}`              | Metadatos y a qué está asociado.            |
+| `GET`    | `/archivos/{id}/url`          | URL firmada temporal (por defecto 5 min).   |
+| `GET`    | `/archivos/{id}/descargar`    | Redirige (302) al fichero.                  |
+| `DELETE` | `/archivos/{id}`              | Lo borra (registro y fichero).              |
+
+{% hint style="warning" %}
+El campo `url` de cada adjunto es la URL pública heredada y **está vacía** en los archivos subidos desde que la aplicación pasó a URLs firmadas. Usa `url_descarga`, que apunta a `/api/v1/archivos/{id}/descargar` y funciona siempre.
+{% endhint %}
+
+### Resumen económico
+
+```
+GET /api/v1/resumen?desde=2026-01-01&hasta=2026-12-31
+```
+
+Ingresos, gastos, neto y saldo **por delegación**, desglose por categoría y cuántas facturas y avisos tiene pendientes cada una. Es la forma rápida de responder "¿cómo van todas las delegaciones este año?".
+
+El saldo suma todo el histórico de las cuentas activas (incluidos los movimientos ignorados, porque el saldo refleja el extracto del banco); los ingresos y gastos sí respetan el rango de fechas y excluyen los ignorados.
+
+### Errores
+
+| Código | Significado                                                    |
+| ------ | -------------------------------------------------------------- |
+| `400`  | Petición mal formada, o un nombre ambiguo (mira `detalles`).   |
+| `401`  | Falta la clave o no es válida.                                 |
+| `403`  | Clave de solo lectura en una operación de escritura.           |
+| `404`  | No existe.                                                     |
+| `409`  | Conflicto (p. ej. el movimiento ya tiene otra factura).        |
+| `500`  | Error del servidor (o la API no está configurada).             |
 
 Formato de error:
 
 ```json
-{ "ok": false, "error": "Movimiento no encontrado." }
+{
+  "ok": false,
+  "error": "\"norte\" coincide con 2 delegaciones. Concreta cuál usando el nombre completo o el id.",
+  "detalles": { "candidatos": [ { "id": "…", "nombre": "Sevilla Norte" }, { "id": "…", "nombre": "Madrid Norte" } ] }
+}
 ```
+
+{% hint style="success" %}
+Los mensajes de error están escritos para que los lea una persona **o un modelo**: dicen qué falta y, cuando aplica, traen en `detalles` los valores válidos o los candidatos entre los que elegir. Casi siempre puedes corregir la llamada sin consultar la documentación.
+{% endhint %}
 
 ### Ejemplos de uso
 
 {% tabs %}
 {% tab title="curl" %}
 ```bash
+# Un movimiento concreto
 curl -H "x-api-key: TU_CLAVE" \
   https://TU-DOMINIO/api/v1/movimientos/9f1c0000-0000-0000-0000-000000000000
+
+# Todos los gastos de más de 500 € del año, en cualquier delegación
+curl -H "x-api-key: TU_CLAVE" \
+  "https://TU-DOMINIO/api/v1/movimientos?tipo=gasto&importe_min=500&fecha_desde=2026-01-01&orden=importe_asc"
+
+# Qué tiene pendiente cada delegación
+curl -H "x-api-key: TU_CLAVE" https://TU-DOMINIO/api/v1/avisos
 ```
 {% endtab %}
 
 {% tab title="Google Apps Script" %}
 ```javascript
 const BASE = "https://TU-DOMINIO/api/v1";
-const API_KEY = "TU_CLAVE"; // mejor en PropertiesService
+const API_KEY = PropertiesService.getScriptProperties().getProperty("MCM_API_KEY");
 
-/** Devuelve el movimiento completo (datos + archivos). */
-function getMovimiento(id) {
-  const res = UrlFetchApp.fetch(`${BASE}/movimientos/${id}`, {
-    method: "get",
-    headers: { "x-api-key": API_KEY },
+function llamar(ruta, opciones = {}) {
+  const res = UrlFetchApp.fetch(`${BASE}${ruta}`, {
+    method: opciones.method || "get",
+    headers: { "x-api-key": API_KEY, "Content-Type": "application/json" },
+    payload: opciones.payload ? JSON.stringify(opciones.payload) : undefined,
     muteHttpExceptions: true,
   });
   const body = JSON.parse(res.getContentText());
-  if (res.getResponseCode() !== 200 || !body.ok) {
-    throw new Error(body.error || "Error consultando el movimiento");
-  }
-  return body.movimiento;
+  if (!body.ok) throw new Error(body.error || "Error llamando a MCM Bank");
+  return body;
 }
 
-/** Descarga la primera factura de un movimiento a una carpeta de Drive. */
+/** Vuelca en la hoja los gastos de un proveedor en todas las delegaciones. */
+function volcarGastos(proveedor) {
+  const { movimientos, resumen } = llamar(
+    `/movimientos?texto=${encodeURIComponent(proveedor)}&tipo=gasto&limite=200`
+  );
+
+  const hoja = SpreadsheetApp.getActiveSheet();
+  hoja.clear();
+  hoja.appendRow(["Fecha", "Delegación", "Concepto", "Importe"]);
+  movimientos.forEach((m) =>
+    hoja.appendRow([m.fecha, m.delegacion?.nombre, m.concepto, m.importe])
+  );
+  hoja.appendRow(["", "", "TOTAL", resumen.gastos]);
+}
+
+/** Descarga las facturas de un movimiento a Drive. */
 function descargarFacturas(id) {
-  const mov = getMovimiento(id);
-  mov.archivos.forEach((archivo) => {
-    const blob = UrlFetchApp.fetch(archivo.url).getBlob();
+  const { movimiento } = llamar(`/movimientos/${id}`);
+  movimiento.archivos.forEach((archivo) => {
+    const blob = UrlFetchApp.fetch(archivo.url_descarga, {
+      headers: { "x-api-key": API_KEY },
+    }).getBlob();
     blob.setName(archivo.nombre_original);
     DriveApp.createFile(blob);
   });
 }
 
-function ejemplo() {
-  const mov = getMovimiento("9f1c0000-0000-0000-0000-000000000000");
-  Logger.log(`${mov.fecha} · ${mov.concepto} · ${mov.importe} €`);
+/** Deja una tarea a una delegación. */
+function pedirFactura(delegacion, texto) {
+  llamar("/avisos", {
+    method: "post",
+    payload: { delegacion, tipo: "tarea", contenido: texto, notificar: true },
+  });
 }
 ```
 {% endtab %}
 {% endtabs %}
 
 {% hint style="success" %}
-Recomendación: guarda la clave con `PropertiesService.getScriptProperties().getProperty("MCM_API_KEY")` en lugar de escribirla directamente en el código.
+Recomendación: guarda la clave con `PropertiesService.getScriptProperties()` en lugar de escribirla directamente en el código.
 {% endhint %}

--- a/docs/manual/22.-servidor-mcp.md
+++ b/docs/manual/22.-servidor-mcp.md
@@ -1,0 +1,179 @@
+---
+icon: robot
+---
+
+# 22. Servidor MCP \[solo pros]
+
+MCM Bank tiene un **servidor MCP**: una forma de conectarlo a Claude (o a cualquier asistente compatible) para trabajar con la tesorería **hablando normal**, sin abrir la aplicación ni escribir código.
+
+{% hint style="success" %}
+Cosas que puedes pedirle tal cual:
+
+* «Búscame los movimientos de Mercadona de más de 50 € en todas las delegaciones»
+* «¿Cómo va cada delegación este año? Dame ingresos, gastos y saldo»
+* «Deja una tarea a Sevilla: falta la factura de la luz de octubre, y avísales por correo»
+* «Sube esta factura y vincúlala con el movimiento del 4 de marzo»
+* «Toma estos doce importes de facturas, dime a qué movimiento corresponde cada uno»
+{% endhint %}
+
+{% hint style="warning" %}
+Es una herramienta de **oficina técnica**: ve y modifica **todas** las delegaciones. La clave que se use aquí da acceso completo, así que no se comparte con las delegaciones.
+{% endhint %}
+
+## Qué es MCP, en dos líneas
+
+MCP (*Model Context Protocol*) es un estándar para que un asistente de IA pueda usar herramientas de verdad —consultar, crear, modificar— en vez de limitarse a conversar. MCM Bank publica sus operaciones como herramientas MCP; el asistente elige cuál usar según lo que le pidas.
+
+## Conectarlo
+
+La dirección del servidor es:
+
+```
+https://TU-DOMINIO/api/mcp
+```
+
+Y se autentica con la misma clave que la API externa (ver **[21. API externa](21.-api-externa-solo-pros.md)**).
+
+{% tabs %}
+{% tab title="Claude Code" %}
+```bash
+claude mcp add --transport http mcm-bank https://TU-DOMINIO/api/mcp \
+  --header "Authorization: Bearer TU_CLAVE"
+```
+
+Para que las notas y facturas que cree salgan firmadas con tu cuenta, añade tu correo:
+
+```bash
+claude mcp add --transport http mcm-bank https://TU-DOMINIO/api/mcp \
+  --header "Authorization: Bearer TU_CLAVE" \
+  --header "x-mcm-usuario-email: tu.correo@movimientoconsolacion.com"
+```
+{% endtab %}
+
+{% tab title="Claude Desktop" %}
+En la configuración de MCP servers (`claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "mcm-bank": {
+      "command": "npx",
+      "args": [
+        "-y", "mcp-remote",
+        "https://TU-DOMINIO/api/mcp",
+        "--header", "Authorization: Bearer TU_CLAVE",
+        "--header", "x-mcm-usuario-email: tu.correo@movimientoconsolacion.com"
+      ]
+    }
+  }
+}
+```
+
+`mcp-remote` es un puente que traduce la conexión HTTP a lo que espera la aplicación de escritorio.
+{% endtab %}
+
+{% tab title="Comprobar que responde" %}
+```bash
+curl -s -X POST https://TU-DOMINIO/api/mcp \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer TU_CLAVE" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | head -c 400
+```
+
+Si ves una lista de herramientas, está listo. Si ves `401`, la clave no es correcta.
+{% endtab %}
+{% endtabs %}
+
+### Clave de solo lectura
+
+Si quieres conectarlo para consultar sin riesgo de que modifique nada, usa la clave de `MCM_API_KEY_READONLY`. Las herramientas de escritura seguirán apareciendo, pero al intentar usarlas el asistente recibirá un aviso claro de que su clave no puede escribir — y te lo dirá.
+
+## Qué sabe hacer
+
+### Consultar
+
+| Herramienta | Para qué |
+| ----------- | -------- |
+| `buscar_movimientos` | Buscar en una, varias o todas las delegaciones por texto, importe, fecha, categoría, cuenta, con o sin factura… Devuelve también el total gastado del conjunto encontrado. |
+| `obtener_movimiento` | Un movimiento completo con sus archivos. |
+| `resumen_economico` | Ingresos, gastos, neto y saldo por delegación, con desglose por categoría y pendientes. |
+| `buscar_facturas` | La bandeja de facturas, con lo pagado y lo pendiente de cada una. |
+| `obtener_factura` | Una factura con sus movimientos y archivos. |
+| `listar_avisos` | Las notas y tareas pendientes de todas las delegaciones. |
+| `listar_delegaciones`, `listar_cuentas`, `listar_categorias`, `listar_contactos`, `listar_pagos_mcm` | Catálogos de referencia. |
+| `obtener_url_archivo` | Un enlace temporal para abrir o leer una factura ya subida. |
+
+### Conciliar facturas
+
+| Herramienta | Para qué |
+| ----------- | -------- |
+| `buscar_movimiento_de_factura` | Dado el importe (y si se sabe, la fecha y el proveedor) de una factura, propone los movimientos que mejor encajan, con los motivos. |
+| `buscar_factura_de_movimiento` | El camino inverso. |
+| `conciliar_facturas` | Un lote entero de golpe. Propone por defecto; con permiso explícito, vincula los casos claros. |
+
+### Modificar
+
+| Herramienta | Para qué |
+| ----------- | -------- |
+| `actualizar_movimiento` | Categoría, contacto, notas, si se ignora, si le falta la factura. |
+| `crear_aviso`, `actualizar_aviso`, `notificar_aviso`, `eliminar_aviso` | El canal de comunicación con las delegaciones. |
+| `crear_factura`, `actualizar_factura`, `eliminar_factura` | La bandeja de facturas. |
+| `vincular_factura`, `desvincular_factura` | Conciliación de una en una. |
+| `subir_archivo` | Sube una factura o documento y lo adjunta a un movimiento o a una factura. |
+| `eliminar_archivo` | Borra un adjunto. |
+
+{% hint style="info" %}
+**Lo que NO puede tocar:** importe, fecha, cuenta y delegación de un movimiento. Vienen del banco, y cambiarlos desde fuera sería una forma silenciosa de descuadrar la contabilidad. Tampoco puede dar de alta contactos ni pagos MCM: esas altas tienen reglas propias que se hacen mejor desde la pantalla.
+{% endhint %}
+
+## Cómo trabajar bien con él
+
+{% stepper %}
+{% step %}
+### Habla en tus términos
+
+No hace falta que sepas ningún identificador. «Sevilla», «la delegación de Madrid», «Alimentación» — se entienden. Si un nombre es ambiguo, el asistente te preguntará entre cuáles elegir.
+{% endstep %}
+
+{% step %}
+### Revisa antes de aplicar
+
+En la conciliación en bloque, pídele primero las propuestas, míralas, y solo entonces dile que las aplique. Él ya tiene instrucciones de trabajar así, pero conviene saberlo.
+{% endstep %}
+
+{% step %}
+### Firma con tu cuenta
+
+Si has configurado tu correo al conectarlo, las notas y facturas que cree aparecerán a tu nombre. Si no, saldrán a nombre de la cuenta técnica configurada en el servidor.
+{% endstep %}
+
+{% step %}
+### Ojo con los borrados
+
+No hay papelera. Si le pides borrar algo, pregúntate antes si no bastaba con marcarlo como hecho o archivarlo.
+{% endstep %}
+{% endstepper %}
+
+## Configuración en el servidor
+
+Todo esto se configura en las variables de entorno de Vercel:
+
+| Variable | Para qué |
+| -------- | -------- |
+| `MCM_API_KEY` | La clave con permiso de lectura y escritura. **Obligatoria** para poder modificar nada. |
+| `MCM_API_KEY_READONLY` | Clave alternativa de solo consulta (opcional). |
+| `MCM_API_USER_EMAIL` | Correo de la cuenta de MCM Bank que firma las escrituras cuando quien llama no indica la suya. |
+| `MCM_API_USER_ID` | Alternativa a la anterior, con el UUID del usuario. |
+| `RESEND_API_KEY` | Necesaria para que `crear_aviso` pueda enviar el correo. |
+
+{% hint style="warning" %}
+Si no defines `MCM_API_USER_EMAIL` ni `MCM_API_USER_ID`, las herramientas de escritura fallarán con un mensaje explicándolo, salvo que quien llama indique `usuario_email` en cada operación. Es a propósito: preferimos no guardar una nota antes que firmarla con la persona equivocada.
+{% endhint %}
+
+## Detalles técnicos
+
+* Transporte **Streamable HTTP sin estado**: cada petición es un `POST` con un mensaje JSON-RPC 2.0; no hay sesión que mantener, así que funciona igual de bien en una función serverless.
+* Versiones del protocolo soportadas: `2025-06-18`, `2025-03-26` y `2024-11-05`.
+* `GET` sobre `/api/mcp` responde `405`: el servidor no abre canal SSE porque no envía nada por su cuenta.
+* Los errores de una herramienta se devuelven como resultado con `isError`, no como error de protocolo, para que el asistente pueda leerlos y corregirse solo.
+* Por debajo usa exactamente las mismas funciones que la API REST (`lib/api/*`), así que lo que se puede hacer por un lado se puede hacer por el otro.

--- a/lib/api/actor.ts
+++ b/lib/api/actor.ts
@@ -1,0 +1,129 @@
+import type { createAdminClient } from "@/lib/supabase/admin"
+import { ApiError, misconfigured, notFound } from "@/lib/api/errors"
+
+type AdminClient = ReturnType<typeof createAdminClient>
+
+/**
+ * Quién firma las escrituras hechas desde fuera de la app.
+ *
+ * La API externa se autentica con una clave compartida, no con una sesión de
+ * usuario, pero la base de datos sí exige un autor (`aviso.creado_por`,
+ * `movimiento_archivo.subido_por`, `factura.creado_por`…) y las personas que
+ * leen esos avisos quieren ver un nombre, no "sistema". Por eso toda escritura
+ * se atribuye a un usuario real:
+ *
+ *   1. `usuario_id` / `usuario_email` que llegue en la propia llamada
+ *      (el admin multidelegación puede firmar con su cuenta), o
+ *   2. las variables de entorno `MCM_API_USER_ID` / `MCM_API_USER_EMAIL`
+ *      (la cuenta "oficina técnica" que firma por defecto).
+ *
+ * Si no hay ninguna de las dos, la escritura falla con un mensaje que explica
+ * exactamente qué configurar. Nunca se elige un usuario "cualquiera": una nota
+ * firmada por la persona equivocada es peor que una nota que no se guarda.
+ */
+
+export interface Actor {
+  id: string
+  nombre: string | null
+  email: string | null
+}
+
+/** Pistas de autoría que puede enviar el cliente en cada escritura. */
+export interface ActorHint {
+  usuario_id?: string | null
+  usuario_email?: string | null
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+export function esUuid(valor: unknown): valor is string {
+  return typeof valor === "string" && UUID_RE.test(valor)
+}
+
+/**
+ * Cache de email → usuario. `auth.admin.listUsers` es una llamada cara (lista
+ * todos los usuarios), así que se memoriza durante la vida del proceso; los
+ * emails de una cuenta cambian muy rara vez y un fallo de cache solo implica
+ * un error "no encontrado" que se resuelve en el siguiente arranque.
+ */
+let usuariosCache: { cargadoEn: number; porEmail: Map<string, Actor>; porId: Map<string, Actor> } | null =
+  null
+const USUARIOS_TTL_MS = 5 * 60 * 1000
+
+async function cargarUsuarios(admin: AdminClient) {
+  if (usuariosCache && Date.now() - usuariosCache.cargadoEn < USUARIOS_TTL_MS) {
+    return usuariosCache
+  }
+
+  const { data, error } = await admin.auth.admin.listUsers({ perPage: 1000 })
+  if (error) {
+    throw new ApiError(500, `No se pudo consultar la lista de usuarios: ${error.message}`)
+  }
+
+  const porEmail = new Map<string, Actor>()
+  const porId = new Map<string, Actor>()
+  for (const u of data?.users ?? []) {
+    const actor: Actor = { id: u.id, email: u.email ?? null, nombre: null }
+    porId.set(u.id, actor)
+    if (u.email) porEmail.set(u.email.toLowerCase(), actor)
+  }
+
+  usuariosCache = { cargadoEn: Date.now(), porEmail, porId }
+  return usuariosCache
+}
+
+/** Completa el nombre del actor desde `perfil` (decorativo: no bloquea). */
+async function conNombre(admin: AdminClient, actor: Actor): Promise<Actor> {
+  const { data } = await (admin as any)
+    .from("perfil")
+    .select("nombre_completo")
+    .eq("usuario_id", actor.id)
+    .maybeSingle()
+  return { ...actor, nombre: data?.nombre_completo?.trim() || null }
+}
+
+/**
+ * Resuelve el usuario al que se atribuyen las escrituras de esta llamada.
+ * Lanza `ApiError` con instrucciones concretas si no hay forma de determinarlo.
+ */
+export async function resolveActor(admin: AdminClient, hint?: ActorHint): Promise<Actor> {
+  const idExplicito = hint?.usuario_id?.trim() || process.env.MCM_API_USER_ID?.trim() || null
+  const emailExplicito =
+    hint?.usuario_email?.trim() || process.env.MCM_API_USER_EMAIL?.trim() || null
+
+  if (idExplicito) {
+    if (!esUuid(idExplicito)) {
+      throw new ApiError(400, `'${idExplicito}' no es un UUID de usuario válido.`)
+    }
+    const { porId } = await cargarUsuarios(admin)
+    const actor = porId.get(idExplicito)
+    if (!actor) {
+      throw notFound(
+        `No existe ningún usuario con el id ${idExplicito}. Comprueba MCM_API_USER_ID o el 'usuario_id' que has enviado.`,
+      )
+    }
+    return conNombre(admin, actor)
+  }
+
+  if (emailExplicito) {
+    const { porEmail } = await cargarUsuarios(admin)
+    const actor = porEmail.get(emailExplicito.toLowerCase())
+    if (!actor) {
+      throw notFound(
+        `No hay ningún usuario de MCM Bank con el correo ${emailExplicito}. Comprueba MCM_API_USER_EMAIL o el 'usuario_email' que has enviado.`,
+      )
+    }
+    return conNombre(admin, actor)
+  }
+
+  throw misconfigured(
+    "Esta operación necesita saber a qué usuario atribuirla y el servidor no tiene autor por defecto. " +
+      "Define la variable de entorno MCM_API_USER_ID (o MCM_API_USER_EMAIL) con la cuenta de la oficina técnica, " +
+      "o envía 'usuario_email' en la propia llamada para firmarla con tu cuenta.",
+  )
+}
+
+/** Nombre legible del actor (para textos y respuestas). */
+export function nombreActor(actor: Actor): string {
+  return actor.nombre || actor.email || actor.id
+}

--- a/lib/api/archivos.ts
+++ b/lib/api/archivos.ts
@@ -1,0 +1,606 @@
+import type { createAdminClient } from "@/lib/supabase/admin"
+import { ApiError, badRequest, notFound, unwrap, wrapSupabaseError } from "@/lib/api/errors"
+import { serializeArchivo, type ArchivoPublico } from "@/lib/api/movimientos-public"
+
+type AdminClient = ReturnType<typeof createAdminClient>
+
+/**
+ * Subida y descarga de archivos (facturas y documentos) desde la API externa.
+ *
+ * Replica exactamente lo que hace la app en el navegador
+ * (`lib/services/file-service.ts` + `hooks/use-movimiento-archivos.ts`): mismo
+ * bucket, misma estructura de carpetas y mismos registros en base de datos, de
+ * modo que un archivo subido por la API se ve igual que uno subido a mano.
+ */
+
+export type BucketArchivo = "facturas" | "documentos"
+
+export const BUCKETS: readonly BucketArchivo[] = ["facturas", "documentos"] as const
+
+const MIME_PERMITIDOS: Record<BucketArchivo, string[]> = {
+  facturas: [
+    "application/pdf",
+    "image/jpeg",
+    "image/jpg",
+    "image/png",
+    "image/gif",
+    "image/webp",
+    "application/vnd.ms-excel",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "application/msword",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "text/plain",
+    "text/csv",
+  ],
+  documentos: [
+    "application/pdf",
+    "image/jpeg",
+    "image/jpg",
+    "image/png",
+    "image/gif",
+    "image/webp",
+    "application/vnd.ms-excel",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "application/msword",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "text/plain",
+    "text/csv",
+    "application/zip",
+    "application/x-rar-compressed",
+    "video/mp4",
+    "audio/mpeg",
+    "audio/wav",
+  ],
+}
+
+/**
+ * Tope de tamaño para subidas por API. La app permite 20 MB, pero una función
+ * serverless de Vercel rechaza cuerpos de petición de más de ~4,5 MB, y en
+ * base64 un archivo ocupa un 33 % más. 3 MB de archivo real caben con margen;
+ * por encima de eso, hay que subirlo desde la app.
+ */
+export const MAX_BYTES_API = 3 * 1024 * 1024
+
+const EXTENSION_A_MIME: Record<string, string> = {
+  pdf: "application/pdf",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  png: "image/png",
+  gif: "image/gif",
+  webp: "image/webp",
+  xls: "application/vnd.ms-excel",
+  xlsx: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  doc: "application/msword",
+  docx: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  txt: "text/plain",
+  csv: "text/csv",
+  zip: "application/zip",
+  mp4: "video/mp4",
+  mp3: "audio/mpeg",
+  wav: "audio/wav",
+}
+
+const MESES = ["ene", "feb", "mar", "abr", "may", "jun", "jul", "ago", "sep", "oct", "nov", "dic"]
+
+function mimeDesdeNombre(nombre: string): string | null {
+  const ext = nombre.split(".").pop()?.toLowerCase()
+  return (ext && EXTENSION_A_MIME[ext]) || null
+}
+
+function limpiarNombre(nombre: string): string {
+  const limpio = nombre.replace(/[^a-zA-Z0-9.-]/g, "_")
+  return limpio || "archivo"
+}
+
+/** Decodifica el contenido base64 (admite data URLs `data:...;base64,XXXX`). */
+function decodificarBase64(contenido: string): Buffer {
+  const limpio = contenido.includes(",") && contenido.trimStart().startsWith("data:")
+    ? contenido.slice(contenido.indexOf(",") + 1)
+    : contenido
+  const buffer = Buffer.from(limpio.replace(/\s+/g, ""), "base64")
+  if (buffer.length === 0) {
+    throw badRequest("El contenido en base64 está vacío o no es base64 válido.")
+  }
+  return buffer
+}
+
+export interface ArchivoEntrante {
+  /** Nombre con extensión, tal y como debe verse en la app. */
+  nombre: string
+  /** Contenido del fichero codificado en base64 (admite data URL). */
+  contenido_base64: string
+  /** Si no se indica, se deduce de la extensión del nombre. */
+  tipo_mime?: string | null
+  descripcion?: string | null
+  /** `facturas` (por defecto) o `documentos`. */
+  bucket?: BucketArchivo | null
+}
+
+interface ArchivoValidado {
+  nombreOriginal: string
+  nombreLimpio: string
+  bucket: BucketArchivo
+  mime: string
+  buffer: Buffer
+  descripcion: string | null
+}
+
+function validarArchivo(entrada: ArchivoEntrante): ArchivoValidado {
+  const nombreOriginal = (entrada.nombre ?? "").trim()
+  if (!nombreOriginal) throw badRequest("Falta el nombre del archivo (con su extensión).")
+
+  const bucket = (entrada.bucket ?? "facturas") as BucketArchivo
+  if (!BUCKETS.includes(bucket)) {
+    throw badRequest(`Bucket '${bucket}' no válido. Usa 'facturas' o 'documentos'.`)
+  }
+
+  const mime = (entrada.tipo_mime?.trim() || mimeDesdeNombre(nombreOriginal) || "").toLowerCase()
+  if (!mime) {
+    throw badRequest(
+      `No sé qué tipo de archivo es '${nombreOriginal}'. Añade la extensión al nombre o indica 'tipo_mime'.`,
+    )
+  }
+  if (!MIME_PERMITIDOS[bucket].includes(mime)) {
+    throw badRequest(`Tipo de archivo no permitido en '${bucket}': ${mime}.`, {
+      permitidos: MIME_PERMITIDOS[bucket],
+    })
+  }
+
+  const buffer = decodificarBase64(entrada.contenido_base64 ?? "")
+  if (buffer.length > MAX_BYTES_API) {
+    throw badRequest(
+      `El archivo ocupa ${(buffer.length / 1024 / 1024).toFixed(1)} MB y por API el máximo son ${(
+        MAX_BYTES_API /
+        1024 /
+        1024
+      ).toFixed(0)} MB. Súbelo desde la aplicación (allí el límite es 20 MB).`,
+    )
+  }
+
+  return {
+    nombreOriginal,
+    nombreLimpio: limpiarNombre(nombreOriginal),
+    bucket,
+    mime,
+    buffer,
+    descripcion: entrada.descripcion?.trim() || null,
+  }
+}
+
+/**
+ * Sube el fichero a Storage con la misma estructura de carpetas que la app:
+ * `<delegacion>/<año>/<mes>/<scope>/<id>/<archivo>`. Si ya existe un fichero
+ * con ese nombre, añade un sufijo en vez de sobrescribir (el original puede ser
+ * la factura buena de otro adjunto).
+ */
+async function subirAStorage(
+  admin: AdminClient,
+  archivo: ArchivoValidado,
+  carpeta: string,
+): Promise<string> {
+  const base = archivo.nombreLimpio
+  const punto = base.lastIndexOf(".")
+  const raiz = punto > 0 ? base.slice(0, punto) : base
+  const extension = punto > 0 ? base.slice(punto) : ""
+
+  for (let intento = 0; intento < 5; intento += 1) {
+    const nombre = intento === 0 ? base : `${raiz}-${intento + 1}${extension}`
+    const path = `${carpeta}/${nombre}`
+    const { data, error } = await admin.storage
+      .from(archivo.bucket)
+      .upload(path, archivo.buffer, { contentType: archivo.mime, cacheControl: "3600", upsert: false })
+
+    if (!error && data) return data.path
+
+    const mensaje = String((error as any)?.message ?? "")
+    const yaExiste = /exists|duplicate/i.test(mensaje)
+    if (!yaExiste) {
+      throw new ApiError(502, `No se pudo subir el archivo a Storage: ${mensaje || "error desconocido"}`)
+    }
+  }
+
+  throw new ApiError(
+    409,
+    `Ya hay varios archivos llamados '${archivo.nombreOriginal}' en esa carpeta. Cambia el nombre.`,
+  )
+}
+
+function carpetaFecha(): string {
+  const ahora = new Date()
+  return `${ahora.getFullYear()}/${MESES[ahora.getMonth()]}`
+}
+
+export interface ResultadoSubida {
+  archivo: ArchivoPublico
+  /** Factura creada o reutilizada cuando el adjunto es una factura. */
+  factura_id?: string | null
+  aviso?: string
+}
+
+/**
+ * Adjunta un archivo a un movimiento.
+ *
+ * Si el bucket es `facturas`, replica el comportamiento de la app: además del
+ * adjunto crea (o reutiliza) la entidad `factura` al otro lado, ya conciliada
+ * con este movimiento y con sus datos. Es lo que hace que "sube esta factura y
+ * vincúlala al movimiento X" sea una sola operación.
+ */
+export async function subirArchivoAMovimiento(
+  admin: AdminClient,
+  params: {
+    movimientoId: string
+    archivo: ArchivoEntrante
+    /** Crear también la entidad factura (por defecto sí, si el bucket es `facturas`). */
+    crearFactura?: boolean
+    actorId: string
+    baseUrl?: string
+  },
+): Promise<ResultadoSubida> {
+  const validado = validarArchivo(params.archivo)
+
+  const movimiento = unwrap(
+    await (admin as any)
+      .from("movimiento")
+      .select("id, delegacion_id, fecha, concepto, importe, contacto_id, factura_id")
+      .eq("id", params.movimientoId)
+      .maybeSingle(),
+  ) as any
+  if (!movimiento) {
+    throw notFound(`No existe ningún movimiento con el id ${params.movimientoId}.`)
+  }
+  if (!movimiento.delegacion_id) {
+    throw badRequest("Ese movimiento no tiene delegación asignada, así que no sé dónde guardar el archivo.")
+  }
+
+  const codigo = await codigoDelegacion(admin, movimiento.delegacion_id)
+  const path = await subirAStorage(
+    admin,
+    validado,
+    `${codigo}/${carpetaFecha()}/${params.movimientoId}`,
+  )
+
+  const fila = unwrap(
+    await (admin as any)
+      .from("movimiento_archivo")
+      .upsert(
+        [
+          {
+            movimiento_id: params.movimientoId,
+            nombre_original: validado.nombreOriginal,
+            nombre_archivo: path.split("/").pop() || validado.nombreLimpio,
+            tipo_mime: validado.mime,
+            "tamaño_bytes": validado.buffer.length,
+            bucket: validado.bucket,
+            path_storage: path,
+            url_publica: "",
+            es_factura: validado.bucket === "facturas",
+            descripcion: validado.descripcion,
+            subido_por: params.actorId,
+          },
+        ],
+        { onConflict: "movimiento_id,path_storage" },
+      )
+      .select()
+      .single(),
+  ) as any
+
+  const resultado: ResultadoSubida = {
+    archivo: serializeArchivo(fila, { baseUrl: params.baseUrl }),
+    factura_id: movimiento.factura_id ?? null,
+  }
+
+  const debeCrearFactura =
+    validado.bucket === "facturas" && params.crearFactura !== false
+  if (debeCrearFactura) {
+    try {
+      const factura = await asegurarFacturaDeMovimiento(admin, params.movimientoId, params.actorId)
+      await registrarArchivoEnFactura(admin, factura.id, movimiento.delegacion_id, {
+        nombre_original: validado.nombreOriginal,
+        nombre_archivo: fila.nombre_archivo,
+        tipo_mime: validado.mime,
+        tamano_bytes: validado.buffer.length,
+        bucket: validado.bucket,
+        path_storage: path,
+        url_publica: "",
+        descripcion: validado.descripcion,
+        subido_por: params.actorId,
+      })
+      resultado.factura_id = factura.id
+    } catch (err) {
+      // El adjunto ya está guardado: no se tira la subida porque falle el
+      // registro en la sección Facturas, pero sí se avisa.
+      resultado.aviso = `El archivo se subió, pero no se pudo registrar en la sección Facturas: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    }
+  }
+
+  return resultado
+}
+
+/** Adjunta un archivo a una factura de la bandeja (entidad `factura`). */
+export async function subirArchivoAFactura(
+  admin: AdminClient,
+  params: { facturaId: string; archivo: ArchivoEntrante; actorId: string; baseUrl?: string },
+): Promise<ResultadoSubida> {
+  const validado = validarArchivo(params.archivo)
+
+  const factura = unwrap(
+    await (admin as any)
+      .from("factura")
+      .select("id, delegacion_id")
+      .eq("id", params.facturaId)
+      .maybeSingle(),
+  ) as any
+  if (!factura) throw notFound(`No existe ninguna factura con el id ${params.facturaId}.`)
+
+  const codigo = await codigoDelegacion(admin, factura.delegacion_id)
+  const path = await subirAStorage(
+    admin,
+    validado,
+    `${codigo}/${carpetaFecha()}/factura/${params.facturaId}`,
+  )
+
+  const fila = unwrap(
+    await (admin as any)
+      .from("archivo_adjunto")
+      .upsert(
+        [
+          {
+            entidad: "factura",
+            entidad_id: params.facturaId,
+            delegacion_id: factura.delegacion_id,
+            nombre_original: validado.nombreOriginal,
+            nombre_archivo: path.split("/").pop() || validado.nombreLimpio,
+            tipo_mime: validado.mime,
+            tamano_bytes: validado.buffer.length,
+            bucket: validado.bucket,
+            path_storage: path,
+            url_publica: "",
+            es_factura: true,
+            descripcion: validado.descripcion,
+            subido_por: params.actorId,
+          },
+        ],
+        { onConflict: "entidad,entidad_id,path_storage" },
+      )
+      .select()
+      .single(),
+  ) as any
+
+  // Si la factura ya está conciliada con movimientos, el adjunto nuevo se
+  // replica en ellos para que se vea desde ambos lados.
+  const movimientos = (unwrap(
+    await (admin as any).from("movimiento").select("id").eq("factura_id", params.facturaId),
+  ) ?? []) as { id: string }[]
+  for (const mov of movimientos) {
+    await replicarArchivoEnMovimiento(admin, mov.id, fila, params.actorId).catch(() => undefined)
+  }
+
+  return { archivo: serializeArchivo(fila, { baseUrl: params.baseUrl }), factura_id: params.facturaId }
+}
+
+/** Archivos de una factura (tabla `archivo_adjunto`). */
+export async function listarArchivosFactura(
+  admin: AdminClient,
+  facturaId: string,
+  options: { baseUrl?: string } = {},
+): Promise<ArchivoPublico[]> {
+  const filas = (unwrap(
+    await (admin as any)
+      .from("archivo_adjunto")
+      .select("*")
+      .eq("entidad", "factura")
+      .eq("entidad_id", facturaId)
+      .order("subido_en", { ascending: true }),
+  ) ?? []) as any[]
+  return filas.map((f) => serializeArchivo(f, { baseUrl: options.baseUrl }))
+}
+
+/** Archivos de varias facturas a la vez, agrupados por factura. */
+export async function archivosDeFacturas(
+  admin: AdminClient,
+  facturaIds: string[],
+  options: { baseUrl?: string } = {},
+): Promise<Map<string, ArchivoPublico[]>> {
+  const agrupados = new Map<string, ArchivoPublico[]>()
+  if (facturaIds.length === 0) return agrupados
+
+  const filas = (unwrap(
+    await (admin as any)
+      .from("archivo_adjunto")
+      .select("*")
+      .eq("entidad", "factura")
+      .in("entidad_id", facturaIds)
+      .order("subido_en", { ascending: true }),
+  ) ?? []) as any[]
+
+  for (const fila of filas) {
+    const lista = agrupados.get(fila.entidad_id) ?? []
+    lista.push(serializeArchivo(fila, { baseUrl: options.baseUrl }))
+    agrupados.set(fila.entidad_id, lista)
+  }
+  return agrupados
+}
+
+/** Copia un adjunto de factura en `movimiento_archivo` (mismo path de Storage). */
+export async function replicarArchivoEnMovimiento(
+  admin: AdminClient,
+  movimientoId: string,
+  adjunto: any,
+  actorId: string,
+): Promise<void> {
+  const { error } = await (admin as any).from("movimiento_archivo").upsert(
+    [
+      {
+        movimiento_id: movimientoId,
+        nombre_original: adjunto.nombre_original,
+        nombre_archivo: adjunto.nombre_archivo,
+        tipo_mime: adjunto.tipo_mime,
+        "tamaño_bytes": adjunto.tamano_bytes ?? adjunto["tamaño_bytes"] ?? 0,
+        bucket: adjunto.bucket,
+        path_storage: adjunto.path_storage,
+        url_publica: adjunto.url_publica ?? "",
+        es_factura: true,
+        descripcion: adjunto.descripcion ?? null,
+        subido_por: adjunto.subido_por ?? actorId,
+      },
+    ],
+    { onConflict: "movimiento_id,path_storage", ignoreDuplicates: true },
+  )
+  if (error) throw wrapSupabaseError(error)
+}
+
+/** Registra en `archivo_adjunto` un archivo ya subido a Storage. Idempotente. */
+export async function registrarArchivoEnFactura(
+  admin: AdminClient,
+  facturaId: string,
+  delegacionId: string,
+  archivo: {
+    nombre_original: string
+    nombre_archivo: string
+    tipo_mime: string
+    tamano_bytes: number
+    bucket: string
+    path_storage: string
+    url_publica: string
+    descripcion?: string | null
+    subido_por: string
+  },
+): Promise<void> {
+  const { error } = await (admin as any).from("archivo_adjunto").upsert(
+    [
+      {
+        entidad: "factura",
+        entidad_id: facturaId,
+        delegacion_id: delegacionId,
+        ...archivo,
+        descripcion: archivo.descripcion ?? null,
+        es_factura: true,
+      },
+    ],
+    { onConflict: "entidad,entidad_id,path_storage", ignoreDuplicates: true },
+  )
+  if (error) throw wrapSupabaseError(error)
+}
+
+/**
+ * Crea (si no existe) la entidad `factura` de un movimiento al que se le acaba
+ * de subir una factura, copiando fecha, importe y contacto. Equivalente
+ * servidor de `DatabaseService.ensureFacturaForMovimiento`.
+ */
+export async function asegurarFacturaDeMovimiento(
+  admin: AdminClient,
+  movimientoId: string,
+  actorId: string,
+): Promise<{ id: string }> {
+  const movimiento = unwrap(
+    await (admin as any)
+      .from("movimiento")
+      .select("id, delegacion_id, fecha, concepto, importe, contacto_id, factura_id")
+      .eq("id", movimientoId)
+      .maybeSingle(),
+  ) as any
+  if (!movimiento) throw notFound(`No existe ningún movimiento con el id ${movimientoId}.`)
+
+  if (movimiento.factura_id) {
+    const existente = unwrap(
+      await (admin as any).from("factura").select("id").eq("id", movimiento.factura_id).maybeSingle(),
+    ) as any
+    if (existente) return existente
+  }
+  if (!movimiento.delegacion_id) throw badRequest("El movimiento no tiene delegación.")
+
+  const creada = unwrap(
+    await (admin as any)
+      .from("factura")
+      .insert({
+        delegacion_id: movimiento.delegacion_id,
+        contacto_id: movimiento.contacto_id,
+        concepto: movimiento.concepto,
+        fecha_emision: movimiento.fecha,
+        importe: Math.abs(Number(movimiento.importe)) || null,
+        origen: "movimiento",
+        creado_por: actorId,
+      })
+      .select("id")
+      .single(),
+  ) as any
+
+  const { error } = await (admin as any)
+    .from("movimiento")
+    .update({ factura_id: creada.id })
+    .eq("id", movimientoId)
+  if (error) {
+    await (admin as any).from("factura").delete().eq("id", creada.id)
+    throw wrapSupabaseError(error)
+  }
+
+  return creada
+}
+
+/** Código de la delegación (o su id, si no tiene código) para la ruta de Storage. */
+async function codigoDelegacion(admin: AdminClient, delegacionId: string): Promise<string> {
+  const delegacion = unwrap(
+    await (admin as any).from("delegacion").select("codigo, id").eq("id", delegacionId).maybeSingle(),
+  ) as any
+  const codigo = delegacion?.codigo?.trim()
+  return limpiarNombre(codigo || delegacionId)
+}
+
+// ---------------------------------------------------------------------------
+// Descarga
+// ---------------------------------------------------------------------------
+
+export interface ArchivoLocalizado {
+  fila: any
+  origen: "movimiento" | "factura"
+}
+
+/** Busca un archivo por id en las dos tablas de adjuntos. */
+export async function localizarArchivo(
+  admin: AdminClient,
+  archivoId: string,
+): Promise<ArchivoLocalizado> {
+  const [movimientoArchivo, adjunto] = await Promise.all([
+    (admin as any).from("movimiento_archivo").select("*").eq("id", archivoId).maybeSingle(),
+    (admin as any).from("archivo_adjunto").select("*").eq("id", archivoId).maybeSingle(),
+  ])
+
+  if (movimientoArchivo.data) return { fila: movimientoArchivo.data, origen: "movimiento" }
+  if (adjunto.data) return { fila: adjunto.data, origen: "factura" }
+  throw notFound(`No existe ningún archivo con el id ${archivoId}.`)
+}
+
+/**
+ * URL firmada de descarga. Los buckets `facturas` y `documentos` son públicos
+ * hoy, pero se firma igualmente: es lo que hace la app y lo correcto el día que
+ * dejen de serlo.
+ */
+export async function urlFirmada(
+  admin: AdminClient,
+  bucket: string,
+  path: string,
+  segundos = 300,
+): Promise<string> {
+  const { data, error } = await admin.storage.from(bucket).createSignedUrl(path, segundos)
+  if (error || !data?.signedUrl) {
+    throw new ApiError(502, `No se pudo generar la URL de descarga: ${error?.message ?? "error desconocido"}`)
+  }
+  return data.signedUrl
+}
+
+/** Borra un archivo de Storage y su registro. */
+export async function eliminarArchivo(admin: AdminClient, archivoId: string): Promise<void> {
+  const { fila, origen } = await localizarArchivo(admin, archivoId)
+
+  const { error: storageError } = await admin.storage.from(fila.bucket).remove([fila.path_storage])
+  if (storageError) {
+    // El fichero puede haber desaparecido ya de Storage; el registro sí se limpia.
+    console.warn("No se pudo borrar el fichero de Storage:", storageError.message)
+  }
+
+  const tabla = origen === "movimiento" ? "movimiento_archivo" : "archivo_adjunto"
+  const { error } = await (admin as any).from(tabla).delete().eq("id", archivoId)
+  if (error) throw wrapSupabaseError(error)
+}

--- a/lib/api/avisos.ts
+++ b/lib/api/avisos.ts
@@ -1,0 +1,364 @@
+import type { createAdminClient } from "@/lib/supabase/admin"
+import { badRequest, notFound, unwrap, wrapSupabaseError } from "@/lib/api/errors"
+import {
+  resolveAmbitoDelegaciones,
+  resolveDelegacion,
+  mapaDelegaciones,
+  type DelegacionPublica,
+} from "@/lib/api/delegaciones"
+import { enviarNotificacionAviso } from "@/lib/services/aviso-notificaciones"
+import {
+  AVISO_DESTINATARIOS,
+  AVISO_MAX_CONTENIDO,
+  AVISO_MAX_REFERENCIA,
+  AVISO_TIPOS,
+  type AvisoDestinatario,
+  type AvisoEstado,
+  type AvisoTipo,
+} from "@/lib/types/avisos"
+
+type AdminClient = ReturnType<typeof createAdminClient>
+
+/**
+ * Avisos y tareas: el canal entre la oficina técnica y los tesoreros de cada
+ * delegación.
+ *
+ * Es lo que permite decirle al agente "deja una nota a Sevilla preguntando por
+ * la factura de octubre" y que aparezca en el panel de esa delegación, con
+ * autor y —si se pide— con su correo.
+ *
+ * Un aviso vive siempre dentro de una delegación: el aislamiento entre
+ * delegaciones lo garantiza RLS en la app, y aquí, que se accede con service
+ * role, se respeta filtrando siempre por `delegacion_id`.
+ */
+
+export const AVISO_ESTADOS = ["pendiente", "hecha"] as const
+
+export interface AvisoPublico {
+  id: string
+  tipo: AvisoTipo
+  contenido: string
+  referencia: string | null
+  destinatario: AvisoDestinatario
+  estado: AvisoEstado
+  delegacion: DelegacionPublica | null
+  autor: { id: string; nombre: string | null }
+  completado_por: { id: string; nombre: string | null } | null
+  completado_en: string | null
+  notificado_en: string | null
+  lecturas: number
+  creado_en: string
+  actualizado_en: string
+}
+
+const AVISO_SELECT = `
+  id,
+  delegacion_id,
+  tipo,
+  contenido,
+  referencia,
+  destinatario,
+  estado,
+  completado_por,
+  completado_en,
+  notificado_en,
+  notificado_por,
+  creado_por,
+  creado_en,
+  actualizado_en,
+  lecturas:aviso_lectura ( usuario_id )
+`
+
+/** Nombres de perfil de los usuarios implicados (autores y completadores). */
+async function nombresDePerfil(
+  admin: AdminClient,
+  filas: any[],
+): Promise<Record<string, string>> {
+  const ids = Array.from(
+    new Set(filas.flatMap((f) => [f.creado_por, f.completado_por].filter(Boolean) as string[])),
+  )
+  if (ids.length === 0) return {}
+
+  const { data, error } = await (admin as any)
+    .from("perfil")
+    .select("usuario_id, nombre_completo")
+    .in("usuario_id", ids)
+
+  if (error) {
+    // Los nombres son decorativos: si fallan, se sigue devolviendo el aviso.
+    console.warn("No se pudieron cargar los nombres de perfil:", error.message)
+    return {}
+  }
+
+  return (data ?? []).reduce((acc: Record<string, string>, perfil: any) => {
+    const nombre = perfil?.nombre_completo?.trim()
+    if (nombre) acc[perfil.usuario_id] = nombre
+    return acc
+  }, {})
+}
+
+function serializeAviso(
+  fila: any,
+  nombres: Record<string, string>,
+  delegaciones: Map<string, DelegacionPublica>,
+): AvisoPublico {
+  const lecturas = (fila.lecturas ?? []) as { usuario_id: string }[]
+  return {
+    id: fila.id,
+    tipo: fila.tipo as AvisoTipo,
+    contenido: fila.contenido,
+    referencia: fila.referencia ?? null,
+    destinatario: fila.destinatario as AvisoDestinatario,
+    estado: fila.estado as AvisoEstado,
+    delegacion: delegaciones.get(fila.delegacion_id) ?? null,
+    autor: { id: fila.creado_por, nombre: nombres[fila.creado_por] ?? null },
+    completado_por: fila.completado_por
+      ? { id: fila.completado_por, nombre: nombres[fila.completado_por] ?? null }
+      : null,
+    completado_en: fila.completado_en ?? null,
+    notificado_en: fila.notificado_en ?? null,
+    lecturas: lecturas.filter((l) => l.usuario_id !== fila.creado_por).length,
+    creado_en: fila.creado_en,
+    actualizado_en: fila.actualizado_en,
+  }
+}
+
+export interface ListarAvisosParams {
+  delegaciones?: string | string[] | null
+  estado?: AvisoEstado | "todas" | null
+  tipo?: AvisoTipo | null
+  destinatario?: AvisoDestinatario | null
+  texto?: string | null
+  limite?: number
+}
+
+export async function listarAvisos(
+  admin: AdminClient,
+  params: ListarAvisosParams = {},
+): Promise<{ total: number; avisos: AvisoPublico[] }> {
+  const limite = Math.min(Math.max(params.limite ?? 100, 1), 300)
+  const ambito = await resolveAmbitoDelegaciones(admin, params.delegaciones)
+
+  let query = (admin as any)
+    .from("aviso")
+    .select(AVISO_SELECT, { count: "exact" })
+    .order("creado_en", { ascending: false })
+    .limit(limite)
+
+  if (ambito) query = query.in("delegacion_id", ambito.map((d) => d.id))
+  // Por defecto solo lo que sigue vivo: es lo que se quiere revisar.
+  const estado = params.estado ?? "pendiente"
+  if (estado !== "todas") query = query.eq("estado", estado)
+  if (params.tipo) query = query.eq("tipo", params.tipo)
+  if (params.destinatario) query = query.eq("destinatario", params.destinatario)
+  if (params.texto?.trim()) query = query.ilike("contenido", `%${params.texto.trim()}%`)
+
+  const { data, count, error } = await query
+  if (error) throw wrapSupabaseError(error)
+
+  const filas = (data ?? []) as any[]
+  const [nombres, delegaciones] = await Promise.all([
+    nombresDePerfil(admin, filas),
+    mapaDelegaciones(admin),
+  ])
+
+  return {
+    total: count ?? filas.length,
+    avisos: filas.map((f) => serializeAviso(f, nombres, delegaciones)),
+  }
+}
+
+export async function obtenerAviso(admin: AdminClient, id: string): Promise<AvisoPublico> {
+  const fila = unwrap(
+    await (admin as any).from("aviso").select(AVISO_SELECT).eq("id", id).maybeSingle(),
+  ) as any
+  if (!fila) throw notFound(`No existe ningún aviso con el id ${id}.`)
+
+  const [nombres, delegaciones] = await Promise.all([
+    nombresDePerfil(admin, [fila]),
+    mapaDelegaciones(admin),
+  ])
+  return serializeAviso(fila, nombres, delegaciones)
+}
+
+export interface CrearAvisoParams {
+  delegacion: string
+  contenido: string
+  tipo?: AvisoTipo | null
+  destinatario?: AvisoDestinatario | null
+  referencia?: string | null
+  /** Enviar además el correo a los destinatarios. */
+  notificar?: boolean
+}
+
+export interface CrearAvisoResultado {
+  aviso: AvisoPublico
+  /** Correos a los que se ha avisado, si se pidió notificar. */
+  notificados?: string[]
+  aviso_notificacion?: string
+}
+
+/**
+ * Crea una nota o tarea en una delegación.
+ *
+ * `tipo` por defecto es `nota` y `destinatario` por defecto es `delegacion`,
+ * que es el caso normal de esta API: la oficina técnica dejando un recado a los
+ * tesoreros. Si el correo falla, el aviso ya está guardado y se devuelve con un
+ * texto explicando qué pasó, en lugar de perder la nota.
+ */
+export async function crearAviso(
+  admin: AdminClient,
+  params: CrearAvisoParams,
+  actorId: string,
+): Promise<CrearAvisoResultado> {
+  const delegacion = await resolveDelegacion(admin, params.delegacion)
+
+  const contenido = (params.contenido ?? "").trim()
+  if (!contenido) throw badRequest("El aviso no puede estar vacío.")
+  if (contenido.length > AVISO_MAX_CONTENIDO) {
+    throw badRequest(
+      `El texto ocupa ${contenido.length} caracteres y el máximo son ${AVISO_MAX_CONTENIDO}.`,
+    )
+  }
+
+  const tipo = (params.tipo ?? "nota") as AvisoTipo
+  if (!AVISO_TIPOS.includes(tipo)) {
+    throw badRequest(`Tipo '${tipo}' no válido.`, { tipos_validos: AVISO_TIPOS })
+  }
+
+  const destinatario = (params.destinatario ?? "delegacion") as AvisoDestinatario
+  if (!AVISO_DESTINATARIOS.includes(destinatario)) {
+    throw badRequest(`Destinatario '${destinatario}' no válido.`, {
+      destinatarios_validos: AVISO_DESTINATARIOS,
+    })
+  }
+
+  const referencia = params.referencia?.trim().slice(0, AVISO_MAX_REFERENCIA) || null
+
+  const fila = unwrap(
+    await (admin as any)
+      .from("aviso")
+      .insert({
+        delegacion_id: delegacion.id,
+        tipo,
+        contenido,
+        referencia,
+        destinatario,
+        creado_por: actorId,
+      })
+      .select(AVISO_SELECT)
+      .single(),
+  ) as any
+
+  const resultado: CrearAvisoResultado = { aviso: await hidratar(admin, fila) }
+
+  if (params.notificar) {
+    try {
+      const { destinatarios } = await enviarNotificacionAviso(admin, fila, {
+        marcarNotificadoPor: actorId,
+      })
+      resultado.notificados = destinatarios
+    } catch (err) {
+      resultado.aviso_notificacion = `El aviso se guardó, pero el correo no salió: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    }
+  }
+
+  return resultado
+}
+
+export interface ActualizarAvisoParams {
+  contenido?: string | null
+  referencia?: string | null
+  destinatario?: AvisoDestinatario | null
+  estado?: AvisoEstado | null
+}
+
+export async function actualizarAviso(
+  admin: AdminClient,
+  id: string,
+  cambios: ActualizarAvisoParams,
+  actorId: string,
+): Promise<AvisoPublico> {
+  const existente = unwrap(
+    await (admin as any).from("aviso").select("id, estado").eq("id", id).maybeSingle(),
+  ) as any
+  if (!existente) throw notFound(`No existe ningún aviso con el id ${id}.`)
+
+  const updates: Record<string, unknown> = {}
+
+  if (cambios.contenido !== undefined && cambios.contenido !== null) {
+    const contenido = cambios.contenido.trim()
+    if (!contenido) throw badRequest("El aviso no puede quedarse vacío.")
+    if (contenido.length > AVISO_MAX_CONTENIDO) {
+      throw badRequest(`El texto no puede pasar de ${AVISO_MAX_CONTENIDO} caracteres.`)
+    }
+    updates.contenido = contenido
+  }
+  if (cambios.referencia !== undefined) {
+    updates.referencia = cambios.referencia?.trim().slice(0, AVISO_MAX_REFERENCIA) || null
+  }
+  if (cambios.destinatario) {
+    if (!AVISO_DESTINATARIOS.includes(cambios.destinatario)) {
+      throw badRequest(`Destinatario '${cambios.destinatario}' no válido.`, {
+        destinatarios_validos: AVISO_DESTINATARIOS,
+      })
+    }
+    updates.destinatario = cambios.destinatario
+  }
+  if (cambios.estado) {
+    if (!AVISO_ESTADOS.includes(cambios.estado)) {
+      throw badRequest(`Estado '${cambios.estado}' no válido.`, { estados_validos: AVISO_ESTADOS })
+    }
+    updates.estado = cambios.estado
+    updates.completado_por = cambios.estado === "hecha" ? actorId : null
+  }
+
+  if (Object.keys(updates).length === 0) {
+    throw badRequest(
+      "No has indicado ningún cambio. Campos admitidos: contenido, referencia, destinatario, estado.",
+    )
+  }
+
+  const { error } = await (admin as any).from("aviso").update(updates).eq("id", id)
+  if (error) throw wrapSupabaseError(error)
+
+  return obtenerAviso(admin, id)
+}
+
+export async function eliminarAviso(admin: AdminClient, id: string): Promise<void> {
+  const existente = unwrap(
+    await (admin as any).from("aviso").select("id").eq("id", id).maybeSingle(),
+  )
+  if (!existente) throw notFound(`No existe ningún aviso con el id ${id}.`)
+
+  const { error } = await (admin as any).from("aviso").delete().eq("id", id)
+  if (error) throw wrapSupabaseError(error)
+}
+
+/** Envía (o reenvía) por correo un aviso ya creado. */
+export async function notificarAviso(
+  admin: AdminClient,
+  id: string,
+  actorId: string,
+): Promise<{ destinatarios: string[] }> {
+  const fila = unwrap(
+    await (admin as any)
+      .from("aviso")
+      .select("id, delegacion_id, tipo, contenido, referencia, destinatario, creado_por")
+      .eq("id", id)
+      .maybeSingle(),
+  ) as any
+  if (!fila) throw notFound(`No existe ningún aviso con el id ${id}.`)
+
+  return enviarNotificacionAviso(admin, fila, { marcarNotificadoPor: actorId })
+}
+
+async function hidratar(admin: AdminClient, fila: any): Promise<AvisoPublico> {
+  const [nombres, delegaciones] = await Promise.all([
+    nombresDePerfil(admin, [fila]),
+    mapaDelegaciones(admin),
+  ])
+  return serializeAviso(fila, nombres, delegaciones)
+}

--- a/lib/api/catalogos.ts
+++ b/lib/api/catalogos.ts
@@ -1,0 +1,262 @@
+import type { createAdminClient } from "@/lib/supabase/admin"
+import { unwrap } from "@/lib/api/errors"
+import { resolveAmbitoDelegaciones, type DelegacionPublica } from "@/lib/api/delegaciones"
+
+type AdminClient = ReturnType<typeof createAdminClient>
+
+/**
+ * Catálogos: cuentas, categorías y contactos.
+ *
+ * Son tablas pequeñas (decenas o pocos cientos de filas en toda la
+ * organización) y se necesitan constantemente para adornar movimientos con
+ * nombres legibles. En vez de embeber joins en cada consulta de movimientos
+ * —lo que obliga a desambiguar claves foráneas en PostgREST— se cargan enteros
+ * una vez y se cruzan en memoria. Sale más simple y más rápido.
+ */
+
+export interface CuentaPublica {
+  id: string
+  delegacion_id: string
+  nombre: string
+  tipo: string | null
+  origen: string | null
+  banco_nombre: string | null
+  iban: string | null
+  activa: boolean
+  color: string | null
+  descripcion: string | null
+  sync_enabled: boolean
+  last_sync_at: string | null
+}
+
+export interface CategoriaPublica {
+  id: string
+  nombre: string
+  tipo: string | null
+  emoji: string | null
+  color: string | null
+  es_global: boolean
+  delegacion_id: string | null
+  categoria_padre_id: string | null
+  orden: number
+  esta_activa: boolean
+}
+
+export interface ContactoPublico {
+  id: string
+  nombre: string
+  tipo: string | null
+  emoji: string | null
+  color: string | null
+  es_global: boolean
+  delegacion_id: string | null
+  email: string | null
+  telefono: string | null
+  iban: string | null
+  identificador_fiscal: string | null
+  archivado: boolean
+}
+
+interface Catalogos {
+  cuentas: Map<string, CuentaPublica>
+  categorias: Map<string, CategoriaPublica>
+  contactos: Map<string, ContactoPublico>
+}
+
+let cache: { cargadoEn: number; catalogos: Catalogos } | null = null
+const CACHE_TTL_MS = 60 * 1000
+
+const CUENTA_COLS =
+  "id, delegacion_id, nombre, tipo, origen, banco_nombre, iban, activa, color, descripcion, sync_enabled, last_sync_at"
+const CATEGORIA_COLS =
+  "id, nombre, tipo, emoji, color, es_global, delegacion_id, categoria_padre_id, orden, esta_activa"
+const CONTACTO_COLS =
+  "id, nombre, tipo, emoji, color, es_global, delegacion_id, email, telefono, iban, identificador_fiscal, archivado"
+
+function indexar<T extends { id: string }>(filas: unknown): Map<string, T> {
+  return new Map(((filas ?? []) as T[]).map((fila) => [fila.id, fila]))
+}
+
+/** Carga (o reutiliza) los tres catálogos completos. */
+export async function cargarCatalogos(
+  admin: AdminClient,
+  options: { forzarRecarga?: boolean } = {},
+): Promise<Catalogos> {
+  if (!options.forzarRecarga && cache && Date.now() - cache.cargadoEn < CACHE_TTL_MS) {
+    return cache.catalogos
+  }
+
+  const [cuentasRes, categoriasRes, contactosRes] = await Promise.all([
+    (admin as any).from("cuenta").select(CUENTA_COLS).order("nombre"),
+    (admin as any).from("categoria").select(CATEGORIA_COLS).order("orden"),
+    (admin as any).from("contacto").select(CONTACTO_COLS).order("nombre"),
+  ])
+
+  const catalogos: Catalogos = {
+    cuentas: indexar<CuentaPublica>(unwrap(cuentasRes)),
+    categorias: indexar<CategoriaPublica>(unwrap(categoriasRes)),
+    contactos: indexar<ContactoPublico>(unwrap(contactosRes)),
+  }
+
+  cache = { cargadoEn: Date.now(), catalogos }
+  return catalogos
+}
+
+function enAmbito(
+  delegacionId: string | null,
+  delegaciones: DelegacionPublica[] | null,
+  esGlobal = false,
+): boolean {
+  if (!delegaciones) return true
+  if (esGlobal && delegacionId == null) return true
+  return delegacionId != null && delegaciones.some((d) => d.id === delegacionId)
+}
+
+/** Cuentas de las delegaciones indicadas (o de todas). */
+export async function listCuentas(
+  admin: AdminClient,
+  params: { delegaciones?: string | string[] | null; incluirInactivas?: boolean } = {},
+): Promise<CuentaPublica[]> {
+  const delegaciones = await resolveAmbitoDelegaciones(admin, params.delegaciones)
+  const { cuentas } = await cargarCatalogos(admin)
+  return [...cuentas.values()]
+    .filter((c) => enAmbito(c.delegacion_id, delegaciones))
+    .filter((c) => params.incluirInactivas || c.activa)
+    .sort((a, b) => a.nombre.localeCompare(b.nombre, "es"))
+}
+
+/**
+ * Categorías visibles para las delegaciones indicadas: las globales de la
+ * organización más las propias de cada delegación.
+ *
+ * Ojo: el orden y la visibilidad *por delegación* se guardan aparte, en
+ * `categoria_orden_delegacion`. Se aplican cuando se pide una única delegación
+ * (que es cuando ese override tiene sentido).
+ */
+export async function listCategorias(
+  admin: AdminClient,
+  params: { delegaciones?: string | string[] | null; incluirInactivas?: boolean } = {},
+): Promise<CategoriaPublica[]> {
+  const delegaciones = await resolveAmbitoDelegaciones(admin, params.delegaciones)
+  const { categorias } = await cargarCatalogos(admin)
+
+  let lista = [...categorias.values()].filter((c) =>
+    enAmbito(c.delegacion_id, delegaciones, c.es_global),
+  )
+
+  if (delegaciones?.length === 1) {
+    const overrides = unwrap(
+      await (admin as any)
+        .from("categoria_orden_delegacion")
+        .select("categoria_id, orden, esta_activa")
+        .eq("delegacion_id", delegaciones[0].id),
+    ) as { categoria_id: string; orden: number; esta_activa: boolean }[] | null
+
+    const porCategoria = new Map((overrides ?? []).map((o) => [o.categoria_id, o]))
+    lista = lista.map((c) => {
+      const override = porCategoria.get(c.id)
+      return override ? { ...c, orden: override.orden, esta_activa: override.esta_activa } : c
+    })
+  }
+
+  return lista
+    .filter((c) => params.incluirInactivas || c.esta_activa)
+    .sort((a, b) => a.orden - b.orden || a.nombre.localeCompare(b.nombre, "es"))
+}
+
+/** Contactos (proveedores y personas) de las delegaciones indicadas. */
+export async function listContactos(
+  admin: AdminClient,
+  params: {
+    delegaciones?: string | string[] | null
+    incluirArchivados?: boolean
+    tipos?: string[]
+    texto?: string
+  } = {},
+): Promise<ContactoPublico[]> {
+  const delegaciones = await resolveAmbitoDelegaciones(admin, params.delegaciones)
+  const { contactos } = await cargarCatalogos(admin)
+  const texto = params.texto?.trim().toLowerCase()
+
+  return [...contactos.values()]
+    .filter((c) => enAmbito(c.delegacion_id, delegaciones, c.es_global))
+    .filter((c) => params.incluirArchivados || !c.archivado)
+    .filter((c) => !params.tipos?.length || (c.tipo != null && params.tipos.includes(c.tipo)))
+    .filter((c) => !texto || c.nombre.toLowerCase().includes(texto))
+    .sort((a, b) => a.nombre.localeCompare(b.nombre, "es"))
+}
+
+/**
+ * Resuelve categorías por nombre o id, igual que las delegaciones: quien usa
+ * la API dice "Alimentación", no un UUID. Devuelve todas las coincidencias
+ * (puede haber una categoría con el mismo nombre en varias delegaciones, y
+ * filtrar por todas ellas es justo lo que se quiere).
+ */
+export async function resolveCategorias(
+  admin: AdminClient,
+  entrada: string | string[] | null | undefined,
+  ambito?: DelegacionPublica[] | null,
+): Promise<CategoriaPublica[] | null> {
+  if (entrada == null) return null
+  const lista = (Array.isArray(entrada) ? entrada : [entrada])
+    .map((x) => String(x ?? "").trim())
+    .filter(Boolean)
+  if (lista.length === 0) return null
+
+  const { categorias } = await cargarCatalogos(admin)
+  const candidatas = [...categorias.values()].filter((c) =>
+    enAmbito(c.delegacion_id, ambito ?? null, c.es_global),
+  )
+
+  const encontradas: CategoriaPublica[] = []
+  for (const item of lista) {
+    const porId = candidatas.filter((c) => c.id === item)
+    const porNombre =
+      porId.length > 0
+        ? porId
+        : candidatas.filter((c) => c.nombre.toLowerCase() === item.toLowerCase())
+    const parciales =
+      porNombre.length > 0
+        ? porNombre
+        : candidatas.filter((c) => c.nombre.toLowerCase().includes(item.toLowerCase()))
+
+    for (const c of parciales) {
+      if (!encontradas.some((e) => e.id === c.id)) encontradas.push(c)
+    }
+  }
+
+  return encontradas
+}
+
+/** Resuelve cuentas por nombre, IBAN o id. */
+export async function resolveCuentas(
+  admin: AdminClient,
+  entrada: string | string[] | null | undefined,
+  ambito?: DelegacionPublica[] | null,
+): Promise<CuentaPublica[] | null> {
+  if (entrada == null) return null
+  const lista = (Array.isArray(entrada) ? entrada : [entrada])
+    .map((x) => String(x ?? "").trim())
+    .filter(Boolean)
+  if (lista.length === 0) return null
+
+  const { cuentas } = await cargarCatalogos(admin)
+  const candidatas = [...cuentas.values()].filter((c) => enAmbito(c.delegacion_id, ambito ?? null))
+
+  const encontradas: CuentaPublica[] = []
+  for (const item of lista) {
+    const termino = item.toLowerCase()
+    const coincidencias = candidatas.filter(
+      (c) =>
+        c.id === item ||
+        c.nombre.toLowerCase() === termino ||
+        c.nombre.toLowerCase().includes(termino) ||
+        (c.iban && c.iban.toLowerCase().replace(/\s+/g, "").includes(termino.replace(/\s+/g, ""))),
+    )
+    for (const c of coincidencias) {
+      if (!encontradas.some((e) => e.id === c.id)) encontradas.push(c)
+    }
+  }
+
+  return encontradas
+}

--- a/lib/api/delegaciones.test.ts
+++ b/lib/api/delegaciones.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest"
+import { ApiError } from "@/lib/api/errors"
+import { encontrarDelegacion, type DelegacionPublica } from "@/lib/api/delegaciones"
+
+const DELEGACIONES: DelegacionPublica[] = [
+  { id: "11111111-1111-1111-1111-111111111111", codigo: "SEV", nombre: "Sevilla" },
+  { id: "22222222-2222-2222-2222-222222222222", codigo: "MAD", nombre: "Madrid" },
+  { id: "33333333-3333-3333-3333-333333333333", codigo: "CAD", nombre: "Cádiz" },
+  { id: "44444444-4444-4444-4444-444444444444", codigo: "SEVE", nombre: "Sevilla Este" },
+]
+
+describe("encontrarDelegacion", () => {
+  it("acepta el id", () => {
+    expect(encontrarDelegacion(DELEGACIONES, DELEGACIONES[1].id).nombre).toBe("Madrid")
+  })
+
+  it("acepta el código, sin distinguir mayúsculas", () => {
+    expect(encontrarDelegacion(DELEGACIONES, "mad").nombre).toBe("Madrid")
+  })
+
+  it("acepta el nombre sin acentos", () => {
+    expect(encontrarDelegacion(DELEGACIONES, "cadiz").nombre).toBe("Cádiz")
+  })
+
+  it("ignora el relleno con el que la gente nombra una delegación", () => {
+    expect(encontrarDelegacion(DELEGACIONES, "la delegación de Madrid").nombre).toBe("Madrid")
+  })
+
+  it("prefiere el nombre exacto antes que la coincidencia parcial", () => {
+    // "Sevilla" también está contenido en "Sevilla Este": debe ganar el exacto.
+    expect(encontrarDelegacion(DELEGACIONES, "Sevilla").nombre).toBe("Sevilla")
+  })
+
+  it("cuando es ambiguo, devuelve los candidatos para poder reintentar", () => {
+    const ambiguas: DelegacionPublica[] = [
+      { id: "a", codigo: null, nombre: "Sevilla Norte" },
+      { id: "b", codigo: null, nombre: "Sevilla Sur" },
+    ]
+    try {
+      encontrarDelegacion(ambiguas, "sevilla")
+      throw new Error("debería haber lanzado")
+    } catch (err) {
+      expect(err).toBeInstanceOf(ApiError)
+      expect((err as ApiError).status).toBe(400)
+      expect((err as ApiError).detalles).toMatchObject({
+        candidatos: [
+          { id: "a", nombre: "Sevilla Norte" },
+          { id: "b", nombre: "Sevilla Sur" },
+        ],
+      })
+    }
+  })
+
+  it("si no existe, lista las disponibles", () => {
+    try {
+      encontrarDelegacion(DELEGACIONES, "Lisboa")
+      throw new Error("debería haber lanzado")
+    } catch (err) {
+      expect((err as ApiError).status).toBe(404)
+      expect((err as ApiError).detalles).toMatchObject({
+        delegaciones_disponibles: ["Sevilla", "Madrid", "Cádiz", "Sevilla Este"],
+      })
+    }
+  })
+
+  it("un id inexistente no se confunde con un nombre", () => {
+    expect(() =>
+      encontrarDelegacion(DELEGACIONES, "99999999-9999-9999-9999-999999999999"),
+    ).toThrow(/No existe ninguna delegación con el id/)
+  })
+})

--- a/lib/api/delegaciones.ts
+++ b/lib/api/delegaciones.ts
@@ -1,0 +1,158 @@
+import type { createAdminClient } from "@/lib/supabase/admin"
+import { badRequest, notFound, unwrap } from "@/lib/api/errors"
+import { esUuid } from "@/lib/api/actor"
+
+type AdminClient = ReturnType<typeof createAdminClient>
+
+/**
+ * Resolución de delegaciones por lenguaje natural.
+ *
+ * Quien usa esta API es un administrador multidelegación que habla de
+ * "Sevilla", "la delegación de Madrid" o "MCM-SEV", no de UUIDs. Aquí se
+ * traduce ese texto a una delegación concreta, y cuando hay ambigüedad se
+ * devuelve un error que **lista los candidatos**, para que el agente pueda
+ * reintentar con el nombre exacto sin tener que preguntar al usuario.
+ */
+
+export interface DelegacionPublica {
+  id: string
+  codigo: string | null
+  nombre: string
+}
+
+/** Quita acentos y mayúsculas para comparar "Cádiz" con "cadiz". */
+function normalizar(texto: string): string {
+  return texto
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .trim()
+}
+
+/** Palabras de relleno que la gente escribe al nombrar una delegación. */
+const RUIDO = /^(la |el |de |del |delegacion |delegación |mcm )+/
+
+function claveBusqueda(texto: string): string {
+  let t = normalizar(texto)
+  let anterior: string
+  do {
+    anterior = t
+    t = t.replace(RUIDO, "")
+  } while (t !== anterior)
+  return t.trim()
+}
+
+let cache: { cargadoEn: number; delegaciones: DelegacionPublica[] } | null = null
+const CACHE_TTL_MS = 60 * 1000
+
+/** Todas las delegaciones de la organización, ordenadas por nombre. */
+export async function listDelegaciones(
+  admin: AdminClient,
+  options: { forzarRecarga?: boolean } = {},
+): Promise<DelegacionPublica[]> {
+  if (!options.forzarRecarga && cache && Date.now() - cache.cargadoEn < CACHE_TTL_MS) {
+    return cache.delegaciones
+  }
+
+  const data = unwrap(
+    await (admin as any).from("delegacion").select("id, codigo, nombre").order("nombre"),
+  )
+  const delegaciones = (data ?? []) as DelegacionPublica[]
+  cache = { cargadoEn: Date.now(), delegaciones }
+  return delegaciones
+}
+
+/** Mapa id → delegación, para adjuntar la delegación a listas de movimientos. */
+export async function mapaDelegaciones(
+  admin: AdminClient,
+): Promise<Map<string, DelegacionPublica>> {
+  const lista = await listDelegaciones(admin)
+  return new Map(lista.map((d) => [d.id, d]))
+}
+
+/**
+ * Resuelve **una** delegación a partir de un id, un código o un nombre
+ * aproximado. Lanza si no hay ninguna coincidencia o si hay varias.
+ */
+export async function resolveDelegacion(
+  admin: AdminClient,
+  entrada: string,
+): Promise<DelegacionPublica> {
+  return encontrarDelegacion(await listDelegaciones(admin), entrada)
+}
+
+/**
+ * El emparejamiento en sí, separado de la consulta para poder probarlo con una
+ * lista de delegaciones cualquiera.
+ */
+export function encontrarDelegacion(
+  todas: DelegacionPublica[],
+  entrada: string,
+): DelegacionPublica {
+  const texto = (entrada ?? "").trim()
+  if (!texto) throw badRequest("Falta la delegación.")
+
+  if (esUuid(texto)) {
+    const porId = todas.find((d) => d.id === texto)
+    if (porId) return porId
+    throw notFound(`No existe ninguna delegación con el id ${texto}.`)
+  }
+
+  const clave = claveBusqueda(texto)
+
+  // 1) Código exacto (MCM-SEV, SEV…) — lo más preciso.
+  const porCodigo = todas.filter((d) => d.codigo && normalizar(d.codigo) === normalizar(texto))
+  if (porCodigo.length === 1) return porCodigo[0]
+
+  // 2) Nombre exacto (ya sin acentos ni "delegación de").
+  const porNombre = todas.filter((d) => claveBusqueda(d.nombre) === clave)
+  if (porNombre.length === 1) return porNombre[0]
+  if (porNombre.length > 1) throw ambiguo(texto, porNombre)
+
+  // 3) Coincidencia parcial: "sevilla" encuentra "Sevilla Este".
+  const parciales = todas.filter((d) => {
+    const nombre = claveBusqueda(d.nombre)
+    const codigo = d.codigo ? normalizar(d.codigo) : ""
+    return nombre.includes(clave) || clave.includes(nombre) || (codigo && codigo.includes(clave))
+  })
+  if (parciales.length === 1) return parciales[0]
+  if (parciales.length > 1) throw ambiguo(texto, parciales)
+
+  throw notFound(
+    `No encuentro ninguna delegación que se parezca a "${texto}".`,
+    { delegaciones_disponibles: todas.map((d) => d.nombre) },
+  )
+}
+
+function ambiguo(texto: string, candidatos: DelegacionPublica[]) {
+  return badRequest(
+    `"${texto}" coincide con ${candidatos.length} delegaciones. Concreta cuál usando el nombre completo o el id.`,
+    { candidatos: candidatos.map((d) => ({ id: d.id, codigo: d.codigo, nombre: d.nombre })) },
+  )
+}
+
+/**
+ * Resuelve una lista de delegaciones. `undefined`, `null` o lista vacía
+ * significan **todas** las delegaciones (el caso normal para un admin
+ * multidelegación: "búscame movimientos de Mercadona en todas").
+ *
+ * Devuelve `null` cuando el ámbito es "todas", para que quien consulte pueda
+ * omitir el filtro por delegación en la query en vez de enumerar 18 ids.
+ */
+export async function resolveAmbitoDelegaciones(
+  admin: AdminClient,
+  entrada?: string | string[] | null,
+): Promise<DelegacionPublica[] | null> {
+  if (entrada == null) return null
+  const lista = Array.isArray(entrada) ? entrada : [entrada]
+  const limpias = lista.map((x) => String(x ?? "").trim()).filter(Boolean)
+  if (limpias.length === 0) return null
+
+  const resueltas: DelegacionPublica[] = []
+  for (const item of limpias) {
+    const delegacion = await resolveDelegacion(admin, item)
+    if (!resueltas.some((d) => d.id === delegacion.id)) resueltas.push(delegacion)
+  }
+  return resueltas
+}

--- a/lib/api/errors.ts
+++ b/lib/api/errors.ts
@@ -1,0 +1,93 @@
+import { NextResponse } from "next/server"
+
+/**
+ * Error con código HTTP para la API externa y el servidor MCP.
+ *
+ * Las capas de dominio (`lib/api/*.ts`) lanzan `ApiError` con un mensaje en
+ * español pensado para que lo lea una persona **o un modelo**: si el mensaje
+ * explica qué falta y cómo arreglarlo, el agente puede corregirse solo sin
+ * volver a preguntar al usuario.
+ */
+export class ApiError extends Error {
+  readonly status: number
+  /** Datos extra que ayudan a corregir la llamada (candidatos, valores válidos…). */
+  readonly detalles?: unknown
+
+  constructor(status: number, message: string, detalles?: unknown) {
+    super(message)
+    this.name = "ApiError"
+    this.status = status
+    this.detalles = detalles
+  }
+}
+
+export const badRequest = (message: string, detalles?: unknown) =>
+  new ApiError(400, message, detalles)
+export const notFound = (message: string, detalles?: unknown) =>
+  new ApiError(404, message, detalles)
+export const conflict = (message: string, detalles?: unknown) =>
+  new ApiError(409, message, detalles)
+export const misconfigured = (message: string, detalles?: unknown) =>
+  new ApiError(500, message, detalles)
+
+/**
+ * Convierte un error de Supabase/PostgREST (un objeto plano, no una instancia
+ * de `Error`) en un `Error` real, para que `err.message` no acabe siendo
+ * `"[object Object]"`.
+ */
+export function wrapSupabaseError(error: unknown): Error {
+  if (error instanceof Error) return error
+  if (error && typeof error === "object") {
+    const e = error as { message?: unknown; details?: unknown; hint?: unknown }
+    // Solo la primera línea de cada parte: cuando el fallo es de red,
+    // supabase-js mete la traza de pila entera en `details`.
+    const partes = [e.message, e.details, e.hint]
+      .filter(Boolean)
+      .map((parte) => String(parte).split("\n")[0].trim())
+      .filter(Boolean)
+    if (partes.length > 0) return new Error(partes.join(" · "))
+  }
+  return new Error("Error desconocido de Supabase.")
+}
+
+/** Lanza si la respuesta de Supabase trae error; si no, devuelve los datos. */
+export function unwrap<T>(res: { data: T; error: unknown }): T {
+  if (res.error) throw wrapSupabaseError(res.error)
+  return res.data
+}
+
+export interface ErrorPayload {
+  ok: false
+  error: string
+  detalles?: unknown
+}
+
+/**
+ * Normaliza cualquier error a `{ status, body }` para una respuesta HTTP.
+ *
+ * Los `ApiError` se devuelven tal cual: su mensaje está escrito para leerse.
+ * Lo demás es un fallo inesperado —una caída de red, un error de Postgres—: se
+ * registra entero en el servidor y hacia fuera solo sale la primera línea,
+ * recortada, para no publicar trazas de pila ni rutas internas.
+ */
+export function toErrorPayload(err: unknown): { status: number; body: ErrorPayload } {
+  if (err instanceof ApiError) {
+    return {
+      status: err.status,
+      body: { ok: false, error: err.message, ...(err.detalles ? { detalles: err.detalles } : {}) },
+    }
+  }
+
+  console.error("[api] Error no controlado:", err)
+  const bruto = err instanceof Error ? err.message : String(err)
+  const primeraLinea = bruto.split("\n")[0].trim()
+  const message = primeraLinea.length > 300 ? `${primeraLinea.slice(0, 299)}…` : primeraLinea
+
+  return { status: 500, body: { ok: false, error: message || "Error interno." } }
+}
+
+/** Respuesta JSON de error lista para devolver desde un route handler. */
+export function errorResponse(err: unknown): NextResponse {
+  const { status, body } = toErrorPayload(err)
+  return NextResponse.json(body, { status })
+}

--- a/lib/api/external-auth.ts
+++ b/lib/api/external-auth.ts
@@ -1,27 +1,60 @@
 import { timingSafeEqual } from "node:crypto"
 
 /**
- * Autenticación para la API externa (consumo desde Google Apps Script u otras
- * aplicaciones internas).
+ * Autenticación para la API externa y el servidor MCP (consumo desde Google
+ * Apps Script, Claude u otras aplicaciones internas).
  *
- * Estrategia deliberadamente simple: una clave secreta compartida que se envía
- * en cada petición. Se acepta en dos formatos para comodidad del cliente:
+ * Estrategia deliberadamente simple: claves secretas compartidas que se envían
+ * en cada petición. Se aceptan dos formatos para comodidad del cliente:
  *
  *   - Cabecera `Authorization: Bearer <clave>`
  *   - Cabecera `x-api-key: <clave>`
  *
- * La clave válida se lee de las variables de entorno. Se admite una variable
- * dedicada `MCM_API_KEY` y, como respaldo, se reutiliza `CRON_SECRET` (que ya
- * existe para el cron de sincronización bancaria). Esto permite empezar sin
- * añadir variables nuevas y, más adelante, separar las claves si interesa.
+ * Hay dos niveles de permiso, para que una clave pegada en una hoja de cálculo
+ * no pueda además escribir en la base de datos:
+ *
+ *   | Variable de entorno   | Permiso        |
+ *   |-----------------------|----------------|
+ *   | `MCM_API_KEY`         | lectura + escritura |
+ *   | `MCM_API_KEY_READONLY`| solo lectura   |
+ *   | `CRON_SECRET`         | solo lectura (respaldo histórico) |
+ *
+ * `CRON_SECRET` existe desde antes (cron de sincronización bancaria) y se
+ * mantiene como respaldo para no romper integraciones ya montadas, pero **nunca
+ * concede escritura**: para escribir hay que definir `MCM_API_KEY`.
  */
 
+/** Permiso requerido por un endpoint. */
+export type ApiScope = "read" | "write"
+
+interface ConfiguredKey {
+  value: string
+  scope: ApiScope
+  /** Nombre de la variable de entorno, solo para trazas y mensajes de error. */
+  source: string
+}
+
 /**
- * Devuelve la clave de API configurada, o `null` si no hay ninguna.
- * El orden de preferencia es: `MCM_API_KEY` y luego `CRON_SECRET`.
+ * Claves configuradas en el servidor, de mayor a menor permiso. Se lee en cada
+ * llamada (no se cachea) para que un cambio de variable de entorno tras un
+ * redeploy tenga efecto sin estado residual.
  */
-function getConfiguredApiKey(): string | null {
-  return process.env.MCM_API_KEY || process.env.CRON_SECRET || null
+function getConfiguredKeys(): ConfiguredKey[] {
+  const keys: ConfiguredKey[] = []
+  if (process.env.MCM_API_KEY) {
+    keys.push({ value: process.env.MCM_API_KEY, scope: "write", source: "MCM_API_KEY" })
+  }
+  if (process.env.MCM_API_KEY_READONLY) {
+    keys.push({
+      value: process.env.MCM_API_KEY_READONLY,
+      scope: "read",
+      source: "MCM_API_KEY_READONLY",
+    })
+  }
+  if (process.env.CRON_SECRET) {
+    keys.push({ value: process.env.CRON_SECRET, scope: "read", source: "CRON_SECRET" })
+  }
+  return keys
 }
 
 /**
@@ -53,19 +86,24 @@ function timingSafeEqualString(a: string, b: string): boolean {
 }
 
 export type ApiAuthResult =
-  | { ok: true }
-  | { ok: false; status: 401 | 500; error: string }
+  | { ok: true; scope: ApiScope; source: string }
+  | { ok: false; status: 401 | 403 | 500; error: string }
 
 /**
- * Verifica que la petición incluya una clave de API válida.
+ * Verifica que la petición incluya una clave de API válida con permiso
+ * suficiente.
  *
  * - 500 si el servidor no tiene ninguna clave configurada (mala configuración).
- * - 401 si falta la clave o no coincide.
- * - `{ ok: true }` si la autenticación es correcta.
+ * - 401 si falta la clave o no coincide con ninguna.
+ * - 403 si la clave es válida pero solo de lectura y el endpoint escribe.
+ * - `{ ok: true, scope }` si la autenticación es correcta.
+ *
+ * @param required Permiso que exige el endpoint (por defecto `"read"`, para que
+ *   los endpoints de consulta ya existentes sigan llamando `verifyApiKey(req)`).
  */
-export function verifyApiKey(request: Request): ApiAuthResult {
-  const configuredKey = getConfiguredApiKey()
-  if (!configuredKey) {
+export function verifyApiKey(request: Request, required: ApiScope = "read"): ApiAuthResult {
+  const configuredKeys = getConfiguredKeys()
+  if (configuredKeys.length === 0) {
     return {
       ok: false,
       status: 500,
@@ -75,7 +113,7 @@ export function verifyApiKey(request: Request): ApiAuthResult {
   }
 
   const providedKey = extractRequestKey(request)
-  if (!providedKey || !timingSafeEqualString(providedKey, configuredKey)) {
+  if (!providedKey) {
     return {
       ok: false,
       status: 401,
@@ -84,5 +122,31 @@ export function verifyApiKey(request: Request): ApiAuthResult {
     }
   }
 
-  return { ok: true }
+  // Se comparan todas las claves (sin cortocircuito) para no filtrar por tiempo
+  // cuál de ellas coincidió.
+  let matched: ConfiguredKey | null = null
+  for (const key of configuredKeys) {
+    if (timingSafeEqualString(providedKey, key.value) && !matched) {
+      matched = key
+    }
+  }
+
+  if (!matched) {
+    return {
+      ok: false,
+      status: 401,
+      error:
+        "No autorizado. Envía la clave en 'Authorization: Bearer <clave>' o en la cabecera 'x-api-key'.",
+    }
+  }
+
+  if (required === "write" && matched.scope !== "write") {
+    const pista =
+      matched.source === "MCM_API_KEY_READONLY"
+        ? "Esa clave es de solo lectura; usa la de MCM_API_KEY para escribir."
+        : "Estás usando CRON_SECRET, que solo da lectura. Define MCM_API_KEY y usa esa clave para escribir."
+    return { ok: false, status: 403, error: `Esta operación modifica datos. ${pista}` }
+  }
+
+  return { ok: true, scope: matched.scope, source: matched.source }
 }

--- a/lib/api/facturas.ts
+++ b/lib/api/facturas.ts
@@ -1,0 +1,863 @@
+import type { createAdminClient } from "@/lib/supabase/admin"
+import { badRequest, conflict, notFound, unwrap, wrapSupabaseError } from "@/lib/api/errors"
+import {
+  resolveAmbitoDelegaciones,
+  resolveDelegacion,
+  mapaDelegaciones,
+  type DelegacionPublica,
+} from "@/lib/api/delegaciones"
+import { cargarCatalogos } from "@/lib/api/catalogos"
+import { aplicarBusquedaTexto } from "@/lib/api/postgrest"
+import {
+  archivosDeFacturas,
+  listarArchivosFactura,
+  replicarArchivoEnMovimiento,
+  subirArchivoAFactura,
+  type ArchivoEntrante,
+} from "@/lib/api/archivos"
+import type { ArchivoPublico } from "@/lib/api/movimientos-public"
+import { margenImporteFactura, scoreCandidatoMovimiento } from "@/lib/utils/facturas-matching"
+
+type AdminClient = ReturnType<typeof createAdminClient>
+
+/**
+ * Facturas: bandeja de entrada y conciliación con movimientos bancarios.
+ *
+ * Es la parte con más reglas de negocio de la API, porque una factura puede
+ * pagarse en varios plazos: el vínculo vive en `movimiento.factura_id` (varios
+ * movimientos → una factura) y el estado de la factura lo recalcula un trigger
+ * comparando su importe con la suma de lo vinculado. Aquí nunca se escribe
+ * `estado` a mano en las operaciones de vínculo: se deja que mande la realidad.
+ */
+
+export const FACTURA_ESTADOS = [
+  "bandeja",
+  "sin_pagar",
+  "pagada_parcial",
+  "pagada",
+  "pagada_fuera",
+] as const
+export type FacturaEstadoApi = (typeof FACTURA_ESTADOS)[number]
+
+const FACTURA_SELECT = `
+  *,
+  contacto:contacto_id (
+    id,
+    nombre,
+    tipo,
+    emoji,
+    color,
+    email,
+    identificador_fiscal
+  ),
+  movimientos:movimiento (
+    id,
+    fecha,
+    concepto,
+    importe,
+    cuenta_id,
+    delegacion_id
+  )
+`
+
+export interface FacturaPublica {
+  id: string
+  numero: string | null
+  concepto: string | null
+  importe: number | null
+  moneda: string
+  fecha_emision: string | null
+  estado: string
+  origen: string
+  notas: string | null
+  email_remitente: string | null
+  delegacion: DelegacionPublica | null
+  contacto: {
+    id: string
+    nombre: string
+    tipo: string | null
+    email: string | null
+    identificador_fiscal: string | null
+  } | null
+  /** Suma (en valor absoluto) de los movimientos ya vinculados. */
+  importe_pagado: number
+  /** Lo que falta por cubrir; `null` si la factura no tiene importe. */
+  importe_pendiente: number | null
+  movimientos: {
+    id: string
+    fecha: string
+    concepto: string
+    importe: number
+  }[]
+  archivos: ArchivoPublico[]
+  creado_en: string
+  actualizado_en: string
+}
+
+function redondear(n: number): number {
+  return Math.round(n * 100) / 100
+}
+
+export function serializeFactura(
+  row: any,
+  archivos: ArchivoPublico[],
+  delegaciones: Map<string, DelegacionPublica>,
+): FacturaPublica {
+  const movimientos = ((row.movimientos ?? []) as any[]).map((m) => ({
+    id: m.id,
+    fecha: m.fecha,
+    concepto: m.concepto,
+    importe: Number(m.importe),
+  }))
+  const pagado = movimientos.reduce((sum, m) => sum + Math.abs(m.importe), 0)
+  const importe = row.importe == null ? null : Number(row.importe)
+
+  return {
+    id: row.id,
+    numero: row.numero ?? null,
+    concepto: row.concepto ?? null,
+    importe,
+    moneda: row.moneda ?? "EUR",
+    fecha_emision: row.fecha_emision ?? null,
+    estado: row.estado,
+    origen: row.origen,
+    notas: row.notas ?? null,
+    email_remitente: row.email_remitente ?? null,
+    delegacion: row.delegacion_id ? delegaciones.get(row.delegacion_id) ?? null : null,
+    contacto: row.contacto
+      ? {
+          id: row.contacto.id,
+          nombre: row.contacto.nombre,
+          tipo: row.contacto.tipo ?? null,
+          email: row.contacto.email ?? null,
+          identificador_fiscal: row.contacto.identificador_fiscal ?? null,
+        }
+      : null,
+    importe_pagado: redondear(pagado),
+    importe_pendiente: importe == null ? null : redondear(Math.max(importe - pagado, 0)),
+    movimientos,
+    archivos,
+    creado_en: row.creado_en,
+    actualizado_en: row.actualizado_en,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Consulta
+// ---------------------------------------------------------------------------
+
+export interface BuscarFacturasParams {
+  delegaciones?: string | string[] | null
+  estados?: string[] | null
+  texto?: string | null
+  numero?: string | null
+  importeMin?: number | null
+  importeMax?: number | null
+  fechaDesde?: string | null
+  fechaHasta?: string | null
+  contactoIds?: string[] | null
+  /** `true` = solo facturas sin ningún movimiento vinculado (sin conciliar). */
+  sinConciliar?: boolean
+  limite?: number
+  offset?: number
+  baseUrl?: string
+}
+
+export interface BuscarFacturasResultado {
+  total: number
+  limite: number
+  offset: number
+  hay_mas: boolean
+  facturas: FacturaPublica[]
+}
+
+export async function buscarFacturas(
+  admin: AdminClient,
+  params: BuscarFacturasParams,
+): Promise<BuscarFacturasResultado> {
+  const limite = Math.min(Math.max(params.limite ?? 50, 1), 200)
+  const offset = Math.max(params.offset ?? 0, 0)
+
+  const ambito = await resolveAmbitoDelegaciones(admin, params.delegaciones)
+
+  if (params.estados?.length) {
+    const invalidos = params.estados.filter((e) => !FACTURA_ESTADOS.includes(e as FacturaEstadoApi))
+    if (invalidos.length > 0) {
+      throw badRequest(`Estado de factura no válido: ${invalidos.join(", ")}.`, {
+        estados_validos: FACTURA_ESTADOS,
+      })
+    }
+  }
+
+  let query = (admin as any).from("factura").select(FACTURA_SELECT, { count: "exact" })
+
+  if (params.sinConciliar) {
+    // "Sin conciliar" no se puede expresar como un filtro sobre `factura`
+    // (el vínculo vive en `movimiento.factura_id`), así que se excluyen por id
+    // las que sí tienen movimientos. Tiene que ser parte de la consulta y no un
+    // filtro posterior: si no, `total` mentiría y las páginas saldrían cojas.
+    const excluidas = await facturasConMovimiento(admin, ambito)
+    if (excluidas.length > 0) {
+      query = query.not("id", "in", `(${excluidas.join(",")})`)
+    }
+  }
+
+  if (ambito) query = query.in("delegacion_id", ambito.map((d) => d.id))
+  if (params.estados?.length) query = query.in("estado", params.estados)
+  if (params.numero) query = query.ilike("numero", `%${params.numero}%`)
+  if (params.importeMin != null) query = query.gte("importe", Math.abs(params.importeMin))
+  if (params.importeMax != null) query = query.lte("importe", Math.abs(params.importeMax))
+  if (params.fechaDesde) query = query.gte("fecha_emision", params.fechaDesde)
+  if (params.fechaHasta) query = query.lte("fecha_emision", params.fechaHasta)
+  if (params.contactoIds?.length) query = query.in("contacto_id", params.contactoIds)
+  query = aplicarBusquedaTexto(query, params.texto, ["concepto", "numero", "notas"])
+
+  query = query
+    .order("fecha_emision", { ascending: false, nullsFirst: false })
+    .order("creado_en", { ascending: false })
+    .range(offset, offset + limite - 1)
+
+  const { data, count, error } = await query
+  if (error) throw wrapSupabaseError(error)
+
+  const filas = (data ?? []) as any[]
+  const delegaciones = await mapaDelegaciones(admin)
+  const archivos = await archivosDeFacturas(admin, filas.map((f) => f.id), {
+    baseUrl: params.baseUrl,
+  })
+
+  const total = count ?? filas.length
+  return {
+    total,
+    limite,
+    offset,
+    hay_mas: offset + filas.length < total,
+    facturas: filas.map((f) => serializeFactura(f, archivos.get(f.id) ?? [], delegaciones)),
+  }
+}
+
+/** Ids de las facturas que ya tienen al menos un movimiento vinculado. */
+async function facturasConMovimiento(
+  admin: AdminClient,
+  ambito: DelegacionPublica[] | null,
+): Promise<string[]> {
+  let query = (admin as any)
+    .from("movimiento")
+    .select("factura_id")
+    .not("factura_id", "is", null)
+    .limit(5000)
+  if (ambito) query = query.in("delegacion_id", ambito.map((d) => d.id))
+
+  const filas = (unwrap(await query) ?? []) as { factura_id: string }[]
+  return [...new Set(filas.map((f) => f.factura_id))]
+}
+
+export async function obtenerFactura(
+  admin: AdminClient,
+  id: string,
+  options: { baseUrl?: string } = {},
+): Promise<FacturaPublica> {
+  const fila = unwrap(
+    await (admin as any).from("factura").select(FACTURA_SELECT).eq("id", id).maybeSingle(),
+  ) as any
+  if (!fila) throw notFound(`No existe ninguna factura con el id ${id}.`)
+
+  const delegaciones = await mapaDelegaciones(admin)
+  const archivos = await listarArchivosFactura(admin, id, { baseUrl: options.baseUrl })
+  return serializeFactura(fila, archivos, delegaciones)
+}
+
+// ---------------------------------------------------------------------------
+// Escritura
+// ---------------------------------------------------------------------------
+
+export interface CrearFacturaParams {
+  delegacion: string
+  numero?: string | null
+  concepto?: string | null
+  importe?: number | null
+  fecha_emision?: string | null
+  moneda?: string | null
+  estado?: FacturaEstadoApi | null
+  notas?: string | null
+  contacto_id?: string | null
+  /** Archivo de la factura, si se sube en la misma llamada. */
+  archivo?: ArchivoEntrante | null
+  /** Movimiento con el que conciliarla inmediatamente. */
+  movimiento_id?: string | null
+}
+
+export async function crearFactura(
+  admin: AdminClient,
+  params: CrearFacturaParams,
+  actorId: string,
+  options: { baseUrl?: string } = {},
+): Promise<FacturaPublica> {
+  const delegacion = await resolveDelegacion(admin, params.delegacion)
+
+  if (params.importe != null && Number(params.importe) <= 0) {
+    throw badRequest("El importe de una factura debe ser positivo (es el importe facturado, sin signo).")
+  }
+  if (params.estado && !FACTURA_ESTADOS.includes(params.estado)) {
+    throw badRequest(`Estado '${params.estado}' no válido.`, { estados_validos: FACTURA_ESTADOS })
+  }
+
+  const creada = unwrap(
+    await (admin as any)
+      .from("factura")
+      .insert({
+        delegacion_id: delegacion.id,
+        numero: params.numero?.trim() || null,
+        concepto: params.concepto?.trim() || null,
+        importe: params.importe == null ? null : Math.abs(Number(params.importe)),
+        fecha_emision: params.fecha_emision || null,
+        moneda: params.moneda?.trim() || "EUR",
+        estado: params.estado || "bandeja",
+        notas: params.notas?.trim() || null,
+        contacto_id: params.contacto_id || null,
+        origen: "subida",
+        creado_por: actorId,
+      })
+      .select("id")
+      .single(),
+  ) as any
+
+  if (params.archivo) {
+    await subirArchivoAFactura(admin, {
+      facturaId: creada.id,
+      archivo: params.archivo,
+      actorId,
+      baseUrl: options.baseUrl,
+    })
+  }
+
+  if (params.movimiento_id) {
+    await vincularFacturaAMovimiento(admin, creada.id, params.movimiento_id, actorId)
+  }
+
+  return obtenerFactura(admin, creada.id, options)
+}
+
+export interface ActualizarFacturaParams {
+  numero?: string | null
+  concepto?: string | null
+  importe?: number | null
+  fecha_emision?: string | null
+  estado?: FacturaEstadoApi | null
+  notas?: string | null
+  contacto_id?: string | null
+}
+
+export async function actualizarFactura(
+  admin: AdminClient,
+  id: string,
+  cambios: ActualizarFacturaParams,
+  options: { baseUrl?: string } = {},
+): Promise<FacturaPublica> {
+  const existente = unwrap(
+    await (admin as any).from("factura").select("id").eq("id", id).maybeSingle(),
+  )
+  if (!existente) throw notFound(`No existe ninguna factura con el id ${id}.`)
+
+  const updates: Record<string, unknown> = {}
+  for (const campo of ["numero", "concepto", "fecha_emision", "notas", "contacto_id", "estado"] as const) {
+    if (cambios[campo] !== undefined) updates[campo] = cambios[campo]
+  }
+  if (cambios.importe !== undefined) {
+    if (cambios.importe != null && Number(cambios.importe) <= 0) {
+      throw badRequest("El importe de una factura debe ser positivo.")
+    }
+    updates.importe = cambios.importe == null ? null : Math.abs(Number(cambios.importe))
+  }
+  if (cambios.estado && !FACTURA_ESTADOS.includes(cambios.estado)) {
+    throw badRequest(`Estado '${cambios.estado}' no válido.`, { estados_validos: FACTURA_ESTADOS })
+  }
+
+  if (Object.keys(updates).length === 0) {
+    throw badRequest(
+      "No has indicado ningún cambio. Campos admitidos: numero, concepto, importe, fecha_emision, estado, notas, contacto_id.",
+    )
+  }
+
+  const { error } = await (admin as any).from("factura").update(updates).eq("id", id)
+  if (error) throw wrapSupabaseError(error)
+
+  return obtenerFactura(admin, id, options)
+}
+
+/** Borra la factura, sus adjuntos y desvincula los movimientos que tuviera. */
+export async function eliminarFactura(admin: AdminClient, id: string): Promise<void> {
+  const existente = unwrap(
+    await (admin as any).from("factura").select("id").eq("id", id).maybeSingle(),
+  )
+  if (!existente) throw notFound(`No existe ninguna factura con el id ${id}.`)
+
+  await (admin as any).from("movimiento").update({ factura_id: null }).eq("factura_id", id)
+
+  const adjuntos = (unwrap(
+    await (admin as any)
+      .from("archivo_adjunto")
+      .select("path_storage, bucket")
+      .eq("entidad", "factura")
+      .eq("entidad_id", id),
+  ) ?? []) as { path_storage: string; bucket: string }[]
+
+  for (const adjunto of adjuntos) {
+    const { error } = await admin.storage.from(adjunto.bucket).remove([adjunto.path_storage])
+    if (error) console.warn("No se pudo borrar el fichero de Storage:", error.message)
+  }
+  await (admin as any).from("archivo_adjunto").delete().eq("entidad", "factura").eq("entidad_id", id)
+
+  const { error } = await (admin as any).from("factura").delete().eq("id", id)
+  if (error) throw wrapSupabaseError(error)
+}
+
+/**
+ * Concilia una factura con un movimiento bancario.
+ *
+ * Puerto servidor de `DatabaseService.linkFacturaToMovimiento`: además del
+ * vínculo, sincroniza el contacto en ambos sentidos, rellena los huecos de la
+ * factura con los datos del movimiento y replica los adjuntos, para que la
+ * factura se vea desde la pestaña de archivos del movimiento.
+ */
+export async function vincularFacturaAMovimiento(
+  admin: AdminClient,
+  facturaId: string,
+  movimientoId: string,
+  actorId: string,
+): Promise<void> {
+  const [facturaRes, movimientoRes] = await Promise.all([
+    (admin as any).from("factura").select("*").eq("id", facturaId).maybeSingle(),
+    (admin as any)
+      .from("movimiento")
+      .select("id, fecha, importe, contacto_id, factura_id, delegacion_id")
+      .eq("id", movimientoId)
+      .maybeSingle(),
+  ])
+
+  const factura = unwrap(facturaRes) as any
+  const movimiento = unwrap(movimientoRes) as any
+  if (!factura) throw notFound(`No existe ninguna factura con el id ${facturaId}.`)
+  if (!movimiento) throw notFound(`No existe ningún movimiento con el id ${movimientoId}.`)
+  if (movimiento.factura_id === facturaId) return // idempotente
+  if (movimiento.factura_id) {
+    throw conflict(
+      `Ese movimiento ya tiene vinculada otra factura (${movimiento.factura_id}). Desvincúlala primero.`,
+    )
+  }
+  if (movimiento.delegacion_id !== factura.delegacion_id) {
+    throw conflict(
+      "La factura y el movimiento son de delegaciones distintas: no se pueden conciliar entre sí.",
+    )
+  }
+
+  const movimientoUpdates: Record<string, unknown> = { factura_id: facturaId }
+  if (factura.contacto_id && !movimiento.contacto_id) {
+    movimientoUpdates.contacto_id = factura.contacto_id
+  }
+  const { error } = await (admin as any)
+    .from("movimiento")
+    .update(movimientoUpdates)
+    .eq("id", movimientoId)
+  if (error) throw wrapSupabaseError(error)
+
+  // Relleno best-effort de los huecos de la factura (no bloquea el vínculo).
+  const facturaUpdates: Record<string, unknown> = {}
+  if (factura.importe == null) facturaUpdates.importe = Math.abs(Number(movimiento.importe))
+  if (!factura.fecha_emision && movimiento.fecha) facturaUpdates.fecha_emision = movimiento.fecha
+  if (!factura.contacto_id && movimiento.contacto_id) facturaUpdates.contacto_id = movimiento.contacto_id
+  if (Object.keys(facturaUpdates).length > 0) {
+    const { error: updErr } = await (admin as any)
+      .from("factura")
+      .update(facturaUpdates)
+      .eq("id", facturaId)
+    if (updErr) console.warn("No se pudieron rellenar los datos de la factura:", updErr.message)
+  }
+
+  const adjuntos = (unwrap(
+    await (admin as any)
+      .from("archivo_adjunto")
+      .select("*")
+      .eq("entidad", "factura")
+      .eq("entidad_id", facturaId),
+  ) ?? []) as any[]
+  for (const adjunto of adjuntos) {
+    await replicarArchivoEnMovimiento(admin, movimientoId, adjunto, actorId).catch((err) =>
+      console.warn("No se pudo replicar el adjunto de la factura:", err?.message ?? err),
+    )
+  }
+}
+
+/** Deshace el vínculo de un movimiento concreto con su factura. */
+export async function desvincularFacturaDeMovimiento(
+  admin: AdminClient,
+  facturaId: string,
+  movimientoId: string,
+): Promise<void> {
+  const { error, count } = await (admin as any)
+    .from("movimiento")
+    .update({ factura_id: null }, { count: "exact" })
+    .eq("id", movimientoId)
+    .eq("factura_id", facturaId)
+  if (error) throw wrapSupabaseError(error)
+  if (count === 0) {
+    throw notFound(`El movimiento ${movimientoId} no está vinculado a la factura ${facturaId}.`)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Conciliación
+// ---------------------------------------------------------------------------
+
+export interface CandidatoMovimiento {
+  movimiento: {
+    id: string
+    fecha: string
+    concepto: string
+    contraparte: string | null
+    importe: number
+    delegacion: DelegacionPublica | null
+    cuenta: string | null
+    categoria: string | null
+    factura_id: string | null
+  }
+  puntuacion: number
+  importe_exacto: boolean
+  motivos: string[]
+}
+
+/** Datos de una factura (real o "de papel") con los que buscar su movimiento. */
+export interface DatosFactura {
+  importe?: number | null
+  fecha?: string | null
+  proveedor?: string | null
+  numero?: string | null
+  contacto_id?: string | null
+}
+
+function normalizarTexto(texto: string): string {
+  return texto
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+}
+
+/**
+ * Busca los movimientos que mejor encajan con una factura.
+ *
+ * El importe manda (con el margen del 2 %, mínimo 0,50 €, que ya usa la app);
+ * fecha, proveedor y contacto desempatan. Se devuelven ordenados de mejor a
+ * peor con los motivos en texto, para que quien lea el resultado —persona o
+ * modelo— pueda decidir con criterio en vez de fiarse de un número.
+ */
+export async function buscarCandidatosParaFactura(
+  admin: AdminClient,
+  datos: DatosFactura,
+  options: {
+    ambito?: DelegacionPublica[] | null
+    ventanaDias?: number
+    incluirConFactura?: boolean
+    limite?: number
+  } = {},
+): Promise<CandidatoMovimiento[]> {
+  const limite = Math.min(options.limite ?? 10, 50)
+  const importe = datos.importe == null ? null : Math.abs(Number(datos.importe))
+
+  let query = (admin as any)
+    .from("movimiento")
+    .select(
+      "id, fecha, concepto, contraparte, descripcion, importe, delegacion_id, cuenta_id, categoria_id, contacto_id, factura_id",
+    )
+    .eq("ignorado", false)
+    .lt("importe", 0)
+
+  if (options.ambito) query = query.in("delegacion_id", options.ambito.map((d) => d.id))
+  if (!options.incluirConFactura) query = query.is("factura_id", null)
+
+  if (importe != null && importe > 0) {
+    const margen = margenImporteFactura(importe)
+    query = query.gte("importe", -(importe + margen)).lte("importe", -(importe - margen))
+  }
+
+  if (datos.fecha) {
+    const ventana = options.ventanaDias ?? 90
+    const centro = new Date(datos.fecha)
+    if (!Number.isNaN(centro.getTime())) {
+      const desde = new Date(centro.getTime() - ventana * 86400000).toISOString().slice(0, 10)
+      const hasta = new Date(centro.getTime() + ventana * 86400000).toISOString().slice(0, 10)
+      query = query.gte("fecha", desde).lte("fecha", hasta)
+    }
+  }
+
+  const filas = (unwrap(
+    await query.order("fecha", { ascending: false }).limit(300),
+  ) ?? []) as any[]
+
+  const catalogos = await cargarCatalogos(admin)
+  const delegaciones = await mapaDelegaciones(admin)
+  const proveedor = datos.proveedor?.trim() ? normalizarTexto(datos.proveedor.trim()) : null
+  const palabrasProveedor = proveedor ? proveedor.split(/\s+/).filter((p) => p.length >= 3) : []
+
+  const puntuados = filas.map((fila) => {
+    const base = scoreCandidatoMovimiento(
+      { importe, fecha_emision: datos.fecha ?? null, contacto_id: datos.contacto_id ?? null },
+      { importe: fila.importe, fecha: fila.fecha, contacto_id: fila.contacto_id } as any,
+    )
+
+    const motivos: string[] = []
+    if (base.importeExacto) motivos.push("importe exacto")
+    else if (importe != null) motivos.push("importe dentro del margen")
+    if (base.fechaCercana) motivos.push("fecha muy cercana")
+    if (base.mismoContacto) motivos.push("mismo contacto")
+
+    let extra = 0
+    if (palabrasProveedor.length > 0) {
+      const textoMovimiento = normalizarTexto(
+        [fila.concepto, fila.contraparte, fila.descripcion].filter(Boolean).join(" "),
+      )
+      const aciertos = palabrasProveedor.filter((p) => textoMovimiento.includes(p))
+      if (aciertos.length > 0) {
+        extra += aciertos.length === palabrasProveedor.length ? 3 : 2
+        motivos.push(`el concepto menciona "${datos.proveedor}"`)
+      }
+    }
+    if (datos.numero) {
+      const textoMovimiento = normalizarTexto(
+        [fila.concepto, fila.contraparte, fila.descripcion].filter(Boolean).join(" "),
+      )
+      if (textoMovimiento.includes(normalizarTexto(datos.numero))) {
+        extra += 3
+        motivos.push(`el concepto menciona el número ${datos.numero}`)
+      }
+    }
+    if (fila.factura_id) motivos.push("ojo: ya tiene otra factura vinculada")
+
+    return {
+      movimiento: {
+        id: fila.id,
+        fecha: fila.fecha,
+        concepto: fila.concepto,
+        contraparte: fila.contraparte ?? null,
+        importe: Number(fila.importe),
+        delegacion: fila.delegacion_id ? delegaciones.get(fila.delegacion_id) ?? null : null,
+        cuenta: fila.cuenta_id ? catalogos.cuentas.get(fila.cuenta_id)?.nombre ?? null : null,
+        categoria: fila.categoria_id ? catalogos.categorias.get(fila.categoria_id)?.nombre ?? null : null,
+        factura_id: fila.factura_id ?? null,
+      },
+      puntuacion: base.score + extra,
+      importe_exacto: base.importeExacto,
+      motivos,
+    }
+  })
+
+  return puntuados
+    .sort((a, b) => b.puntuacion - a.puntuacion || (a.movimiento.fecha < b.movimiento.fecha ? 1 : -1))
+    .slice(0, limite)
+}
+
+export interface ItemConciliacion extends DatosFactura {
+  /** Etiqueta libre para reconocer esta línea en el resultado. */
+  referencia?: string | null
+  /** Restringe la búsqueda de esta línea a una delegación concreta. */
+  delegacion?: string | null
+  /** Si la factura ya existe en MCM Bank, su id (entonces no se crea otra). */
+  factura_id?: string | null
+}
+
+export interface ResultadoItemConciliacion {
+  referencia: string | null
+  importe: number | null
+  proveedor: string | null
+  fecha: string | null
+  /** El mejor candidato destaca lo suficiente como para vincularlo sin dudar. */
+  match_directo: boolean
+  candidatos: CandidatoMovimiento[]
+  /** Relleno solo cuando `aplicar: true` y hubo match directo. */
+  vinculado?: { factura_id: string; movimiento_id: string }
+  aviso?: string
+}
+
+export interface ConciliarLoteParams {
+  items: ItemConciliacion[]
+  delegaciones?: string | string[] | null
+  ventanaDias?: number
+  maxCandidatos?: number
+  /** Vincular automáticamente los match directos. Por defecto solo propone. */
+  aplicar?: boolean
+  /** Con `aplicar`, crear la factura en MCM Bank si la línea no traía `factura_id`. */
+  crearFacturas?: boolean
+}
+
+export interface ConciliarLoteResultado {
+  total: number
+  con_match_directo: number
+  sin_candidatos: number
+  vinculados: number
+  resultados: ResultadoItemConciliacion[]
+}
+
+/**
+ * Concilia un lote de facturas de golpe: "toma estos 12 importes, dime a qué
+ * movimiento corresponde cada uno".
+ *
+ * Por defecto solo propone. Con `aplicar: true` vincula únicamente los que
+ * tienen un match directo (importe exacto y ventaja clara sobre el segundo);
+ * los dudosos se devuelven para que decida una persona. Es deliberado: una
+ * conciliación equivocada es más cara de deshacer que de revisar.
+ */
+export async function conciliarLote(
+  admin: AdminClient,
+  params: ConciliarLoteParams,
+  actorId: string | null,
+): Promise<ConciliarLoteResultado> {
+  const items = params.items ?? []
+  if (items.length === 0) throw badRequest("No has enviado ninguna factura que conciliar.")
+  if (items.length > 100) {
+    throw badRequest(`Son demasiadas facturas de una vez (${items.length}). El máximo son 100.`)
+  }
+  if (params.aplicar && !actorId) {
+    throw badRequest("Para aplicar la conciliación hace falta saber quién la firma.")
+  }
+
+  const ambitoGeneral = await resolveAmbitoDelegaciones(admin, params.delegaciones)
+  const resultados: ResultadoItemConciliacion[] = []
+  let vinculados = 0
+
+  for (const item of items) {
+    const ambito = item.delegacion
+      ? [await resolveDelegacion(admin, item.delegacion)]
+      : ambitoGeneral
+
+    const candidatos = await buscarCandidatosParaFactura(admin, item, {
+      ambito,
+      ventanaDias: params.ventanaDias,
+      limite: params.maxCandidatos ?? 5,
+    })
+
+    const mejor = candidatos[0]
+    const segundo = candidatos[1]
+    const matchDirecto = Boolean(
+      mejor?.importe_exacto && (!segundo || mejor.puntuacion >= segundo.puntuacion + 2),
+    )
+
+    const resultado: ResultadoItemConciliacion = {
+      referencia: item.referencia ?? null,
+      importe: item.importe == null ? null : Math.abs(Number(item.importe)),
+      proveedor: item.proveedor ?? null,
+      fecha: item.fecha ?? null,
+      match_directo: matchDirecto,
+      candidatos,
+    }
+
+    if (params.aplicar && matchDirecto && actorId) {
+      try {
+        let facturaId = item.factura_id ?? null
+        if (!facturaId) {
+          if (!params.crearFacturas) {
+            resultado.aviso =
+              "Hay match directo pero la línea no trae 'factura_id'. Vuelve a llamar con 'crear_facturas: true' para registrarla en la bandeja y vincularla."
+            resultados.push(resultado)
+            continue
+          }
+          const delegacionMovimiento = mejor.movimiento.delegacion
+          if (!delegacionMovimiento) {
+            resultado.aviso = "El movimiento candidato no tiene delegación; no se puede crear la factura."
+            resultados.push(resultado)
+            continue
+          }
+          const creada = await crearFactura(
+            admin,
+            {
+              delegacion: delegacionMovimiento.id,
+              numero: item.numero ?? null,
+              concepto: item.proveedor ?? null,
+              importe: item.importe ?? null,
+              fecha_emision: item.fecha ?? null,
+              contacto_id: item.contacto_id ?? null,
+            },
+            actorId,
+          )
+          facturaId = creada.id
+        }
+
+        await vincularFacturaAMovimiento(admin, facturaId, mejor.movimiento.id, actorId)
+        resultado.vinculado = { factura_id: facturaId, movimiento_id: mejor.movimiento.id }
+        vinculados += 1
+      } catch (err) {
+        resultado.aviso = `No se pudo vincular: ${err instanceof Error ? err.message : String(err)}`
+      }
+    }
+
+    resultados.push(resultado)
+  }
+
+  return {
+    total: resultados.length,
+    con_match_directo: resultados.filter((r) => r.match_directo).length,
+    sin_candidatos: resultados.filter((r) => r.candidatos.length === 0).length,
+    vinculados,
+    resultados,
+  }
+}
+
+/**
+ * El camino inverso: dado un movimiento, qué facturas de la bandeja podrían
+ * corresponderle. Compara contra el importe **pendiente** de cada factura, para
+ * que funcione también con pagos en varios plazos.
+ */
+export async function buscarFacturasParaMovimiento(
+  admin: AdminClient,
+  movimientoId: string,
+  options: { limite?: number; baseUrl?: string } = {},
+): Promise<{ factura: FacturaPublica; puntuacion: number; motivos: string[] }[]> {
+  const movimiento = unwrap(
+    await (admin as any)
+      .from("movimiento")
+      .select("id, delegacion_id, fecha, importe, contacto_id")
+      .eq("id", movimientoId)
+      .maybeSingle(),
+  ) as any
+  if (!movimiento) throw notFound(`No existe ningún movimiento con el id ${movimientoId}.`)
+  if (!movimiento.delegacion_id) return []
+
+  const filas = (unwrap(
+    await (admin as any)
+      .from("factura")
+      .select(FACTURA_SELECT)
+      .eq("delegacion_id", movimiento.delegacion_id)
+      .not("estado", "in", "(pagada,pagada_fuera)")
+      .order("creado_en", { ascending: false })
+      .limit(60),
+  ) ?? []) as any[]
+
+  const delegaciones = await mapaDelegaciones(admin)
+  const archivos = await archivosDeFacturas(admin, filas.map((f) => f.id), {
+    baseUrl: options.baseUrl,
+  })
+  const importeMovimiento = Math.abs(Number(movimiento.importe))
+
+  return filas
+    .map((fila) => {
+      const factura = serializeFactura(fila, archivos.get(fila.id) ?? [], delegaciones)
+      const pendiente = factura.importe_pendiente
+      const base = scoreCandidatoMovimiento(
+        { importe: pendiente, fecha_emision: factura.fecha_emision, contacto_id: fila.contacto_id },
+        { importe: movimiento.importe, fecha: movimiento.fecha, contacto_id: movimiento.contacto_id } as any,
+      )
+
+      const fueraDeMargen =
+        pendiente != null &&
+        Math.abs(pendiente - importeMovimiento) > margenImporteFactura(importeMovimiento)
+
+      const motivos: string[] = []
+      if (base.importeExacto) motivos.push("el importe pendiente coincide exactamente")
+      if (base.fechaCercana) motivos.push("fecha muy cercana")
+      if (base.mismoContacto) motivos.push("mismo contacto")
+
+      return { factura, puntuacion: base.score, motivos, fueraDeMargen }
+    })
+    .filter((c) => !c.fueraDeMargen)
+    .sort((a, b) => b.puntuacion - a.puntuacion)
+    .slice(0, options.limite ?? 10)
+    .map(({ factura, puntuacion, motivos }) => ({ factura, puntuacion, motivos }))
+}

--- a/lib/api/movimientos-public.ts
+++ b/lib/api/movimientos-public.ts
@@ -1,16 +1,22 @@
 /**
- * Lógica de datos y serialización para la API externa de movimientos.
+ * Lógica de datos y serialización de movimientos para la API externa y el
+ * servidor MCP.
  *
- * Se separa de las rutas para que tanto el endpoint combinado
- * (`/api/v1/movimientos/[id]`) como el de archivos
- * (`/api/v1/movimientos/[id]/archivos`) compartan exactamente el mismo formato
- * de salida.
+ * Se separa de las rutas para que todos los consumidores (endpoints REST,
+ * herramientas MCP, conciliación de facturas) compartan exactamente el mismo
+ * formato de salida.
  *
- * El acceso se hace con el cliente admin (service role), de modo que la consulta
- * por ID es global y no depende de la delegación seleccionada ni de RLS: un ID
- * de movimiento es único en toda la base de datos.
+ * El acceso se hace con el cliente admin (service role), de modo que las
+ * consultas son globales y no dependen de la delegación seleccionada ni de RLS:
+ * quien usa esta API es un administrador multidelegación que revisa todas las
+ * delegaciones a la vez.
  */
 import type { createAdminClient } from "@/lib/supabase/admin"
+import { applyAbsoluteAmountFilter } from "@/lib/db/amount-filter"
+import { badRequest, notFound, unwrap, wrapSupabaseError } from "@/lib/api/errors"
+import { aplicarBusquedaTexto } from "@/lib/api/postgrest"
+import { mapaDelegaciones, type DelegacionPublica } from "@/lib/api/delegaciones"
+import { cargarCatalogos } from "@/lib/api/catalogos"
 
 type AdminClient = ReturnType<typeof createAdminClient>
 
@@ -23,7 +29,11 @@ export interface ArchivoPublico {
   es_factura: boolean
   descripcion: string | null
   bucket: string
+  /** URL pública directa. Vacía en los archivos subidos tras pasar a URLs firmadas. */
   url: string
+  /** Endpoint autenticado que redirige a una URL firmada de descarga. */
+  url_descarga?: string
+  path_storage?: string
   subido_en: string
 }
 
@@ -39,6 +49,8 @@ export interface MovimientoPublico {
   metodo: string | null
   notas: string | null
   ignorado: boolean
+  factura_id: string | null
+  factura_pendiente: boolean
   booking_date: string | null
   value_date: string | null
   origen_sync: string | null
@@ -80,6 +92,8 @@ const MOVIMIENTO_SELECT = `
   metodo,
   notas,
   ignorado,
+  factura_id,
+  factura_pendiente,
   booking_date,
   value_date,
   origen_sync,
@@ -107,19 +121,32 @@ const MOVIMIENTO_SELECT = `
 `
 
 /**
- * Convierte un error de Supabase/PostgREST (un objeto plano, no una instancia
- * de `Error`) en un `Error` real, para que el `catch` de las rutas pueda
- * mostrar `err.message` en vez de volcar `String(objetoPlano)` como
- * `"[object Object]"`.
+ * Columnas planas para listados. No se embeben relaciones: `movimiento` tiene
+ * dos claves foráneas hacia `cuenta` y desambiguarlas en cada consulta es
+ * frágil. Cuenta, categoría, contacto y delegación son tablas pequeñas que se
+ * cargan enteras una vez (ver `lib/api/catalogos.ts`) y se cruzan en memoria.
  */
-function wrapSupabaseError(error: unknown): Error {
-  if (error instanceof Error) return error
-  const message =
-    error && typeof error === "object" && "message" in error
-      ? String((error as { message?: unknown }).message)
-      : "Error desconocido de Supabase."
-  return new Error(message)
-}
+const MOVIMIENTO_LISTA_SELECT = `
+  id,
+  fecha,
+  concepto,
+  descripcion,
+  contraparte,
+  importe,
+  metodo,
+  notas,
+  ignorado,
+  factura_id,
+  factura_pendiente,
+  booking_date,
+  value_date,
+  origen_sync,
+  creado_en,
+  delegacion_id,
+  cuenta_id,
+  categoria_id,
+  contacto_id
+`
 
 /**
  * Obtiene un movimiento por su ID con sus relaciones (cuenta, categoría,
@@ -178,18 +205,45 @@ export async function getArchivosRaw(admin: AdminClient, movimientoId: string) {
   return (data ?? []) as any[]
 }
 
-/** Serializa una fila de `movimiento_archivo` al formato público. */
-export function serializeArchivo(row: any): ArchivoPublico {
+/** Archivos de varios movimientos a la vez, agrupados por movimiento. */
+export async function getArchivosDeMovimientos(
+  admin: AdminClient,
+  movimientoIds: string[],
+): Promise<Map<string, any[]>> {
+  const agrupados = new Map<string, any[]>()
+  if (movimientoIds.length === 0) return agrupados
+
+  const data = unwrap(
+    await (admin as any)
+      .from("movimiento_archivo")
+      .select("*")
+      .in("movimiento_id", movimientoIds)
+      .order("subido_en", { ascending: true }),
+  ) as any[] | null
+
+  for (const fila of data ?? []) {
+    const lista = agrupados.get(fila.movimiento_id) ?? []
+    lista.push(fila)
+    agrupados.set(fila.movimiento_id, lista)
+  }
+  return agrupados
+}
+
+/** Serializa una fila de `movimiento_archivo` o `archivo_adjunto` al formato público. */
+export function serializeArchivo(row: any, options: { baseUrl?: string } = {}): ArchivoPublico {
   return {
     id: row.id,
     nombre_original: row.nombre_original,
     tipo_mime: row.tipo_mime,
-    // La columna en BD es `tamaño_bytes` (con ñ); se expone sin ñ para clientes.
+    // En `movimiento_archivo` la columna es `tamaño_bytes` (con ñ) y en
+    // `archivo_adjunto` es `tamano_bytes`; se expone siempre sin ñ.
     tamano_bytes: row["tamaño_bytes"] ?? row.tamano_bytes ?? 0,
     es_factura: !!row.es_factura,
     descripcion: row.descripcion ?? null,
     bucket: row.bucket,
-    url: row.url_publica,
+    url: row.url_publica ?? "",
+    ...(options.baseUrl ? { url_descarga: `${options.baseUrl}/api/v1/archivos/${row.id}/descargar` } : {}),
+    path_storage: row.path_storage,
     subido_en: row.subido_en,
   }
 }
@@ -205,11 +259,13 @@ export function serializeMovimiento(
     concepto: row.concepto,
     descripcion: row.descripcion ?? null,
     contraparte: row.contraparte ?? null,
-    importe: row.importe,
+    importe: Number(row.importe),
     tipo: Number(row.importe) >= 0 ? "ingreso" : "gasto",
     metodo: row.metodo ?? null,
     notas: row.notas ?? null,
     ignorado: !!row.ignorado,
+    factura_id: row.factura_id ?? null,
+    factura_pendiente: !!row.factura_pendiente,
     booking_date: row.booking_date ?? null,
     value_date: row.value_date ?? null,
     origen_sync: row.origen_sync ?? null,
@@ -248,4 +304,363 @@ export function serializeMovimiento(
       : null,
     archivos,
   }
+}
+
+// ---------------------------------------------------------------------------
+// Búsqueda de movimientos
+// ---------------------------------------------------------------------------
+
+export type OrdenMovimientos = "fecha_desc" | "fecha_asc" | "importe_desc" | "importe_asc"
+
+export interface BuscarMovimientosParams {
+  /** Delegaciones ya resueltas. `null` = todas. */
+  delegaciones?: DelegacionPublica[] | null
+  /** Texto libre; cada palabra debe aparecer en concepto, descripción o contraparte. */
+  texto?: string | null
+  /** Rango por valor absoluto: `importe_min: 50` encuentra tanto +50 como -50. */
+  importeMin?: number | null
+  importeMax?: number | null
+  tipo?: "ingreso" | "gasto" | null
+  fechaDesde?: string | null
+  fechaHasta?: string | null
+  categoriaIds?: string[] | null
+  sinCategoria?: boolean
+  cuentaIds?: string[] | null
+  contactoIds?: string[] | null
+  /** `true` = solo con factura vinculada, `false` = solo sin factura. */
+  conFactura?: boolean | null
+  facturaPendiente?: boolean
+  /** Por defecto se excluyen (igual que en la app). */
+  incluirIgnorados?: boolean
+  /** Por defecto se excluyen los de cuentas desactivadas (igual que en la app). */
+  incluirCuentasInactivas?: boolean
+  orden?: OrdenMovimientos
+  limite?: number
+  offset?: number
+  incluirArchivos?: boolean
+  baseUrl?: string
+}
+
+export interface ResumenPorDelegacion {
+  delegacion: DelegacionPublica | null
+  movimientos: number
+  ingresos: number
+  gastos: number
+  neto: number
+}
+
+export interface BuscarMovimientosResultado {
+  total: number
+  limite: number
+  offset: number
+  hay_mas: boolean
+  resumen: {
+    movimientos: number
+    ingresos: number
+    gastos: number
+    neto: number
+    truncado: boolean
+    por_delegacion: ResumenPorDelegacion[]
+  }
+  movimientos: MovimientoPublico[]
+}
+
+const LIMITE_POR_DEFECTO = 50
+const LIMITE_MAXIMO = 200
+/** Tope de filas que se agregan para el resumen (páginas de 1000). */
+const RESUMEN_MAX_FILAS = 20_000
+
+const COLUMNAS_TEXTO = ["concepto", "descripcion", "contraparte", "notas", "texto_extra_1", "texto_extra_2"]
+
+function redondear(n: number): number {
+  return Math.round(n * 100) / 100
+}
+
+/**
+ * Aplica al query builder todos los filtros de búsqueda. Se usa tanto para la
+ * página de resultados como para la consulta de agregados, de modo que el
+ * resumen siempre corresponde exactamente a lo que se ha buscado.
+ */
+function aplicarFiltros(query: any, params: BuscarMovimientosParams, cuentasExcluidas: string[]): any {
+  let q = query
+
+  if (params.delegaciones) {
+    q = q.in("delegacion_id", params.delegaciones.map((d) => d.id))
+  }
+  if (!params.incluirIgnorados) {
+    q = q.eq("ignorado", false)
+  }
+  if (cuentasExcluidas.length > 0) {
+    q = q.not("cuenta_id", "in", `(${cuentasExcluidas.join(",")})`)
+  }
+  if (params.fechaDesde) q = q.gte("fecha", params.fechaDesde)
+  if (params.fechaHasta) q = q.lte("fecha", params.fechaHasta)
+  if (params.tipo === "gasto") q = q.lt("importe", 0)
+  if (params.tipo === "ingreso") q = q.gte("importe", 0)
+  if (params.categoriaIds?.length) q = q.in("categoria_id", params.categoriaIds)
+  if (params.sinCategoria) q = q.is("categoria_id", null)
+  if (params.cuentaIds?.length) q = q.in("cuenta_id", params.cuentaIds)
+  if (params.contactoIds?.length) q = q.in("contacto_id", params.contactoIds)
+  if (params.conFactura === true) q = q.not("factura_id", "is", null)
+  if (params.conFactura === false) q = q.is("factura_id", null)
+  if (params.facturaPendiente) q = q.eq("factura_pendiente", true)
+
+  q = applyAbsoluteAmountFilter(
+    q,
+    params.importeMin ?? undefined,
+    params.importeMax ?? undefined,
+  )
+  q = aplicarBusquedaTexto(q, params.texto, COLUMNAS_TEXTO)
+
+  return q
+}
+
+function aplicarOrden(query: any, orden: OrdenMovimientos): any {
+  switch (orden) {
+    case "fecha_asc":
+      return query.order("fecha", { ascending: true }).order("creado_en", { ascending: true })
+    case "importe_desc":
+      return query.order("importe", { ascending: false })
+    case "importe_asc":
+      return query.order("importe", { ascending: true })
+    case "fecha_desc":
+    default:
+      return query.order("fecha", { ascending: false }).order("creado_en", { ascending: false })
+  }
+}
+
+/**
+ * Busca movimientos en una, varias o todas las delegaciones y devuelve además
+ * el resumen económico del conjunto completo (no solo de la página): sin eso,
+ * "cuánto llevamos gastado en Mercadona" obligaría a paginar a mano.
+ */
+export async function buscarMovimientos(
+  admin: AdminClient,
+  params: BuscarMovimientosParams,
+): Promise<BuscarMovimientosResultado> {
+  const limite = Math.min(Math.max(params.limite ?? LIMITE_POR_DEFECTO, 1), LIMITE_MAXIMO)
+  const offset = Math.max(params.offset ?? 0, 0)
+  const orden = params.orden ?? "fecha_desc"
+
+  if (params.fechaDesde && params.fechaHasta && params.fechaDesde > params.fechaHasta) {
+    throw badRequest(
+      `El rango de fechas está al revés: 'desde' (${params.fechaDesde}) es posterior a 'hasta' (${params.fechaHasta}).`,
+    )
+  }
+
+  const catalogos = await cargarCatalogos(admin)
+  const cuentasExcluidas = params.incluirCuentasInactivas
+    ? []
+    : [...catalogos.cuentas.values()].filter((c) => !c.activa).map((c) => c.id)
+
+  // Página de resultados
+  let query = (admin as any)
+    .from("movimiento")
+    .select(MOVIMIENTO_LISTA_SELECT, { count: "exact" })
+  query = aplicarFiltros(query, params, cuentasExcluidas)
+  query = aplicarOrden(query, orden).range(offset, offset + limite - 1)
+
+  const { data, count, error } = await query
+  if (error) throw wrapSupabaseError(error)
+  const filas = (data ?? []) as any[]
+
+  const total = count ?? filas.length
+
+  // Agregados sobre TODO el conjunto que cumple los filtros
+  const resumen = await agregarResumen(admin, params, cuentasExcluidas, total)
+
+  const delegaciones = await mapaDelegaciones(admin)
+  const archivosPorMovimiento =
+    params.incluirArchivos === false
+      ? new Map<string, any[]>()
+      : await getArchivosDeMovimientos(admin, filas.map((f) => f.id))
+
+  const movimientos = filas.map((fila) => {
+    const enriquecida = {
+      ...fila,
+      cuenta: fila.cuenta_id ? catalogos.cuentas.get(fila.cuenta_id) ?? null : null,
+      categoria: fila.categoria_id ? catalogos.categorias.get(fila.categoria_id) ?? null : null,
+      contacto: fila.contacto_id ? catalogos.contactos.get(fila.contacto_id) ?? null : null,
+      delegacion: fila.delegacion_id ? delegaciones.get(fila.delegacion_id) ?? null : null,
+    }
+    const archivos = (archivosPorMovimiento.get(fila.id) ?? []).map((a) =>
+      serializeArchivo(a, { baseUrl: params.baseUrl }),
+    )
+    return serializeMovimiento(enriquecida, archivos)
+  })
+
+  return {
+    total,
+    limite,
+    offset,
+    hay_mas: offset + movimientos.length < total,
+    resumen: {
+      ...resumen,
+      por_delegacion: resumen.por_delegacion.map((r) => ({
+        ...r,
+        delegacion: r.delegacion ? delegaciones.get(r.delegacion.id) ?? r.delegacion : null,
+      })),
+    },
+    movimientos,
+  }
+}
+
+/**
+ * Suma ingresos, gastos y neto de todo el conjunto filtrado, desglosado por
+ * delegación. Se traen solo dos columnas por fila y se agregan en memoria: es
+ * más simple que una función SQL nueva y a la escala de MCM (miles de
+ * movimientos) es instantáneo. Si algún día se pasa del tope, se marca
+ * `truncado: true` en vez de mentir con un total incompleto.
+ */
+async function agregarResumen(
+  admin: AdminClient,
+  params: BuscarMovimientosParams,
+  cuentasExcluidas: string[],
+  total: number,
+): Promise<Omit<BuscarMovimientosResultado["resumen"], "por_delegacion"> & {
+  por_delegacion: { delegacion: DelegacionPublica | null; movimientos: number; ingresos: number; gastos: number; neto: number }[]
+}> {
+  const porDelegacion = new Map<string, { movimientos: number; ingresos: number; gastos: number }>()
+  let totalFilas = 0
+  let ingresos = 0
+  let gastos = 0
+
+  const PAGINA = 1000
+  for (let desde = 0; desde < RESUMEN_MAX_FILAS; desde += PAGINA) {
+    // Se pagina ordenando por `id` (único) y no por fecha: con un orden no
+    // estable, las filas que comparten fecha pueden repetirse o saltarse entre
+    // páginas y el total saldría mal.
+    let query = (admin as any).from("movimiento").select("delegacion_id, importe")
+    query = aplicarFiltros(query, params, cuentasExcluidas)
+    query = query.order("id", { ascending: true }).range(desde, desde + PAGINA - 1)
+
+    const { data, error } = await query
+    if (error) throw wrapSupabaseError(error)
+    const filas = (data ?? []) as { delegacion_id: string | null; importe: number }[]
+
+    for (const fila of filas) {
+      const importe = Number(fila.importe)
+      totalFilas += 1
+      if (importe >= 0) ingresos += importe
+      else gastos += importe
+
+      const clave = fila.delegacion_id ?? "sin_delegacion"
+      const acumulado = porDelegacion.get(clave) ?? { movimientos: 0, ingresos: 0, gastos: 0 }
+      acumulado.movimientos += 1
+      if (importe >= 0) acumulado.ingresos += importe
+      else acumulado.gastos += importe
+      porDelegacion.set(clave, acumulado)
+    }
+
+    if (filas.length < PAGINA) break
+  }
+
+  const delegaciones = await mapaDelegaciones(admin)
+
+  return {
+    truncado: totalFilas < total,
+    movimientos: totalFilas,
+    ingresos: redondear(ingresos),
+    gastos: redondear(gastos),
+    neto: redondear(ingresos + gastos),
+    por_delegacion: [...porDelegacion.entries()]
+      .map(([id, v]) => ({
+        delegacion: delegaciones.get(id) ?? null,
+        movimientos: v.movimientos,
+        ingresos: redondear(v.ingresos),
+        gastos: redondear(v.gastos),
+        neto: redondear(v.ingresos + v.gastos),
+      }))
+      .sort((a, b) => a.gastos - b.gastos),
+  }
+}
+
+/** Movimiento completo (con archivos) o `null`. */
+export async function obtenerMovimiento(
+  admin: AdminClient,
+  id: string,
+  options: { baseUrl?: string } = {},
+): Promise<MovimientoPublico | null> {
+  const row = await getMovimientoRaw(admin, id)
+  if (!row) return null
+  const archivos = (await getArchivosRaw(admin, id)).map((a) =>
+    serializeArchivo(a, { baseUrl: options.baseUrl }),
+  )
+  return serializeMovimiento(row, archivos)
+}
+
+// ---------------------------------------------------------------------------
+// Escritura
+// ---------------------------------------------------------------------------
+
+/** Campos de un movimiento que la API externa puede modificar. */
+export interface ActualizarMovimientoParams {
+  categoria_id?: string | null
+  contacto_id?: string | null
+  notas?: string | null
+  descripcion?: string | null
+  contraparte?: string | null
+  metodo?: string | null
+  ignorado?: boolean
+  factura_pendiente?: boolean
+}
+
+/**
+ * Actualiza los campos "editables por humanos" de un movimiento.
+ *
+ * Deliberadamente NO deja tocar importe, fecha, cuenta ni delegación: esos
+ * datos vienen del banco y cambiarlos desde una integración externa sería una
+ * forma silenciosa de descuadrar la contabilidad. Para el vínculo con facturas
+ * está `vincularFacturaAMovimiento`, que además mantiene el estado de la factura.
+ */
+export async function actualizarMovimiento(
+  admin: AdminClient,
+  id: string,
+  cambios: ActualizarMovimientoParams,
+  options: { baseUrl?: string } = {},
+): Promise<MovimientoPublico> {
+  const existente = unwrap(
+    await (admin as any).from("movimiento").select("id, delegacion_id").eq("id", id).maybeSingle(),
+  )
+  if (!existente) throw notFound(`No existe ningún movimiento con el id ${id}.`)
+
+  const updates: Record<string, unknown> = {}
+  for (const campo of [
+    "categoria_id",
+    "contacto_id",
+    "notas",
+    "descripcion",
+    "contraparte",
+    "metodo",
+    "ignorado",
+    "factura_pendiente",
+  ] as const) {
+    if (cambios[campo] !== undefined) updates[campo] = cambios[campo]
+  }
+
+  if (Object.keys(updates).length === 0) {
+    throw badRequest(
+      "No has indicado ningún cambio. Campos admitidos: categoria_id, contacto_id, notas, descripcion, contraparte, metodo, ignorado, factura_pendiente.",
+    )
+  }
+
+  if (typeof updates.categoria_id === "string") {
+    const { categorias } = await cargarCatalogos(admin)
+    if (!categorias.has(updates.categoria_id as string)) {
+      throw notFound(`No existe ninguna categoría con el id ${updates.categoria_id}.`)
+    }
+  }
+  if (typeof updates.contacto_id === "string") {
+    const { contactos } = await cargarCatalogos(admin)
+    if (!contactos.has(updates.contacto_id as string)) {
+      throw notFound(`No existe ningún contacto con el id ${updates.contacto_id}.`)
+    }
+  }
+
+  const { error } = await (admin as any).from("movimiento").update(updates).eq("id", id)
+  if (error) throw wrapSupabaseError(error)
+
+  const actualizado = await obtenerMovimiento(admin, id, options)
+  if (!actualizado) throw notFound(`No existe ningún movimiento con el id ${id}.`)
+  return actualizado
 }

--- a/lib/api/pagos.ts
+++ b/lib/api/pagos.ts
@@ -1,0 +1,105 @@
+import type { createAdminClient } from "@/lib/supabase/admin"
+import { wrapSupabaseError } from "@/lib/api/errors"
+import { resolveAmbitoDelegaciones, mapaDelegaciones, type DelegacionPublica } from "@/lib/api/delegaciones"
+import { cargarCatalogos } from "@/lib/api/catalogos"
+
+type AdminClient = ReturnType<typeof createAdminClient>
+
+/**
+ * Pagos MCM: reembolsos a personas del movimiento (kilometraje, gastos
+ * adelantados…).
+ *
+ * De momento la API solo los **lee**. Es la sección menos usada y su alta tiene
+ * reglas propias (cálculo de gasolina, contacto obligatorio) que se hacen mejor
+ * desde la pantalla; exponerlas a medias sería peor que no exponerlas. Leerlos
+ * sí hace falta: al revisar movimientos conviene ver si uno corresponde a un
+ * pago MCM ya registrado.
+ */
+
+export interface PagoMcmPublico {
+  id: string
+  concepto: string
+  descripcion: string | null
+  importe: number
+  moneda: string
+  estado: string
+  tipo_calculo: string
+  delegacion: DelegacionPublica | null
+  contacto: { id: string; nombre: string; tipo: string | null } | null
+  categoria_sugerida: { id: string; nombre: string } | null
+  movimiento_id: string | null
+  notas: string | null
+  creado_en: string
+  actualizado_en: string
+}
+
+export interface ListarPagosParams {
+  delegaciones?: string | string[] | null
+  estados?: string[] | null
+  contactoIds?: string[] | null
+  limite?: number
+  offset?: number
+}
+
+export async function listarPagosMcm(
+  admin: AdminClient,
+  params: ListarPagosParams = {},
+): Promise<{ total: number; limite: number; offset: number; pagos: PagoMcmPublico[] }> {
+  const limite = Math.min(Math.max(params.limite ?? 50, 1), 200)
+  const offset = Math.max(params.offset ?? 0, 0)
+  const ambito = await resolveAmbitoDelegaciones(admin, params.delegaciones)
+
+  let query = (admin as any)
+    .from("pago_mcm")
+    .select("*", { count: "exact" })
+    .order("creado_en", { ascending: false })
+    .range(offset, offset + limite - 1)
+
+  if (ambito) query = query.in("delegacion_id", ambito.map((d) => d.id))
+  if (params.estados?.length) query = query.in("estado", params.estados)
+  if (params.contactoIds?.length) query = query.in("contacto_id", params.contactoIds)
+
+  const { data, count, error } = await query
+  if (error) throw wrapSupabaseError(error)
+
+  const filas = (data ?? []) as any[]
+  const [delegaciones, catalogos] = await Promise.all([
+    mapaDelegaciones(admin),
+    cargarCatalogos(admin),
+  ])
+
+  return {
+    total: count ?? filas.length,
+    limite,
+    offset,
+    pagos: filas.map((f) => serializePago(f, delegaciones, catalogos)),
+  }
+}
+
+function serializePago(
+  fila: any,
+  delegaciones: Map<string, DelegacionPublica>,
+  catalogos: Awaited<ReturnType<typeof cargarCatalogos>>,
+): PagoMcmPublico {
+  const contacto = fila.contacto_id ? catalogos.contactos.get(fila.contacto_id) : null
+  const categoria = fila.categoria_id_sugerida
+    ? catalogos.categorias.get(fila.categoria_id_sugerida)
+    : null
+
+  return {
+    id: fila.id,
+    concepto: fila.concepto,
+    descripcion: fila.descripcion ?? null,
+    importe: Number(fila.importe),
+    moneda: fila.moneda ?? "EUR",
+    estado: fila.estado,
+    tipo_calculo: fila.tipo_calculo,
+    delegacion: delegaciones.get(fila.delegacion_id) ?? null,
+    contacto: contacto ? { id: contacto.id, nombre: contacto.nombre, tipo: contacto.tipo } : null,
+    categoria_sugerida: categoria ? { id: categoria.id, nombre: categoria.nombre } : null,
+    movimiento_id: fila.movimiento_id ?? null,
+    notas: fila.notas ?? null,
+    creado_en: fila.creado_en,
+    actualizado_en: fila.actualizado_en,
+  }
+}

--- a/lib/api/postgrest.test.ts
+++ b/lib/api/postgrest.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest"
+import { aplicarBusquedaTexto, ilikeOrClause, palabrasBusqueda } from "@/lib/api/postgrest"
+
+/** Mock mínimo de un query builder de Supabase que registra los `or()`. */
+function mockQuery() {
+  const calls: string[] = []
+  const q: any = {
+    calls,
+    or: (filtro: string) => (calls.push(filtro), q),
+  }
+  return q
+}
+
+describe("ilikeOrClause", () => {
+  it("entrecomilla el valor para que las comas no partan la cláusula", () => {
+    // Sin comillas, PostgREST leería "Mercadona" y " S.A." como dos condiciones.
+    expect(ilikeOrClause(["concepto"], "Mercadona, S.A.")).toBe(
+      'concepto.ilike."%Mercadona, S.A.%"',
+    )
+  })
+
+  it("escapa comillas y barras invertidas dentro del valor", () => {
+    expect(ilikeOrClause(["concepto"], 'a"b\\c')).toBe('concepto.ilike."%a\\"b\\\\c%"')
+  })
+
+  it("repite la condición en cada columna", () => {
+    expect(ilikeOrClause(["concepto", "notas"], "luz")).toBe(
+      'concepto.ilike."%luz%",notas.ilike."%luz%"',
+    )
+  })
+})
+
+describe("palabrasBusqueda", () => {
+  it("parte por espacios y descarta los huecos", () => {
+    expect(palabrasBusqueda("  mercadona   valencia ")).toEqual(["mercadona", "valencia"])
+  })
+
+  it("corta a un máximo de palabras para no generar una query enorme", () => {
+    expect(palabrasBusqueda("a b c d e f g h", 3)).toEqual(["a", "b", "c"])
+  })
+})
+
+describe("aplicarBusquedaTexto", () => {
+  it("no toca el query si no hay texto", () => {
+    const q = mockQuery()
+    aplicarBusquedaTexto(q, "   ", ["concepto"])
+    expect(q.calls).toHaveLength(0)
+  })
+
+  it("añade un or() por palabra, de modo que se exigen todas (AND entre or())", () => {
+    const q = mockQuery()
+    aplicarBusquedaTexto(q, "mercadona valencia", ["concepto", "contraparte"])
+
+    expect(q.calls).toEqual([
+      'concepto.ilike."%mercadona%",contraparte.ilike."%mercadona%"',
+      'concepto.ilike."%valencia%",contraparte.ilike."%valencia%"',
+    ])
+  })
+})

--- a/lib/api/postgrest.ts
+++ b/lib/api/postgrest.ts
@@ -1,0 +1,57 @@
+/**
+ * Utilidades para construir filtros de PostgREST sin romperse con el texto que
+ * escriben las personas.
+ *
+ * El operador `or=(...)` de PostgREST separa condiciones por comas y delimita
+ * grupos con paréntesis, así que un término de búsqueda como
+ * `"Mercadona, S.A. (Valencia)"` rompe la query si se interpola tal cual. La
+ * solución del propio PostgREST es entrecomillar el valor: dentro de comillas
+ * dobles, comas y paréntesis son literales y solo hay que escapar `\` y `"`.
+ */
+
+/** Escapa un valor para usarlo entrecomillado dentro de `or=(...)`. */
+function valorEntrecomillado(valor: string): string {
+  return `"${valor.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`
+}
+
+/**
+ * Cláusula `or` que busca un término en varias columnas con `ilike`.
+ *
+ * `%` y `_` se dejan pasar como comodines de SQL: es útil ("MERCA%") y quien
+ * llama controla el texto.
+ */
+export function ilikeOrClause(columnas: string[], termino: string): string {
+  return columnas.map((col) => `${col}.ilike.${valorEntrecomillado(`%${termino}%`)}`).join(",")
+}
+
+/**
+ * Divide una búsqueda en palabras. Cada palabra se aplicará como un `or()`
+ * independiente, y como supabase-js une los `or()` sucesivos con AND, el
+ * resultado es "todas las palabras aparecen en alguna de las columnas".
+ *
+ * Así `"mercadona valencia"` encuentra un movimiento cuyo concepto es
+ * `"COMPRA MERCADONA"` y cuya contraparte es `"Mercadona Valencia"`, en vez de
+ * exigir que la frase entera esté en una sola columna.
+ */
+export function palabrasBusqueda(texto: string, maxPalabras = 6): string[] {
+  return texto
+    .trim()
+    .split(/\s+/)
+    .filter((p) => p.length > 0)
+    .slice(0, maxPalabras)
+}
+
+/** Aplica una búsqueda de texto multi-palabra sobre varias columnas. */
+export function aplicarBusquedaTexto<T extends { or: (filtro: string) => T }>(
+  query: T,
+  texto: string | undefined | null,
+  columnas: string[],
+): T {
+  const limpio = (texto ?? "").trim()
+  if (!limpio) return query
+  let q = query
+  for (const palabra of palabrasBusqueda(limpio)) {
+    q = q.or(ilikeOrClause(columnas, palabra))
+  }
+  return q
+}

--- a/lib/api/resumen.ts
+++ b/lib/api/resumen.ts
@@ -1,0 +1,247 @@
+import type { createAdminClient } from "@/lib/supabase/admin"
+import { wrapSupabaseError } from "@/lib/api/errors"
+import {
+  listDelegaciones,
+  resolveAmbitoDelegaciones,
+  type DelegacionPublica,
+} from "@/lib/api/delegaciones"
+import { cargarCatalogos } from "@/lib/api/catalogos"
+
+type AdminClient = ReturnType<typeof createAdminClient>
+
+/**
+ * Foto económica de una, varias o todas las delegaciones.
+ *
+ * Las funciones de agregación que ya existen en Postgres (`get_financial_summary`,
+ * `get_saldos_por_cuenta`…) llevan un `assert_delegacion_member` que comprueba
+ * `auth.uid()`, así que no sirven con la clave de servicio: no hay usuario
+ * detrás. Se agrega aquí, paginando y sumando. A la escala de MCM (miles de
+ * movimientos) son un par de peticiones; si algún día crece, esto es lo primero
+ * que debería convertirse en una función SQL con su propio permiso.
+ */
+
+const PAGINA = 1000
+const MAX_FILAS = 40_000
+
+function redondear(n: number): number {
+  return Math.round(n * 100) / 100
+}
+
+export interface ResumenDelegacion {
+  delegacion: DelegacionPublica
+  movimientos: number
+  ingresos: number
+  gastos: number
+  neto: number
+  /** Saldo acumulado de todas las cuentas activas (todo el histórico). */
+  saldo: number | null
+  cuentas: number
+  facturas_pendientes: number
+  avisos_pendientes: number
+}
+
+export interface ResumenCategoria {
+  categoria: { id: string; nombre: string; emoji: string | null; color: string | null } | null
+  movimientos: number
+  ingresos: number
+  gastos: number
+  neto: number
+}
+
+export interface ResumenGeneral {
+  desde: string | null
+  hasta: string | null
+  totales: {
+    delegaciones: number
+    movimientos: number
+    ingresos: number
+    gastos: number
+    neto: number
+    saldo: number
+  }
+  truncado: boolean
+  por_delegacion: ResumenDelegacion[]
+  por_categoria: ResumenCategoria[]
+}
+
+interface FilaAgregable {
+  delegacion_id: string | null
+  categoria_id: string | null
+  cuenta_id: string | null
+  importe: number
+  fecha: string
+  ignorado: boolean
+}
+
+/** Trae las columnas mínimas de los movimientos del ámbito, paginando. */
+async function traerFilas(
+  admin: AdminClient,
+  delegacionIds: string[] | null,
+): Promise<{ filas: FilaAgregable[]; truncado: boolean }> {
+  const filas: FilaAgregable[] = []
+
+  for (let desde = 0; desde < MAX_FILAS; desde += PAGINA) {
+    let query = (admin as any)
+      .from("movimiento")
+      .select("delegacion_id, categoria_id, cuenta_id, importe, fecha, ignorado")
+      // Orden por `id` (único): con un orden no estable las páginas se solapan
+      // y los totales saldrían mal.
+      .order("id", { ascending: true })
+      .range(desde, desde + PAGINA - 1)
+
+    if (delegacionIds) query = query.in("delegacion_id", delegacionIds)
+
+    const { data, error } = await query
+    if (error) throw wrapSupabaseError(error)
+
+    const pagina = (data ?? []) as FilaAgregable[]
+    filas.push(...pagina)
+    if (pagina.length < PAGINA) return { filas, truncado: false }
+  }
+
+  return { filas, truncado: true }
+}
+
+export interface ResumenParams {
+  delegaciones?: string | string[] | null
+  desde?: string | null
+  hasta?: string | null
+  /** Incluir en ingresos/gastos los movimientos marcados como ignorados. */
+  incluirIgnorados?: boolean
+}
+
+export async function resumenGeneral(
+  admin: AdminClient,
+  params: ResumenParams = {},
+): Promise<ResumenGeneral> {
+  const ambito = await resolveAmbitoDelegaciones(admin, params.delegaciones)
+  const delegaciones = ambito ?? (await listDelegaciones(admin))
+  const catalogos = await cargarCatalogos(admin)
+
+  const { filas, truncado } = await traerFilas(admin, ambito ? ambito.map((d) => d.id) : null)
+
+  const cuentasActivas = new Set(
+    [...catalogos.cuentas.values()].filter((c) => c.activa).map((c) => c.id),
+  )
+
+  const porDelegacion = new Map<string, { movimientos: number; ingresos: number; gastos: number; saldo: number }>()
+  const porCategoria = new Map<string, { movimientos: number; ingresos: number; gastos: number }>()
+
+  for (const fila of filas) {
+    const importe = Number(fila.importe)
+    const clave = fila.delegacion_id ?? "sin_delegacion"
+    const acumulado =
+      porDelegacion.get(clave) ?? { movimientos: 0, ingresos: 0, gastos: 0, saldo: 0 }
+
+    // El saldo refleja el extracto del banco: suma todo, también lo ignorado.
+    if (fila.cuenta_id && cuentasActivas.has(fila.cuenta_id)) acumulado.saldo += importe
+
+    const dentroDeFechas =
+      (!params.desde || fila.fecha >= params.desde) && (!params.hasta || fila.fecha <= params.hasta)
+    const cuenta = fila.cuenta_id ? catalogos.cuentas.get(fila.cuenta_id) : null
+    const contable =
+      dentroDeFechas && (params.incluirIgnorados || !fila.ignorado) && (!cuenta || cuenta.activa)
+
+    if (contable) {
+      acumulado.movimientos += 1
+      if (importe >= 0) acumulado.ingresos += importe
+      else acumulado.gastos += importe
+
+      const claveCategoria = fila.categoria_id ?? "sin_categoria"
+      const cat = porCategoria.get(claveCategoria) ?? { movimientos: 0, ingresos: 0, gastos: 0 }
+      cat.movimientos += 1
+      if (importe >= 0) cat.ingresos += importe
+      else cat.gastos += importe
+      porCategoria.set(claveCategoria, cat)
+    }
+
+    porDelegacion.set(clave, acumulado)
+  }
+
+  const [facturasPendientes, avisosPendientes] = await Promise.all([
+    contarPorDelegacion(admin, "factura", (q) =>
+      q.not("estado", "in", "(pagada,pagada_fuera)"),
+    ),
+    contarPorDelegacion(admin, "aviso", (q) => q.eq("estado", "pendiente")),
+  ])
+
+  const resumenDelegaciones: ResumenDelegacion[] = delegaciones.map((delegacion) => {
+    const v = porDelegacion.get(delegacion.id) ?? { movimientos: 0, ingresos: 0, gastos: 0, saldo: 0 }
+    return {
+      delegacion,
+      movimientos: v.movimientos,
+      ingresos: redondear(v.ingresos),
+      gastos: redondear(v.gastos),
+      neto: redondear(v.ingresos + v.gastos),
+      saldo: redondear(v.saldo),
+      cuentas: [...catalogos.cuentas.values()].filter(
+        (c) => c.delegacion_id === delegacion.id && c.activa,
+      ).length,
+      facturas_pendientes: facturasPendientes.get(delegacion.id) ?? 0,
+      avisos_pendientes: avisosPendientes.get(delegacion.id) ?? 0,
+    }
+  })
+
+  const totales = resumenDelegaciones.reduce(
+    (acc, r) => ({
+      delegaciones: acc.delegaciones + 1,
+      movimientos: acc.movimientos + r.movimientos,
+      ingresos: acc.ingresos + r.ingresos,
+      gastos: acc.gastos + r.gastos,
+      neto: acc.neto + r.neto,
+      saldo: acc.saldo + (r.saldo ?? 0),
+    }),
+    { delegaciones: 0, movimientos: 0, ingresos: 0, gastos: 0, neto: 0, saldo: 0 },
+  )
+
+  return {
+    desde: params.desde ?? null,
+    hasta: params.hasta ?? null,
+    truncado,
+    totales: {
+      ...totales,
+      ingresos: redondear(totales.ingresos),
+      gastos: redondear(totales.gastos),
+      neto: redondear(totales.neto),
+      saldo: redondear(totales.saldo),
+    },
+    por_delegacion: resumenDelegaciones.sort((a, b) => a.gastos - b.gastos),
+    por_categoria: [...porCategoria.entries()]
+      .map(([id, v]) => {
+        const categoria = catalogos.categorias.get(id)
+        return {
+          categoria: categoria
+            ? {
+                id: categoria.id,
+                nombre: categoria.nombre,
+                emoji: categoria.emoji,
+                color: categoria.color,
+              }
+            : null,
+          movimientos: v.movimientos,
+          ingresos: redondear(v.ingresos),
+          gastos: redondear(v.gastos),
+          neto: redondear(v.ingresos + v.gastos),
+        }
+      })
+      .sort((a, b) => a.gastos - b.gastos),
+  }
+}
+
+/** Cuenta filas por delegación en una tabla que tenga `delegacion_id`. */
+async function contarPorDelegacion(
+  admin: AdminClient,
+  tabla: string,
+  filtro: (q: any) => any,
+): Promise<Map<string, number>> {
+  const { data, error } = await filtro(
+    (admin as any).from(tabla).select("delegacion_id"),
+  ).limit(5000)
+  if (error) throw wrapSupabaseError(error)
+
+  const conteo = new Map<string, number>()
+  for (const fila of (data ?? []) as { delegacion_id: string }[]) {
+    conteo.set(fila.delegacion_id, (conteo.get(fila.delegacion_id) ?? 0) + 1)
+  }
+  return conteo
+}

--- a/lib/api/route-helpers.ts
+++ b/lib/api/route-helpers.ts
@@ -1,0 +1,109 @@
+import { NextResponse } from "next/server"
+import { verifyApiKey, type ApiScope } from "@/lib/api/external-auth"
+import { badRequest, errorResponse } from "@/lib/api/errors"
+import type { ActorHint } from "@/lib/api/actor"
+
+/**
+ * Andamiaje común de las rutas de `/api/v1`: autenticación, lectura de
+ * parámetros y forma homogénea de la respuesta (`{ ok: true, ... }` o
+ * `{ ok: false, error }`).
+ */
+
+export interface PeticionApi {
+  scope: ApiScope
+  baseUrl: string
+  actorHint: ActorHint
+  params: URLSearchParams
+}
+
+/**
+ * Ejecuta el cuerpo de una ruta con la clave ya verificada. Devuelve la
+ * respuesta de error si la autenticación falla, y convierte cualquier `ApiError`
+ * en su código HTTP correspondiente.
+ */
+export async function conApi(
+  request: Request,
+  scopeRequerido: ApiScope,
+  fn: (ctx: PeticionApi) => Promise<object>,
+): Promise<NextResponse> {
+  const auth = verifyApiKey(request, scopeRequerido)
+  if (!auth.ok) {
+    return NextResponse.json({ ok: false, error: auth.error }, { status: auth.status })
+  }
+
+  const url = new URL(request.url)
+  try {
+    const datos = await fn({
+      scope: auth.scope,
+      baseUrl: `${url.protocol}//${url.host}`,
+      actorHint: {
+        usuario_email: request.headers.get("x-mcm-usuario-email"),
+        usuario_id: request.headers.get("x-mcm-usuario-id"),
+      },
+      params: url.searchParams,
+    })
+    return NextResponse.json({ ok: true, ...datos })
+  } catch (err) {
+    return errorResponse(err)
+  }
+}
+
+/** Lee y valida el cuerpo JSON de una petición. */
+export async function cuerpoJson(request: Request): Promise<Record<string, unknown>> {
+  let cuerpo: unknown
+  try {
+    cuerpo = await request.json()
+  } catch {
+    throw badRequest("El cuerpo de la petición no es JSON válido.")
+  }
+  if (typeof cuerpo !== "object" || cuerpo === null || Array.isArray(cuerpo)) {
+    throw badRequest("El cuerpo de la petición debe ser un objeto JSON.")
+  }
+  return cuerpo as Record<string, unknown>
+}
+
+// --- Lectura de parámetros de la query string -------------------------------
+
+export function qTexto(params: URLSearchParams, clave: string): string | undefined {
+  const valor = params.get(clave)
+  return valor?.trim() || undefined
+}
+
+export function qNumero(params: URLSearchParams, clave: string): number | undefined {
+  const valor = qTexto(params, clave)
+  if (valor === undefined) return undefined
+  const n = Number(valor.replace(",", "."))
+  if (!Number.isFinite(n)) throw badRequest(`'${clave}' debe ser un número (ha llegado '${valor}').`)
+  return n
+}
+
+export function qBooleano(params: URLSearchParams, clave: string): boolean | undefined {
+  const valor = qTexto(params, clave)?.toLowerCase()
+  if (valor === undefined) return undefined
+  if (["true", "1", "si", "sí"].includes(valor)) return true
+  if (["false", "0", "no"].includes(valor)) return false
+  throw badRequest(`'${clave}' debe ser true o false (ha llegado '${valor}').`)
+}
+
+/**
+ * Lista de valores: admite tanto `?delegaciones=a&delegaciones=b` como
+ * `?delegaciones=a,b`, que es lo que se escribe a mano en un `curl`.
+ */
+export function qLista(params: URLSearchParams, clave: string): string[] | undefined {
+  const valores = params.getAll(clave).flatMap((v) => v.split(","))
+  const limpios = valores.map((v) => v.trim()).filter(Boolean)
+  return limpios.length > 0 ? limpios : undefined
+}
+
+export function qOpcion<T extends string>(
+  params: URLSearchParams,
+  clave: string,
+  validos: readonly T[],
+): T | undefined {
+  const valor = qTexto(params, clave)
+  if (valor === undefined) return undefined
+  if (!validos.includes(valor as T)) {
+    throw badRequest(`'${valor}' no vale para '${clave}'.`, { valores_validos: validos })
+  }
+  return valor as T
+}

--- a/lib/mcp/args.test.ts
+++ b/lib/mcp/args.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest"
+import { ApiError } from "@/lib/api/errors"
+import { booleano, fecha, lista, numero, opcion, texto, textoObligatorio } from "@/lib/mcp/args"
+
+/**
+ * Estas pruebas fijan la tolerancia que se espera con lo que manda un modelo:
+ * números como texto, listas como cadena suelta, fechas en formato español.
+ * Si alguien la endurece sin querer, aquí se nota.
+ */
+
+describe("numero", () => {
+  it("acepta un número normal", () => {
+    expect(numero({ importe: 50 }, "importe")).toBe(50)
+  })
+
+  it("acepta un número escrito como texto, con coma decimal", () => {
+    expect(numero({ importe: "50,25" }, "importe")).toBe(50.25)
+  })
+
+  it("devuelve undefined si no viene", () => {
+    expect(numero({}, "importe")).toBeUndefined()
+    expect(numero({ importe: "" }, "importe")).toBeUndefined()
+  })
+
+  it("rechaza lo que no es un número, diciendo qué llegó", () => {
+    expect(() => numero({ importe: "mucho" }, "importe")).toThrow(/importe.*mucho/)
+  })
+})
+
+describe("booleano", () => {
+  it("entiende las formas habituales de decir sí y no", () => {
+    expect(booleano({ x: true }, "x")).toBe(true)
+    expect(booleano({ x: "true" }, "x")).toBe(true)
+    expect(booleano({ x: "sí" }, "x")).toBe(true)
+    expect(booleano({ x: "false" }, "x")).toBe(false)
+    expect(booleano({ x: "no" }, "x")).toBe(false)
+  })
+
+  it("rechaza un valor ambiguo", () => {
+    expect(() => booleano({ x: "quizá" }, "x")).toThrow(ApiError)
+  })
+})
+
+describe("lista", () => {
+  it("acepta un array", () => {
+    expect(lista({ d: ["Sevilla", "Madrid"] }, "d")).toEqual(["Sevilla", "Madrid"])
+  })
+
+  it("acepta un valor suelto", () => {
+    expect(lista({ d: "Sevilla" }, "d")).toEqual(["Sevilla"])
+  })
+
+  it("acepta una cadena separada por comas", () => {
+    expect(lista({ d: "Sevilla, Madrid" }, "d")).toEqual(["Sevilla", "Madrid"])
+  })
+
+  it("una lista vacía es como no filtrar", () => {
+    expect(lista({ d: [] }, "d")).toBeUndefined()
+  })
+})
+
+describe("fecha", () => {
+  it("deja pasar el formato ISO", () => {
+    expect(fecha({ f: "2026-03-04" }, "f")).toBe("2026-03-04")
+  })
+
+  it("traduce el formato español", () => {
+    expect(fecha({ f: "4/3/2026" }, "f")).toBe("2026-03-04")
+    expect(fecha({ f: "04-03-2026" }, "f")).toBe("2026-03-04")
+  })
+
+  it("rechaza lo que no es una fecha", () => {
+    expect(() => fecha({ f: "el martes pasado" }, "f")).toThrow(/AAAA-MM-DD/)
+  })
+})
+
+describe("texto y opcion", () => {
+  it("recorta y trata la cadena vacía como ausencia", () => {
+    expect(texto({ t: "  hola  " }, "t")).toBe("hola")
+    expect(texto({ t: "   " }, "t")).toBeUndefined()
+  })
+
+  it("textoObligatorio explica qué falta", () => {
+    expect(() => textoObligatorio({}, "delegacion")).toThrow(/Falta 'delegacion'/)
+  })
+
+  it("opcion enumera los valores válidos al fallar", () => {
+    try {
+      opcion({ tipo: "gastito" }, "tipo", ["ingreso", "gasto"] as const)
+      throw new Error("debería haber lanzado")
+    } catch (err) {
+      expect(err).toBeInstanceOf(ApiError)
+      expect((err as ApiError).detalles).toEqual({ valores_validos: ["ingreso", "gasto"] })
+    }
+  })
+})

--- a/lib/mcp/args.ts
+++ b/lib/mcp/args.ts
@@ -1,0 +1,121 @@
+import { badRequest } from "@/lib/api/errors"
+
+/**
+ * Lectura tolerante de los argumentos que llegan de un modelo.
+ *
+ * Un LLM manda `"50"` donde el esquema dice número, `"Sevilla"` donde dice
+ * lista, o `"true"` donde dice booleano. Nada de eso es un error del usuario ni
+ * merece un rechazo: se normaliza y se sigue. Lo que sí se rechaza —con un
+ * mensaje que dice exactamente qué llegó— es lo que no se puede interpretar sin
+ * adivinar.
+ */
+
+export type Args = Record<string, unknown>
+
+export function texto(args: Args, campo: string): string | undefined {
+  const valor = args[campo]
+  if (valor == null) return undefined
+  if (typeof valor === "string") return valor.trim() || undefined
+  if (typeof valor === "number" || typeof valor === "boolean") return String(valor)
+  throw badRequest(`'${campo}' debe ser texto y ha llegado ${JSON.stringify(valor)}.`)
+}
+
+export function textoObligatorio(args: Args, campo: string): string {
+  const valor = texto(args, campo)
+  if (!valor) throw badRequest(`Falta '${campo}'.`)
+  return valor
+}
+
+export function numero(args: Args, campo: string): number | undefined {
+  const valor = args[campo]
+  if (valor == null || valor === "") return undefined
+  const n = typeof valor === "number" ? valor : Number(String(valor).replace(",", "."))
+  if (!Number.isFinite(n)) {
+    throw badRequest(`'${campo}' debe ser un número y ha llegado ${JSON.stringify(valor)}.`)
+  }
+  return n
+}
+
+export function booleano(args: Args, campo: string): boolean | undefined {
+  const valor = args[campo]
+  if (valor == null || valor === "") return undefined
+  if (typeof valor === "boolean") return valor
+  const texto = String(valor).toLowerCase()
+  if (["true", "si", "sí", "1", "yes"].includes(texto)) return true
+  if (["false", "no", "0"].includes(texto)) return false
+  throw badRequest(`'${campo}' debe ser true o false y ha llegado ${JSON.stringify(valor)}.`)
+}
+
+/** Lista de textos; acepta también un único valor suelto o una lista separada por comas. */
+export function lista(args: Args, campo: string): string[] | undefined {
+  const valor = args[campo]
+  if (valor == null || valor === "") return undefined
+  if (Array.isArray(valor)) {
+    const limpia = valor.map((v) => String(v).trim()).filter(Boolean)
+    return limpia.length > 0 ? limpia : undefined
+  }
+  if (typeof valor === "string") {
+    const limpia = valor.split(",").map((v) => v.trim()).filter(Boolean)
+    return limpia.length > 0 ? limpia : undefined
+  }
+  throw badRequest(`'${campo}' debe ser una lista de textos y ha llegado ${JSON.stringify(valor)}.`)
+}
+
+export function objeto(args: Args, campo: string): Args | undefined {
+  const valor = args[campo]
+  if (valor == null) return undefined
+  if (typeof valor === "object" && !Array.isArray(valor)) return valor as Args
+  throw badRequest(`'${campo}' debe ser un objeto y ha llegado ${JSON.stringify(valor)}.`)
+}
+
+export function listaDeObjetos(args: Args, campo: string): Args[] | undefined {
+  const valor = args[campo]
+  if (valor == null) return undefined
+  if (!Array.isArray(valor)) {
+    throw badRequest(`'${campo}' debe ser una lista y ha llegado ${JSON.stringify(valor)}.`)
+  }
+  return valor.map((item, i) => {
+    if (typeof item !== "object" || item === null || Array.isArray(item)) {
+      throw badRequest(`El elemento ${i + 1} de '${campo}' debería ser un objeto.`)
+    }
+    return item as Args
+  })
+}
+
+/**
+ * Normaliza una fecha suelta a `YYYY-MM-DD`. Acepta lo que ya viene bien y
+ * también `DD/MM/AAAA`, que es como se escribe en España.
+ */
+export function fecha(args: Args, campo: string): string | undefined {
+  const valor = texto(args, campo)
+  if (!valor) return undefined
+
+  if (/^\d{4}-\d{2}-\d{2}$/.test(valor)) return valor
+
+  const espanola = valor.match(/^(\d{1,2})[/-](\d{1,2})[/-](\d{4})$/)
+  if (espanola) {
+    const [, dia, mes, anio] = espanola
+    return `${anio}-${mes.padStart(2, "0")}-${dia.padStart(2, "0")}`
+  }
+
+  const parseada = new Date(valor)
+  if (!Number.isNaN(parseada.getTime())) return parseada.toISOString().slice(0, 10)
+
+  throw badRequest(
+    `No entiendo la fecha '${valor}' en '${campo}'. Usa el formato AAAA-MM-DD.`,
+  )
+}
+
+/** Valida contra una lista cerrada, diciendo cuáles son los valores válidos. */
+export function opcion<T extends string>(
+  args: Args,
+  campo: string,
+  validos: readonly T[],
+): T | undefined {
+  const valor = texto(args, campo)
+  if (!valor) return undefined
+  if (!validos.includes(valor as T)) {
+    throw badRequest(`'${valor}' no vale para '${campo}'.`, { valores_validos: validos })
+  }
+  return valor as T
+}

--- a/lib/mcp/protocol.ts
+++ b/lib/mcp/protocol.ts
@@ -1,0 +1,73 @@
+/**
+ * Capa JSON-RPC 2.0 del servidor MCP.
+ *
+ * MCM Bank expone su servidor MCP como un endpoint HTTP sin estado
+ * (transporte "Streamable HTTP"): cada petición POST lleva un mensaje JSON-RPC
+ * y se responde con `application/json`. No hace falta sesión ni SSE porque el
+ * servidor solo ofrece herramientas —no envía notificaciones al cliente por su
+ * cuenta—, y sin estado funciona igual de bien en una función serverless que se
+ * apaga entre llamadas.
+ *
+ * Se implementa a mano en lugar de con el SDK oficial para no añadir una
+ * dependencia (ni su adaptador a Next.js) por unas 150 líneas de protocolo.
+ */
+
+export const PROTOCOLOS_SOPORTADOS = ["2025-06-18", "2025-03-26", "2024-11-05"] as const
+export const PROTOCOLO_POR_DEFECTO = "2025-06-18"
+
+/** Códigos de error estándar de JSON-RPC. */
+export const JSONRPC_ERRORES = {
+  PARSE_ERROR: -32700,
+  INVALID_REQUEST: -32600,
+  METHOD_NOT_FOUND: -32601,
+  INVALID_PARAMS: -32602,
+  INTERNAL_ERROR: -32603,
+} as const
+
+export type JsonRpcId = string | number | null
+
+export interface JsonRpcRequest {
+  jsonrpc: "2.0"
+  id?: JsonRpcId
+  method: string
+  params?: Record<string, unknown>
+}
+
+export interface JsonRpcSuccess {
+  jsonrpc: "2.0"
+  id: JsonRpcId
+  result: unknown
+}
+
+export interface JsonRpcFailure {
+  jsonrpc: "2.0"
+  id: JsonRpcId
+  error: { code: number; message: string; data?: unknown }
+}
+
+export type JsonRpcResponse = JsonRpcSuccess | JsonRpcFailure
+
+export function exito(id: JsonRpcId, result: unknown): JsonRpcSuccess {
+  return { jsonrpc: "2.0", id, result }
+}
+
+export function fallo(
+  id: JsonRpcId,
+  code: number,
+  message: string,
+  data?: unknown,
+): JsonRpcFailure {
+  return { jsonrpc: "2.0", id, error: { code, message, ...(data === undefined ? {} : { data }) } }
+}
+
+/** Un mensaje sin `id` es una notificación: no se responde. */
+export function esNotificacion(mensaje: JsonRpcRequest): boolean {
+  return mensaje.id === undefined
+}
+
+export function negociarProtocolo(solicitado: unknown): string {
+  if (typeof solicitado === "string" && (PROTOCOLOS_SOPORTADOS as readonly string[]).includes(solicitado)) {
+    return solicitado
+  }
+  return PROTOCOLO_POR_DEFECTO
+}

--- a/lib/mcp/server.test.ts
+++ b/lib/mcp/server.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "vitest"
+import { procesarMensaje } from "@/lib/mcp/server"
+import { HERRAMIENTAS } from "@/lib/mcp/tools"
+import { PROTOCOLO_POR_DEFECTO } from "@/lib/mcp/protocol"
+
+const OPCIONES = { scope: "read" as const, baseUrl: "https://ejemplo.test", actorHint: {} }
+
+/**
+ * Comprueba el protocolo, no las herramientas: nada de aquí toca la base de
+ * datos. Es la red de seguridad de que un cliente MCP puede completar el
+ * saludo y descubrir las herramientas.
+ */
+describe("procesarMensaje", () => {
+  it("responde al initialize con la versión que pide el cliente si la soporta", async () => {
+    const respuesta: any = await procesarMensaje(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: { protocolVersion: "2024-11-05" },
+      },
+      OPCIONES,
+    )
+    expect(respuesta.result.protocolVersion).toBe("2024-11-05")
+    expect(respuesta.result.capabilities.tools).toBeDefined()
+    expect(respuesta.result.serverInfo.name).toBe("mcm-bank")
+    expect(respuesta.result.instructions).toContain("delegaciones")
+  })
+
+  it("cae en la versión por defecto si la pedida no se soporta", async () => {
+    const respuesta: any = await procesarMensaje(
+      { jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "1999-01-01" } },
+      OPCIONES,
+    )
+    expect(respuesta.result.protocolVersion).toBe(PROTOCOLO_POR_DEFECTO)
+  })
+
+  it("no responde a las notificaciones", async () => {
+    expect(
+      await procesarMensaje({ jsonrpc: "2.0", method: "notifications/initialized" }, OPCIONES),
+    ).toBeNull()
+  })
+
+  it("lista las herramientas con su esquema", async () => {
+    const respuesta: any = await procesarMensaje({ jsonrpc: "2.0", id: 2, method: "tools/list" }, OPCIONES)
+    const tools = respuesta.result.tools
+
+    expect(tools.length).toBe(HERRAMIENTAS.length)
+    for (const tool of tools) {
+      expect(typeof tool.name).toBe("string")
+      expect(tool.description.length).toBeGreaterThan(20)
+      expect(tool.inputSchema.type).toBe("object")
+    }
+    expect(tools.map((t: any) => t.name)).toContain("buscar_movimientos")
+  })
+
+  it("una clave de solo lectura no puede usar una herramienta de escritura", async () => {
+    const respuesta: any = await procesarMensaje(
+      {
+        jsonrpc: "2.0",
+        id: 3,
+        method: "tools/call",
+        params: { name: "crear_aviso", arguments: { delegacion: "Sevilla", contenido: "hola" } },
+      },
+      OPCIONES,
+    )
+    expect(respuesta.result.isError).toBe(true)
+    expect(respuesta.result.content[0].text).toContain("solo lectura")
+  })
+
+  it("una herramienta inexistente devuelve la lista de las que hay", async () => {
+    const respuesta: any = await procesarMensaje(
+      { jsonrpc: "2.0", id: 4, method: "tools/call", params: { name: "no_existe", arguments: {} } },
+      OPCIONES,
+    )
+    expect(respuesta.result.isError).toBe(true)
+    expect(respuesta.result.content[0].text).toContain("buscar_movimientos")
+  })
+
+  it("un método desconocido es un error de JSON-RPC", async () => {
+    const respuesta: any = await procesarMensaje({ jsonrpc: "2.0", id: 5, method: "foo" }, OPCIONES)
+    expect(respuesta.error.code).toBe(-32601)
+  })
+
+  it("conciliar_facturas solo exige escritura cuando se pide aplicar", async () => {
+    const propuesta: any = await procesarMensaje(
+      {
+        jsonrpc: "2.0",
+        id: 6,
+        method: "tools/call",
+        params: { name: "conciliar_facturas", arguments: { facturas: [] } },
+      },
+      OPCIONES,
+    )
+    // Falla por otra razón (lista vacía), no por permisos.
+    expect(propuesta.result.content[0].text).not.toContain("solo lectura")
+
+    const aplicando: any = await procesarMensaje(
+      {
+        jsonrpc: "2.0",
+        id: 7,
+        method: "tools/call",
+        params: { name: "conciliar_facturas", arguments: { facturas: [], aplicar: true } },
+      },
+      OPCIONES,
+    )
+    expect(aplicando.result.content[0].text).toContain("solo lectura")
+  })
+})
+
+describe("catálogo de herramientas", () => {
+  it("no hay nombres repetidos", () => {
+    const nombres = HERRAMIENTAS.map((h) => h.name)
+    expect(new Set(nombres).size).toBe(nombres.length)
+  })
+
+  it("todo campo obligatorio del esquema está declarado en properties", () => {
+    for (const herramienta of HERRAMIENTAS) {
+      const esquema = herramienta.inputSchema as any
+      for (const obligatorio of esquema.required ?? []) {
+        expect(
+          Object.keys(esquema.properties),
+          `${herramienta.name} exige '${obligatorio}' pero no lo declara`,
+        ).toContain(obligatorio)
+      }
+    }
+  })
+})

--- a/lib/mcp/server.ts
+++ b/lib/mcp/server.ts
@@ -1,0 +1,180 @@
+import { createAdminClient } from "@/lib/supabase/admin"
+import type { ApiScope } from "@/lib/api/external-auth"
+import { toErrorPayload } from "@/lib/api/errors"
+import type { ActorHint } from "@/lib/api/actor"
+import {
+  HERRAMIENTAS_POR_NOMBRE,
+  definicionesDeHerramientas,
+  permisoDe,
+  type ContextoMcp,
+} from "@/lib/mcp/tools"
+import {
+  JSONRPC_ERRORES,
+  exito,
+  fallo,
+  negociarProtocolo,
+  type JsonRpcId,
+  type JsonRpcRequest,
+  type JsonRpcResponse,
+} from "@/lib/mcp/protocol"
+
+export const SERVIDOR = {
+  name: "mcm-bank",
+  title: "MCM Bank",
+  version: "1.0.0",
+}
+
+/**
+ * Instrucciones que el servidor entrega al cliente en `initialize`. Es el
+ * "manual de uso" que lee el modelo antes de decidir qué herramienta llamar, y
+ * el sitio donde se explican las convenciones que no caben en cada esquema.
+ */
+export const INSTRUCCIONES = `MCM Bank es la aplicación de tesorería del Movimiento Consolación para el Mundo.
+Está organizada en delegaciones; cada delegación tiene cuentas, movimientos bancarios,
+facturas y un canal de avisos con la oficina técnica.
+
+Quien usa este servidor es un administrador de la oficina técnica que revisa TODAS las
+delegaciones, así que casi todas las herramientas trabajan sobre varias delegaciones a la vez:
+si omites el parámetro 'delegaciones', se buscan todas.
+
+Convenciones que conviene tener claras:
+
+- Las delegaciones, categorías y cuentas se indican por su nombre normal ("Sevilla",
+  "Alimentación"), no hace falta el id. Si el nombre es ambiguo, el error te devuelve los
+  candidatos para que reintentes con el correcto.
+- Los importes de los movimientos llevan signo: los gastos son NEGATIVOS y los ingresos
+  positivos. Los filtros por importe usan el valor absoluto; usa 'tipo' para quedarte con
+  gastos o con ingresos. Para "los mayores gastos", ordena por importe_asc.
+- Las facturas llevan siempre importe positivo. Una factura puede tener varios movimientos
+  vinculados (pago en plazos) y un movimiento como mucho una factura.
+- Antes de conciliar en bloque, usa 'conciliar_facturas' sin 'aplicar' para ver las
+  propuestas, enséñaselas a la persona y solo después vuelve a llamar con aplicar=true.
+- Las escrituras quedan firmadas por un usuario real de MCM Bank. Puedes indicar
+  'usuario_email' en cada llamada para firmar con la cuenta de quien te está hablando.
+- Antes de borrar cualquier cosa, pregunta. No hay papelera.`
+
+export interface OpcionesMcp {
+  scope: ApiScope
+  baseUrl: string
+  actorHint: ActorHint
+}
+
+/** Procesa un mensaje JSON-RPC. Devuelve `null` si era una notificación. */
+export async function procesarMensaje(
+  mensaje: JsonRpcRequest,
+  opciones: OpcionesMcp,
+): Promise<JsonRpcResponse | null> {
+  const id: JsonRpcId = mensaje.id ?? null
+  const esNotificacion = mensaje.id === undefined
+
+  if (mensaje.jsonrpc !== "2.0" || typeof mensaje.method !== "string") {
+    return esNotificacion
+      ? null
+      : fallo(id, JSONRPC_ERRORES.INVALID_REQUEST, "Mensaje JSON-RPC 2.0 mal formado.")
+  }
+
+  const params = (mensaje.params ?? {}) as Record<string, unknown>
+
+  switch (mensaje.method) {
+    case "initialize":
+      return exito(id, {
+        protocolVersion: negociarProtocolo(params.protocolVersion),
+        capabilities: { tools: { listChanged: false } },
+        serverInfo: SERVIDOR,
+        instructions: INSTRUCCIONES,
+      })
+
+    // El cliente avisa de que ya está listo; no hay nada que hacer.
+    case "notifications/initialized":
+    case "notifications/cancelled":
+    case "notifications/progress":
+      return null
+
+    case "ping":
+      return exito(id, {})
+
+    case "logging/setLevel":
+      return exito(id, {})
+
+    case "tools/list":
+      return exito(id, { tools: definicionesDeHerramientas() })
+
+    // El servidor no ofrece recursos ni prompts, pero algunos clientes los
+    // piden igualmente al conectar: se responde con listas vacías en vez de
+    // con un error que asuste en los registros.
+    case "resources/list":
+      return exito(id, { resources: [] })
+    case "resources/templates/list":
+      return exito(id, { resourceTemplates: [] })
+    case "prompts/list":
+      return exito(id, { prompts: [] })
+
+    case "tools/call":
+      return exito(id, await ejecutarHerramienta(params, opciones))
+
+    default:
+      return esNotificacion
+        ? null
+        : fallo(id, JSONRPC_ERRORES.METHOD_NOT_FOUND, `Método '${mensaje.method}' no soportado.`)
+  }
+}
+
+/**
+ * Ejecuta una herramienta y devuelve el resultado en el formato de `tools/call`.
+ *
+ * Los fallos se devuelven como `isError: true` con el mensaje en el contenido,
+ * no como error de JSON-RPC: así el modelo los lee, entiende qué ha fallado y
+ * puede corregirse solo (indicar la delegación exacta, usar una categoría que
+ * exista…) en lugar de ver la llamada rota sin explicación.
+ */
+async function ejecutarHerramienta(
+  params: Record<string, unknown>,
+  opciones: OpcionesMcp,
+): Promise<Record<string, unknown>> {
+  const nombre = typeof params.name === "string" ? params.name : ""
+  const args = (params.arguments ?? {}) as Record<string, unknown>
+
+  const herramienta = HERRAMIENTAS_POR_NOMBRE.get(nombre)
+  if (!herramienta) {
+    return resultadoError(
+      `No existe la herramienta '${nombre}'.`,
+      { herramientas: [...HERRAMIENTAS_POR_NOMBRE.keys()] },
+    )
+  }
+
+  const requerido = permisoDe(herramienta, args)
+  if (requerido === "write" && opciones.scope !== "write") {
+    return resultadoError(
+      `'${nombre}' modifica datos y la clave con la que te has conectado es de solo lectura. ` +
+        "Pídele a quien administra MCM Bank una clave con permiso de escritura (MCM_API_KEY).",
+    )
+  }
+
+  try {
+    // Dentro del try: si el servidor está mal configurado, `createAdminClient`
+    // lanza, y eso debe llegar al cliente como un error de la herramienta y no
+    // como una petición rota sin explicación.
+    const contexto: ContextoMcp = {
+      admin: createAdminClient(),
+      scope: opciones.scope,
+      baseUrl: opciones.baseUrl,
+      actorHint: opciones.actorHint,
+    }
+
+    const resultado = await herramienta.handler(args, contexto)
+    return {
+      content: [{ type: "text", text: JSON.stringify(resultado, null, 2) }],
+    }
+  } catch (err) {
+    const { body } = toErrorPayload(err)
+    return resultadoError(body.error, body.detalles)
+  }
+}
+
+function resultadoError(mensaje: string, detalles?: unknown): Record<string, unknown> {
+  const cuerpo = detalles ? { error: mensaje, detalles } : { error: mensaje }
+  return {
+    isError: true,
+    content: [{ type: "text", text: JSON.stringify(cuerpo, null, 2) }],
+  }
+}

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -1,0 +1,1041 @@
+import type { createAdminClient } from "@/lib/supabase/admin"
+import type { ApiScope } from "@/lib/api/external-auth"
+import { badRequest } from "@/lib/api/errors"
+import { nombreActor, resolveActor, type Actor, type ActorHint } from "@/lib/api/actor"
+import {
+  listDelegaciones,
+  resolveAmbitoDelegaciones,
+} from "@/lib/api/delegaciones"
+import {
+  listCategorias,
+  listContactos,
+  listCuentas,
+  resolveCategorias,
+  resolveCuentas,
+} from "@/lib/api/catalogos"
+import {
+  actualizarMovimiento,
+  buscarMovimientos,
+  obtenerMovimiento,
+  type OrdenMovimientos,
+} from "@/lib/api/movimientos-public"
+import {
+  actualizarFactura,
+  buscarCandidatosParaFactura,
+  buscarFacturas,
+  buscarFacturasParaMovimiento,
+  conciliarLote,
+  crearFactura,
+  desvincularFacturaDeMovimiento,
+  eliminarFactura,
+  obtenerFactura,
+  vincularFacturaAMovimiento,
+  FACTURA_ESTADOS,
+} from "@/lib/api/facturas"
+import {
+  actualizarAviso,
+  crearAviso,
+  eliminarAviso,
+  listarAvisos,
+  notificarAviso,
+  obtenerAviso,
+} from "@/lib/api/avisos"
+import { listarPagosMcm } from "@/lib/api/pagos"
+import { resumenGeneral } from "@/lib/api/resumen"
+import {
+  eliminarArchivo,
+  localizarArchivo,
+  subirArchivoAFactura,
+  subirArchivoAMovimiento,
+  urlFirmada,
+  MAX_BYTES_API,
+} from "@/lib/api/archivos"
+import {
+  booleano,
+  fecha,
+  lista,
+  listaDeObjetos,
+  numero,
+  objeto,
+  opcion,
+  texto,
+  textoObligatorio,
+  type Args,
+} from "@/lib/mcp/args"
+
+type AdminClient = ReturnType<typeof createAdminClient>
+
+export interface ContextoMcp {
+  admin: AdminClient
+  scope: ApiScope
+  /** Origen de la petición, para construir enlaces de descarga. */
+  baseUrl: string
+  /** Autoría por defecto (cabeceras de la petición o variables de entorno). */
+  actorHint: ActorHint
+}
+
+export interface HerramientaMcp {
+  name: string
+  title: string
+  description: string
+  inputSchema: Record<string, unknown>
+  /** Permiso que exige. Puede depender de los argumentos (p. ej. `aplicar: true`). */
+  scope: ApiScope | ((args: Args) => ApiScope)
+  annotations?: Record<string, unknown>
+  handler: (args: Args, ctx: ContextoMcp) => Promise<unknown>
+}
+
+// ---------------------------------------------------------------------------
+// Utilidades compartidas
+// ---------------------------------------------------------------------------
+
+/** Esquema JSON reutilizable para el ámbito de delegaciones. */
+const CAMPO_DELEGACIONES = {
+  type: "array",
+  items: { type: "string" },
+  description:
+    "Delegaciones a las que limitar la búsqueda, por nombre, código o id (se admite el nombre tal cual lo diría una persona: 'Sevilla', 'la delegación de Madrid'). Si se omite, se buscan TODAS las delegaciones.",
+}
+
+const CAMPO_USUARIO_EMAIL = {
+  type: "string",
+  description:
+    "Correo del usuario de MCM Bank al que atribuir esta acción (aparecerá como autor). Si se omite se usa la cuenta configurada en el servidor.",
+}
+
+function objetoSchema(propiedades: Record<string, unknown>, obligatorios: string[] = []) {
+  return {
+    type: "object",
+    properties: propiedades,
+    ...(obligatorios.length > 0 ? { required: obligatorios } : {}),
+    additionalProperties: false,
+  }
+}
+
+async function actorDe(args: Args, ctx: ContextoMcp): Promise<Actor> {
+  return resolveActor(ctx.admin, {
+    usuario_id: texto(args, "usuario_id") ?? ctx.actorHint.usuario_id,
+    usuario_email: texto(args, "usuario_email") ?? ctx.actorHint.usuario_email,
+  })
+}
+
+/** Traduce los filtros de búsqueda en lenguaje natural a ids concretos. */
+async function filtrosDeMovimientos(args: Args, ctx: ContextoMcp) {
+  const delegaciones = await resolveAmbitoDelegaciones(ctx.admin, lista(args, "delegaciones"))
+
+  const categoriasPedidas = lista(args, "categorias")
+  const categorias = await resolveCategorias(ctx.admin, categoriasPedidas, delegaciones)
+  if (categoriasPedidas && (!categorias || categorias.length === 0)) {
+    const disponibles = await listCategorias(ctx.admin, {
+      delegaciones: lista(args, "delegaciones") ?? null,
+    })
+    throw badRequest(
+      `No encuentro ninguna categoría que se llame ${categoriasPedidas.join(" ni ")}.`,
+      { categorias_disponibles: disponibles.map((c) => c.nombre).slice(0, 60) },
+    )
+  }
+
+  const cuentasPedidas = lista(args, "cuentas")
+  const cuentas = await resolveCuentas(ctx.admin, cuentasPedidas, delegaciones)
+  if (cuentasPedidas && (!cuentas || cuentas.length === 0)) {
+    const disponibles = await listCuentas(ctx.admin, {
+      delegaciones: lista(args, "delegaciones") ?? null,
+    })
+    throw badRequest(`No encuentro ninguna cuenta que se llame ${cuentasPedidas.join(" ni ")}.`, {
+      cuentas_disponibles: disponibles.map((c) => c.nombre).slice(0, 60),
+    })
+  }
+
+  return { delegaciones, categorias, cuentas }
+}
+
+// ---------------------------------------------------------------------------
+// Herramientas
+// ---------------------------------------------------------------------------
+
+export const HERRAMIENTAS: HerramientaMcp[] = [
+  // -------------------------------------------------------------- Referencia
+  {
+    name: "listar_delegaciones",
+    title: "Listar delegaciones",
+    description:
+      "Lista todas las delegaciones de MCM con su id, código y nombre. Útil como primer paso cuando hay que desambiguar un nombre o cuando se quiere recorrer todas las delegaciones una por una.",
+    inputSchema: objetoSchema({}),
+    scope: "read",
+    annotations: { readOnlyHint: true },
+    handler: async (_args, ctx) => {
+      const delegaciones = await listDelegaciones(ctx.admin)
+      return { total: delegaciones.length, delegaciones }
+    },
+  },
+  {
+    name: "listar_cuentas",
+    title: "Listar cuentas",
+    description:
+      "Cuentas bancarias y cajas de una, varias o todas las delegaciones, con banco, IBAN y si están activas.",
+    inputSchema: objetoSchema({
+      delegaciones: CAMPO_DELEGACIONES,
+      incluir_inactivas: { type: "boolean", description: "Incluir cuentas desactivadas." },
+    }),
+    scope: "read",
+    annotations: { readOnlyHint: true },
+    handler: async (args, ctx) => {
+      const cuentas = await listCuentas(ctx.admin, {
+        delegaciones: lista(args, "delegaciones") ?? null,
+        incluirInactivas: booleano(args, "incluir_inactivas"),
+      })
+      return { total: cuentas.length, cuentas }
+    },
+  },
+  {
+    name: "listar_categorias",
+    title: "Listar categorías",
+    description:
+      "Categorías de ingresos y gastos visibles para una delegación (las globales de MCM más las propias de la delegación). Consúltala antes de categorizar un movimiento para usar el nombre exacto.",
+    inputSchema: objetoSchema({
+      delegaciones: CAMPO_DELEGACIONES,
+      incluir_inactivas: { type: "boolean", description: "Incluir categorías desactivadas." },
+    }),
+    scope: "read",
+    annotations: { readOnlyHint: true },
+    handler: async (args, ctx) => {
+      const categorias = await listCategorias(ctx.admin, {
+        delegaciones: lista(args, "delegaciones") ?? null,
+        incluirInactivas: booleano(args, "incluir_inactivas"),
+      })
+      return { total: categorias.length, categorias }
+    },
+  },
+  {
+    name: "listar_contactos",
+    title: "Listar contactos",
+    description:
+      "Proveedores y personas dados de alta en MCM Bank. Solo lectura: dar de alta contactos se hace desde la aplicación.",
+    inputSchema: objetoSchema({
+      delegaciones: CAMPO_DELEGACIONES,
+      texto: { type: "string", description: "Filtra por nombre." },
+      tipos: {
+        type: "array",
+        items: { type: "string", enum: ["proveedor", "persona_mcm", "destinatario_mcm"] },
+        description: "Tipos de contacto a incluir.",
+      },
+      incluir_archivados: { type: "boolean" },
+    }),
+    scope: "read",
+    annotations: { readOnlyHint: true },
+    handler: async (args, ctx) => {
+      const contactos = await listContactos(ctx.admin, {
+        delegaciones: lista(args, "delegaciones") ?? null,
+        texto: texto(args, "texto"),
+        tipos: lista(args, "tipos"),
+        incluirArchivados: booleano(args, "incluir_archivados"),
+      })
+      return { total: contactos.length, contactos }
+    },
+  },
+
+  // ------------------------------------------------------------- Movimientos
+  {
+    name: "buscar_movimientos",
+    title: "Buscar movimientos",
+    description:
+      "Busca movimientos bancarios en una, varias o TODAS las delegaciones a la vez y devuelve además el total gastado/ingresado del conjunto encontrado, desglosado por delegación. " +
+      "Es la herramienta principal: sirve para '¿qué se ha gastado en Mercadona en todas las delegaciones por encima de 50 €?', 'gastos sin categorizar de este trimestre' o 'movimientos sin factura de Sevilla'. " +
+      "Los importes se filtran por valor absoluto: importe_min 50 encuentra tanto un ingreso de 50 € como un gasto de -50 €; usa 'tipo' para quedarte con unos u otros.",
+    inputSchema: objetoSchema({
+      texto: {
+        type: "string",
+        description:
+          "Texto a buscar en concepto, descripción, contraparte y notas. Con varias palabras, deben aparecer todas (en cualquiera de esos campos).",
+      },
+      delegaciones: CAMPO_DELEGACIONES,
+      tipo: { type: "string", enum: ["ingreso", "gasto"], description: "Quedarse solo con ingresos o solo con gastos." },
+      importe_min: { type: "number", description: "Importe mínimo en euros, en valor absoluto." },
+      importe_max: { type: "number", description: "Importe máximo en euros, en valor absoluto." },
+      fecha_desde: { type: "string", description: "Fecha inicial (AAAA-MM-DD), incluida." },
+      fecha_hasta: { type: "string", description: "Fecha final (AAAA-MM-DD), incluida." },
+      categorias: {
+        type: "array",
+        items: { type: "string" },
+        description: "Categorías por nombre o id.",
+      },
+      sin_categoria: { type: "boolean", description: "Solo movimientos sin categorizar." },
+      cuentas: { type: "array", items: { type: "string" }, description: "Cuentas por nombre, IBAN o id." },
+      con_factura: {
+        type: "boolean",
+        description: "true = solo los que ya tienen factura vinculada; false = solo los que no la tienen.",
+      },
+      factura_pendiente: {
+        type: "boolean",
+        description: "Solo los marcados como 'le falta la factura'.",
+      },
+      incluir_ignorados: {
+        type: "boolean",
+        description: "Incluir los movimientos marcados como ignorados (por defecto se excluyen, igual que en la app).",
+      },
+      orden: {
+        type: "string",
+        enum: ["fecha_desc", "fecha_asc", "importe_desc", "importe_asc"],
+        description:
+          "Orden del resultado. Recuerda que los gastos son negativos: para los mayores gastos usa importe_asc.",
+      },
+      limite: { type: "number", description: "Cuántos devolver (por defecto 25, máximo 200)." },
+      offset: { type: "number", description: "Desplazamiento para paginar." },
+      incluir_archivos: {
+        type: "boolean",
+        description: "Adjuntar la lista de archivos de cada movimiento (por defecto no, para no alargar la respuesta).",
+      },
+    }),
+    scope: "read",
+    annotations: { readOnlyHint: true },
+    handler: async (args, ctx) => {
+      const { delegaciones, categorias, cuentas } = await filtrosDeMovimientos(args, ctx)
+
+      return buscarMovimientos(ctx.admin, {
+        delegaciones,
+        texto: texto(args, "texto"),
+        tipo: opcion(args, "tipo", ["ingreso", "gasto"] as const),
+        importeMin: numero(args, "importe_min"),
+        importeMax: numero(args, "importe_max"),
+        fechaDesde: fecha(args, "fecha_desde"),
+        fechaHasta: fecha(args, "fecha_hasta"),
+        categoriaIds: categorias?.map((c) => c.id) ?? null,
+        sinCategoria: booleano(args, "sin_categoria"),
+        cuentaIds: cuentas?.map((c) => c.id) ?? null,
+        conFactura: booleano(args, "con_factura") ?? null,
+        facturaPendiente: booleano(args, "factura_pendiente"),
+        incluirIgnorados: booleano(args, "incluir_ignorados"),
+        orden: opcion(args, "orden", [
+          "fecha_desc",
+          "fecha_asc",
+          "importe_desc",
+          "importe_asc",
+        ] as const) as OrdenMovimientos | undefined,
+        limite: numero(args, "limite") ?? 25,
+        offset: numero(args, "offset"),
+        incluirArchivos: booleano(args, "incluir_archivos") ?? false,
+        baseUrl: ctx.baseUrl,
+      })
+    },
+  },
+  {
+    name: "obtener_movimiento",
+    title: "Ver un movimiento",
+    description:
+      "Devuelve un movimiento completo por su id, con cuenta, categoría, delegación, contacto y todos sus archivos adjuntos.",
+    inputSchema: objetoSchema(
+      { id: { type: "string", description: "Id (UUID) del movimiento." } },
+      ["id"],
+    ),
+    scope: "read",
+    annotations: { readOnlyHint: true },
+    handler: async (args, ctx) => {
+      const movimiento = await obtenerMovimiento(ctx.admin, textoObligatorio(args, "id"), {
+        baseUrl: ctx.baseUrl,
+      })
+      if (!movimiento) throw badRequest(`No existe ningún movimiento con el id ${args.id}.`)
+      return { movimiento }
+    },
+  },
+  {
+    name: "actualizar_movimiento",
+    title: "Editar un movimiento",
+    description:
+      "Cambia los datos editables de un movimiento: categoría, contacto, notas, descripción, si se ignora y si le falta la factura. " +
+      "Importe, fecha, cuenta y delegación NO se pueden cambiar desde aquí: vienen del banco.",
+    inputSchema: objetoSchema(
+      {
+        id: { type: "string", description: "Id (UUID) del movimiento." },
+        categoria_id: { type: "string", description: "Id de la categoría (usa listar_categorias). null para quitarla." },
+        contacto_id: { type: "string", description: "Id del contacto. null para quitarlo." },
+        notas: { type: "string" },
+        descripcion: { type: "string" },
+        contraparte: { type: "string" },
+        metodo: { type: "string" },
+        ignorado: { type: "boolean", description: "Excluir el movimiento de los informes." },
+        factura_pendiente: { type: "boolean", description: "Marcar que a este movimiento le falta la factura." },
+        usuario_email: CAMPO_USUARIO_EMAIL,
+      },
+      ["id"],
+    ),
+    scope: "write",
+    annotations: { readOnlyHint: false, idempotentHint: true },
+    handler: async (args, ctx) => {
+      const cambios: Record<string, unknown> = {}
+      for (const campo of ["categoria_id", "contacto_id", "notas", "descripcion", "contraparte", "metodo"]) {
+        if (campo in args) cambios[campo] = args[campo] === null ? null : texto(args, campo) ?? null
+      }
+      if ("ignorado" in args) cambios.ignorado = booleano(args, "ignorado")
+      if ("factura_pendiente" in args) cambios.factura_pendiente = booleano(args, "factura_pendiente")
+
+      const movimiento = await actualizarMovimiento(
+        ctx.admin,
+        textoObligatorio(args, "id"),
+        cambios,
+        { baseUrl: ctx.baseUrl },
+      )
+      return { movimiento }
+    },
+  },
+  {
+    name: "resumen_economico",
+    title: "Resumen económico",
+    description:
+      "Foto económica de una, varias o todas las delegaciones: ingresos, gastos, neto y saldo por delegación, desglose por categoría, y cuántas facturas y avisos tiene pendientes cada una. " +
+      "Es la forma rápida de responder '¿cómo van todas las delegaciones este año?'.",
+    inputSchema: objetoSchema({
+      delegaciones: CAMPO_DELEGACIONES,
+      desde: { type: "string", description: "Fecha inicial (AAAA-MM-DD) para ingresos y gastos." },
+      hasta: { type: "string", description: "Fecha final (AAAA-MM-DD)." },
+      incluir_ignorados: { type: "boolean" },
+    }),
+    scope: "read",
+    annotations: { readOnlyHint: true },
+    handler: async (args, ctx) =>
+      resumenGeneral(ctx.admin, {
+        delegaciones: lista(args, "delegaciones") ?? null,
+        desde: fecha(args, "desde"),
+        hasta: fecha(args, "hasta"),
+        incluirIgnorados: booleano(args, "incluir_ignorados"),
+      }),
+  },
+
+  // ---------------------------------------------------------------- Facturas
+  {
+    name: "buscar_facturas",
+    title: "Buscar facturas",
+    description:
+      "Busca en la bandeja de facturas de una, varias o todas las delegaciones. Devuelve para cada una cuánto lleva pagado y cuánto queda pendiente, además de sus archivos.",
+    inputSchema: objetoSchema({
+      delegaciones: CAMPO_DELEGACIONES,
+      estados: {
+        type: "array",
+        items: { type: "string", enum: [...FACTURA_ESTADOS] },
+        description:
+          "bandeja (recién subida), sin_pagar, pagada_parcial, pagada, pagada_fuera (pagada fuera de MCM Bank).",
+      },
+      texto: { type: "string", description: "Busca en concepto, número y notas." },
+      numero: { type: "string", description: "Número de factura (búsqueda parcial)." },
+      importe_min: { type: "number" },
+      importe_max: { type: "number" },
+      fecha_desde: { type: "string", description: "Fecha de emisión desde (AAAA-MM-DD)." },
+      fecha_hasta: { type: "string", description: "Fecha de emisión hasta (AAAA-MM-DD)." },
+      sin_conciliar: { type: "boolean", description: "Solo las que no tienen ningún movimiento vinculado." },
+      limite: { type: "number", description: "Por defecto 25, máximo 200." },
+      offset: { type: "number" },
+    }),
+    scope: "read",
+    annotations: { readOnlyHint: true },
+    handler: async (args, ctx) =>
+      buscarFacturas(ctx.admin, {
+        delegaciones: lista(args, "delegaciones") ?? null,
+        estados: lista(args, "estados"),
+        texto: texto(args, "texto"),
+        numero: texto(args, "numero"),
+        importeMin: numero(args, "importe_min"),
+        importeMax: numero(args, "importe_max"),
+        fechaDesde: fecha(args, "fecha_desde"),
+        fechaHasta: fecha(args, "fecha_hasta"),
+        sinConciliar: booleano(args, "sin_conciliar"),
+        limite: numero(args, "limite") ?? 25,
+        offset: numero(args, "offset"),
+        baseUrl: ctx.baseUrl,
+      }),
+  },
+  {
+    name: "obtener_factura",
+    title: "Ver una factura",
+    description: "Devuelve una factura por su id, con sus movimientos vinculados y sus archivos.",
+    inputSchema: objetoSchema({ id: { type: "string" } }, ["id"]),
+    scope: "read",
+    annotations: { readOnlyHint: true },
+    handler: async (args, ctx) => ({
+      factura: await obtenerFactura(ctx.admin, textoObligatorio(args, "id"), { baseUrl: ctx.baseUrl }),
+    }),
+  },
+  {
+    name: "crear_factura",
+    title: "Registrar una factura",
+    description:
+      "Registra una factura en la bandeja de una delegación. Puede subirse el PDF o la foto en la misma llamada (en base64) y vincularla ya a un movimiento.",
+    inputSchema: objetoSchema(
+      {
+        delegacion: { type: "string", description: "Nombre, código o id de la delegación." },
+        concepto: { type: "string", description: "De qué es la factura." },
+        numero: { type: "string", description: "Número de factura del proveedor." },
+        importe: { type: "number", description: "Importe total facturado, en positivo." },
+        fecha_emision: { type: "string", description: "AAAA-MM-DD." },
+        notas: { type: "string" },
+        contacto_id: { type: "string", description: "Id del proveedor (ver listar_contactos)." },
+        estado: { type: "string", enum: [...FACTURA_ESTADOS] },
+        movimiento_id: {
+          type: "string",
+          description: "Si ya se sabe qué movimiento la pagó, se concilia en el momento.",
+        },
+        archivo: {
+          type: "object",
+          description: "Archivo de la factura, opcional.",
+          properties: {
+            nombre: { type: "string", description: "Nombre con extensión, p. ej. 'factura-octubre.pdf'." },
+            contenido_base64: { type: "string", description: "Contenido del fichero en base64." },
+            tipo_mime: { type: "string" },
+            descripcion: { type: "string" },
+          },
+          required: ["nombre", "contenido_base64"],
+        },
+        usuario_email: CAMPO_USUARIO_EMAIL,
+      },
+      ["delegacion"],
+    ),
+    scope: "write",
+    handler: async (args, ctx) => {
+      const actor = await actorDe(args, ctx)
+      const archivo = objeto(args, "archivo")
+      const factura = await crearFactura(
+        ctx.admin,
+        {
+          delegacion: textoObligatorio(args, "delegacion"),
+          concepto: texto(args, "concepto"),
+          numero: texto(args, "numero"),
+          importe: numero(args, "importe"),
+          fecha_emision: fecha(args, "fecha_emision"),
+          notas: texto(args, "notas"),
+          contacto_id: texto(args, "contacto_id"),
+          estado: opcion(args, "estado", FACTURA_ESTADOS),
+          movimiento_id: texto(args, "movimiento_id"),
+          archivo: archivo
+            ? {
+                nombre: textoObligatorio(archivo, "nombre"),
+                contenido_base64: textoObligatorio(archivo, "contenido_base64"),
+                tipo_mime: texto(archivo, "tipo_mime"),
+                descripcion: texto(archivo, "descripcion"),
+              }
+            : null,
+        },
+        actor.id,
+        { baseUrl: ctx.baseUrl },
+      )
+      return { factura, firmado_por: nombreActor(actor) }
+    },
+  },
+  {
+    name: "actualizar_factura",
+    title: "Editar una factura",
+    description:
+      "Corrige los datos de una factura: número, concepto, importe, fecha, proveedor, notas o estado.",
+    inputSchema: objetoSchema(
+      {
+        id: { type: "string" },
+        numero: { type: "string" },
+        concepto: { type: "string" },
+        importe: { type: "number", description: "En positivo." },
+        fecha_emision: { type: "string", description: "AAAA-MM-DD." },
+        estado: { type: "string", enum: [...FACTURA_ESTADOS] },
+        notas: { type: "string" },
+        contacto_id: { type: "string" },
+      },
+      ["id"],
+    ),
+    scope: "write",
+    annotations: { idempotentHint: true },
+    handler: async (args, ctx) => {
+      const cambios: Record<string, unknown> = {}
+      for (const campo of ["numero", "concepto", "notas", "contacto_id"]) {
+        if (campo in args) cambios[campo] = args[campo] === null ? null : texto(args, campo) ?? null
+      }
+      if ("importe" in args) cambios.importe = args.importe === null ? null : numero(args, "importe")
+      if ("fecha_emision" in args) {
+        cambios.fecha_emision = args.fecha_emision === null ? null : fecha(args, "fecha_emision")
+      }
+      if ("estado" in args) cambios.estado = opcion(args, "estado", FACTURA_ESTADOS)
+
+      return {
+        factura: await actualizarFactura(ctx.admin, textoObligatorio(args, "id"), cambios, {
+          baseUrl: ctx.baseUrl,
+        }),
+      }
+    },
+  },
+  {
+    name: "eliminar_factura",
+    title: "Borrar una factura",
+    description:
+      "Borra una factura, sus archivos y desvincula los movimientos que tuviera. No borra los movimientos. Es irreversible: confírmalo con la persona antes de usarlo.",
+    inputSchema: objetoSchema({ id: { type: "string" } }, ["id"]),
+    scope: "write",
+    annotations: { destructiveHint: true, idempotentHint: true },
+    handler: async (args, ctx) => {
+      await eliminarFactura(ctx.admin, textoObligatorio(args, "id"))
+      return { eliminada: true, id: args.id }
+    },
+  },
+  {
+    name: "vincular_factura",
+    title: "Conciliar factura y movimiento",
+    description:
+      "Vincula una factura con el movimiento bancario que la pagó. Una factura puede tener varios movimientos (pago en plazos); un movimiento, como mucho una factura. " +
+      "Al vincular, la factura pasa sola a 'pagada' (o 'pagada_parcial') y sus archivos se ven también desde el movimiento.",
+    inputSchema: objetoSchema(
+      {
+        factura_id: { type: "string" },
+        movimiento_id: { type: "string" },
+        usuario_email: CAMPO_USUARIO_EMAIL,
+      },
+      ["factura_id", "movimiento_id"],
+    ),
+    scope: "write",
+    annotations: { idempotentHint: true },
+    handler: async (args, ctx) => {
+      const actor = await actorDe(args, ctx)
+      const facturaId = textoObligatorio(args, "factura_id")
+      await vincularFacturaAMovimiento(
+        ctx.admin,
+        facturaId,
+        textoObligatorio(args, "movimiento_id"),
+        actor.id,
+      )
+      return { factura: await obtenerFactura(ctx.admin, facturaId, { baseUrl: ctx.baseUrl }) }
+    },
+  },
+  {
+    name: "desvincular_factura",
+    title: "Deshacer una conciliación",
+    description: "Quita el vínculo entre una factura y un movimiento concreto.",
+    inputSchema: objetoSchema({ factura_id: { type: "string" }, movimiento_id: { type: "string" } }, [
+      "factura_id",
+      "movimiento_id",
+    ]),
+    scope: "write",
+    annotations: { idempotentHint: true },
+    handler: async (args, ctx) => {
+      const facturaId = textoObligatorio(args, "factura_id")
+      await desvincularFacturaDeMovimiento(
+        ctx.admin,
+        facturaId,
+        textoObligatorio(args, "movimiento_id"),
+      )
+      return { factura: await obtenerFactura(ctx.admin, facturaId, { baseUrl: ctx.baseUrl }) }
+    },
+  },
+  {
+    name: "buscar_movimiento_de_factura",
+    title: "Buscar el movimiento de una factura",
+    description:
+      "Dado el importe (y opcionalmente la fecha y el proveedor) de UNA factura, propone los movimientos bancarios que mejor encajan, en las delegaciones que se indiquen o en todas, ordenados de mejor a peor y con los motivos. No modifica nada.",
+    inputSchema: objetoSchema(
+      {
+        importe: { type: "number", description: "Importe de la factura, en positivo." },
+        fecha: { type: "string", description: "Fecha de la factura (AAAA-MM-DD); afina mucho el resultado." },
+        proveedor: { type: "string", description: "Nombre del proveedor; se busca en el concepto del movimiento." },
+        numero: { type: "string", description: "Número de factura; a veces aparece en el concepto." },
+        delegaciones: CAMPO_DELEGACIONES,
+        ventana_dias: { type: "number", description: "Cuántos días alrededor de la fecha mirar (por defecto 90)." },
+        incluir_con_factura: {
+          type: "boolean",
+          description: "Incluir también movimientos que ya tienen otra factura vinculada.",
+        },
+        limite: { type: "number", description: "Cuántos candidatos devolver (por defecto 10)." },
+      },
+      ["importe"],
+    ),
+    scope: "read",
+    annotations: { readOnlyHint: true },
+    handler: async (args, ctx) => {
+      const ambito = await resolveAmbitoDelegaciones(ctx.admin, lista(args, "delegaciones"))
+      const candidatos = await buscarCandidatosParaFactura(
+        ctx.admin,
+        {
+          importe: numero(args, "importe"),
+          fecha: fecha(args, "fecha"),
+          proveedor: texto(args, "proveedor"),
+          numero: texto(args, "numero"),
+        },
+        {
+          ambito,
+          ventanaDias: numero(args, "ventana_dias"),
+          incluirConFactura: booleano(args, "incluir_con_factura"),
+          limite: numero(args, "limite"),
+        },
+      )
+      return { total: candidatos.length, candidatos }
+    },
+  },
+  {
+    name: "buscar_factura_de_movimiento",
+    title: "Buscar la factura de un movimiento",
+    description:
+      "El camino inverso: dado un movimiento, propone las facturas de su delegación que podrían corresponderle, comparando contra el importe que a cada una le queda por pagar.",
+    inputSchema: objetoSchema(
+      { movimiento_id: { type: "string" }, limite: { type: "number" } },
+      ["movimiento_id"],
+    ),
+    scope: "read",
+    annotations: { readOnlyHint: true },
+    handler: async (args, ctx) => {
+      const candidatas = await buscarFacturasParaMovimiento(
+        ctx.admin,
+        textoObligatorio(args, "movimiento_id"),
+        { limite: numero(args, "limite"), baseUrl: ctx.baseUrl },
+      )
+      return { total: candidatas.length, candidatas }
+    },
+  },
+  {
+    name: "conciliar_facturas",
+    title: "Cuadrar un lote de facturas",
+    description:
+      "Recibe una lista de facturas (importe y, si se sabe, fecha, proveedor y número) y busca a qué movimiento bancario corresponde cada una, en las delegaciones indicadas o en todas. " +
+      "Es lo que resuelve 'toma estos 12 importes, dime de qué movimiento es cada uno'. " +
+      "Por defecto SOLO PROPONE. Con aplicar=true vincula automáticamente los casos claros (importe exacto y con ventaja clara sobre el segundo candidato) y deja los dudosos para que decida una persona.",
+    inputSchema: objetoSchema(
+      {
+        facturas: {
+          type: "array",
+          description: "Las facturas a cuadrar (máximo 100).",
+          items: {
+            type: "object",
+            properties: {
+              referencia: { type: "string", description: "Etiqueta libre para reconocer esta línea en el resultado." },
+              importe: { type: "number", description: "Importe de la factura, en positivo." },
+              fecha: { type: "string", description: "AAAA-MM-DD." },
+              proveedor: { type: "string" },
+              numero: { type: "string" },
+              delegacion: { type: "string", description: "Limita esta línea a una delegación concreta." },
+              factura_id: { type: "string", description: "Si la factura ya está en MCM Bank, su id." },
+            },
+            required: ["importe"],
+          },
+        },
+        delegaciones: CAMPO_DELEGACIONES,
+        ventana_dias: { type: "number", description: "Días alrededor de la fecha de cada factura (por defecto 90)." },
+        max_candidatos: { type: "number", description: "Candidatos por factura (por defecto 5)." },
+        aplicar: {
+          type: "boolean",
+          description: "Vincular automáticamente los casos claros. Por defecto false (solo propone).",
+        },
+        crear_facturas: {
+          type: "boolean",
+          description:
+            "Con aplicar=true, registrar en la bandeja las facturas que aún no existan en MCM Bank antes de vincularlas.",
+        },
+        usuario_email: CAMPO_USUARIO_EMAIL,
+      },
+      ["facturas"],
+    ),
+    scope: (args) => (args.aplicar ? "write" : "read"),
+    handler: async (args, ctx) => {
+      const aplicar = booleano(args, "aplicar") ?? false
+      const items = listaDeObjetos(args, "facturas") ?? []
+      const actor = aplicar ? await actorDe(args, ctx) : null
+
+      return conciliarLote(
+        ctx.admin,
+        {
+          items: items.map((item) => ({
+            referencia: texto(item, "referencia"),
+            importe: numero(item, "importe"),
+            fecha: fecha(item, "fecha"),
+            proveedor: texto(item, "proveedor"),
+            numero: texto(item, "numero"),
+            delegacion: texto(item, "delegacion"),
+            factura_id: texto(item, "factura_id"),
+          })),
+          delegaciones: lista(args, "delegaciones") ?? null,
+          ventanaDias: numero(args, "ventana_dias"),
+          maxCandidatos: numero(args, "max_candidatos"),
+          aplicar,
+          crearFacturas: booleano(args, "crear_facturas"),
+        },
+        actor?.id ?? null,
+      )
+    },
+  },
+
+  // ---------------------------------------------------------------- Archivos
+  {
+    name: "subir_archivo",
+    title: "Subir una factura o documento",
+    description:
+      "Sube un archivo (PDF, imagen, hoja de cálculo…) y lo adjunta a un movimiento o a una factura. " +
+      "Al adjuntarlo a un movimiento como factura, además se registra solo en la sección Facturas ya conciliado con ese movimiento, igual que si se hubiera hecho desde la app. " +
+      `El contenido va en base64 y el máximo por API son ${Math.round(MAX_BYTES_API / 1024 / 1024)} MB (por encima, hay que subirlo desde la aplicación).`,
+    inputSchema: objetoSchema(
+      {
+        movimiento_id: { type: "string", description: "Adjuntar a este movimiento. Indica esto o factura_id." },
+        factura_id: { type: "string", description: "Adjuntar a esta factura de la bandeja." },
+        nombre: { type: "string", description: "Nombre del fichero con su extensión, p. ej. 'mercadona-oct.pdf'." },
+        contenido_base64: { type: "string", description: "Contenido del fichero codificado en base64." },
+        tipo_mime: { type: "string", description: "Si se omite, se deduce de la extensión." },
+        descripcion: { type: "string", description: "Nota corta sobre el archivo." },
+        bucket: {
+          type: "string",
+          enum: ["facturas", "documentos"],
+          description: "'facturas' (por defecto) o 'documentos' para material que no es una factura.",
+        },
+        crear_factura: {
+          type: "boolean",
+          description:
+            "Solo para movimientos y bucket 'facturas': crear también la entidad factura. Por defecto true.",
+        },
+        usuario_email: CAMPO_USUARIO_EMAIL,
+      },
+      ["nombre", "contenido_base64"],
+    ),
+    scope: "write",
+    handler: async (args, ctx) => {
+      const actor = await actorDe(args, ctx)
+      const archivo = {
+        nombre: textoObligatorio(args, "nombre"),
+        contenido_base64: textoObligatorio(args, "contenido_base64"),
+        tipo_mime: texto(args, "tipo_mime"),
+        descripcion: texto(args, "descripcion"),
+        bucket: opcion(args, "bucket", ["facturas", "documentos"] as const),
+      }
+
+      const movimientoId = texto(args, "movimiento_id")
+      const facturaId = texto(args, "factura_id")
+      if (!movimientoId && !facturaId) {
+        throw badRequest("Indica a qué se adjunta: 'movimiento_id' o 'factura_id'.")
+      }
+      if (movimientoId && facturaId) {
+        throw badRequest(
+          "Indica solo uno: 'movimiento_id' o 'factura_id'. Para adjuntarlo a los dos, súbelo al movimiento y se registrará también en su factura.",
+        )
+      }
+
+      const resultado = movimientoId
+        ? await subirArchivoAMovimiento(ctx.admin, {
+            movimientoId,
+            archivo,
+            crearFactura: booleano(args, "crear_factura"),
+            actorId: actor.id,
+            baseUrl: ctx.baseUrl,
+          })
+        : await subirArchivoAFactura(ctx.admin, {
+            facturaId: facturaId as string,
+            archivo,
+            actorId: actor.id,
+            baseUrl: ctx.baseUrl,
+          })
+
+      return { ...resultado, firmado_por: nombreActor(actor) }
+    },
+  },
+  {
+    name: "obtener_url_archivo",
+    title: "Enlace de descarga de un archivo",
+    description:
+      "Devuelve una URL temporal (5 minutos) para descargar un archivo adjunto. Úsala para abrir o leer una factura ya subida.",
+    inputSchema: objetoSchema(
+      {
+        archivo_id: { type: "string", description: "Id del archivo (aparece en los adjuntos del movimiento o la factura)." },
+        segundos: { type: "number", description: "Validez del enlace en segundos (por defecto 300)." },
+      },
+      ["archivo_id"],
+    ),
+    scope: "read",
+    annotations: { readOnlyHint: true },
+    handler: async (args, ctx) => {
+      const { fila } = await localizarArchivo(ctx.admin, textoObligatorio(args, "archivo_id"))
+      const segundos = Math.min(Math.max(numero(args, "segundos") ?? 300, 30), 3600)
+      const url = await urlFirmada(ctx.admin, fila.bucket, fila.path_storage, segundos)
+      return {
+        url,
+        nombre: fila.nombre_original,
+        tipo_mime: fila.tipo_mime,
+        caduca_en_segundos: segundos,
+      }
+    },
+  },
+  {
+    name: "eliminar_archivo",
+    title: "Borrar un archivo",
+    description: "Borra un archivo adjunto y su fichero. Irreversible.",
+    inputSchema: objetoSchema({ archivo_id: { type: "string" } }, ["archivo_id"]),
+    scope: "write",
+    annotations: { destructiveHint: true, idempotentHint: true },
+    handler: async (args, ctx) => {
+      await eliminarArchivo(ctx.admin, textoObligatorio(args, "archivo_id"))
+      return { eliminado: true, archivo_id: args.archivo_id }
+    },
+  },
+
+  // ------------------------------------------------------------------ Avisos
+  {
+    name: "listar_avisos",
+    title: "Ver avisos y tareas",
+    description:
+      "Notas y tareas del canal entre la oficina técnica y los tesoreros. Por defecto solo las pendientes, de todas las delegaciones: es la forma de ver de un vistazo qué tiene cada delegación por resolver.",
+    inputSchema: objetoSchema({
+      delegaciones: CAMPO_DELEGACIONES,
+      estado: {
+        type: "string",
+        enum: ["pendiente", "hecha", "todas"],
+        description: "Por defecto 'pendiente'.",
+      },
+      tipo: { type: "string", enum: ["tarea", "nota"] },
+      destinatario: {
+        type: "string",
+        enum: ["oficina_tecnica", "delegacion"],
+        description: "A quién va dirigido el aviso.",
+      },
+      texto: { type: "string", description: "Filtra por el contenido." },
+      limite: { type: "number", description: "Por defecto 100." },
+    }),
+    scope: "read",
+    annotations: { readOnlyHint: true },
+    handler: async (args, ctx) =>
+      listarAvisos(ctx.admin, {
+        delegaciones: lista(args, "delegaciones") ?? null,
+        estado: opcion(args, "estado", ["pendiente", "hecha", "todas"] as const),
+        tipo: opcion(args, "tipo", ["tarea", "nota"] as const),
+        destinatario: opcion(args, "destinatario", ["oficina_tecnica", "delegacion"] as const),
+        texto: texto(args, "texto"),
+        limite: numero(args, "limite"),
+      }),
+  },
+  {
+    name: "crear_aviso",
+    title: "Dejar una nota o tarea",
+    description:
+      "Escribe una nota o una tarea en el canal de una delegación. Es el módulo de comunicación entre la oficina técnica y los tesoreros: aparece en el panel de avisos de esa delegación. " +
+      "Usa tipo 'tarea' cuando esperas que alguien haga algo (se puede marcar como hecha) y 'nota' cuando solo informas. Con notificar=true además se envía por correo a quien corresponda.",
+    inputSchema: objetoSchema(
+      {
+        delegacion: { type: "string", description: "Nombre, código o id de la delegación." },
+        contenido: { type: "string", description: "El texto del aviso (máximo 2000 caracteres)." },
+        tipo: { type: "string", enum: ["tarea", "nota"], description: "Por defecto 'nota'." },
+        destinatario: {
+          type: "string",
+          enum: ["delegacion", "oficina_tecnica"],
+          description:
+            "A quién va dirigido: 'delegacion' (los tesoreros, por defecto) u 'oficina_tecnica' (los gestores centrales).",
+        },
+        referencia: { type: "string", description: "Etiqueta corta de contexto, máximo 60 caracteres." },
+        notificar: { type: "boolean", description: "Enviarlo además por correo." },
+        usuario_email: CAMPO_USUARIO_EMAIL,
+      },
+      ["delegacion", "contenido"],
+    ),
+    scope: "write",
+    handler: async (args, ctx) => {
+      const actor = await actorDe(args, ctx)
+      const resultado = await crearAviso(
+        ctx.admin,
+        {
+          delegacion: textoObligatorio(args, "delegacion"),
+          contenido: textoObligatorio(args, "contenido"),
+          tipo: opcion(args, "tipo", ["tarea", "nota"] as const),
+          destinatario: opcion(args, "destinatario", ["delegacion", "oficina_tecnica"] as const),
+          referencia: texto(args, "referencia"),
+          notificar: booleano(args, "notificar"),
+        },
+        actor.id,
+      )
+      return { ...resultado, firmado_por: nombreActor(actor) }
+    },
+  },
+  {
+    name: "actualizar_aviso",
+    title: "Editar o cerrar un aviso",
+    description:
+      "Cambia el texto de un aviso o lo marca como hecho (estado 'hecha') o de nuevo pendiente.",
+    inputSchema: objetoSchema(
+      {
+        id: { type: "string" },
+        contenido: { type: "string" },
+        referencia: { type: "string" },
+        destinatario: { type: "string", enum: ["delegacion", "oficina_tecnica"] },
+        estado: { type: "string", enum: ["pendiente", "hecha"] },
+        usuario_email: CAMPO_USUARIO_EMAIL,
+      },
+      ["id"],
+    ),
+    scope: "write",
+    annotations: { idempotentHint: true },
+    handler: async (args, ctx) => {
+      const actor = await actorDe(args, ctx)
+      const aviso = await actualizarAviso(
+        ctx.admin,
+        textoObligatorio(args, "id"),
+        {
+          contenido: texto(args, "contenido"),
+          referencia: "referencia" in args ? texto(args, "referencia") ?? null : undefined,
+          destinatario: opcion(args, "destinatario", ["delegacion", "oficina_tecnica"] as const),
+          estado: opcion(args, "estado", ["pendiente", "hecha"] as const),
+        },
+        actor.id,
+      )
+      return { aviso }
+    },
+  },
+  {
+    name: "eliminar_aviso",
+    title: "Borrar un aviso",
+    description: "Borra una nota o tarea. Irreversible; para archivarla, mejor marcarla como hecha.",
+    inputSchema: objetoSchema({ id: { type: "string" } }, ["id"]),
+    scope: "write",
+    annotations: { destructiveHint: true, idempotentHint: true },
+    handler: async (args, ctx) => {
+      await eliminarAviso(ctx.admin, textoObligatorio(args, "id"))
+      return { eliminado: true, id: args.id }
+    },
+  },
+  {
+    name: "notificar_aviso",
+    title: "Enviar un aviso por correo",
+    description:
+      "Envía (o reenvía) por correo un aviso ya creado: a los tesoreros de su delegación o a la oficina técnica, según a quién vaya dirigido. Nunca se envía a su autor.",
+    inputSchema: objetoSchema(
+      { id: { type: "string" }, usuario_email: CAMPO_USUARIO_EMAIL },
+      ["id"],
+    ),
+    scope: "write",
+    handler: async (args, ctx) => {
+      const actor = await actorDe(args, ctx)
+      const id = textoObligatorio(args, "id")
+      const { destinatarios } = await notificarAviso(ctx.admin, id, actor.id)
+      return { aviso: await obtenerAviso(ctx.admin, id), notificados: destinatarios }
+    },
+  },
+
+  // -------------------------------------------------------------- Pagos MCM
+  {
+    name: "listar_pagos_mcm",
+    title: "Ver pagos MCM",
+    description:
+      "Reembolsos a personas del movimiento (kilometraje, gastos adelantados). Solo lectura: darlos de alta se hace desde la aplicación.",
+    inputSchema: objetoSchema({
+      delegaciones: CAMPO_DELEGACIONES,
+      estados: { type: "array", items: { type: "string" } },
+      limite: { type: "number" },
+      offset: { type: "number" },
+    }),
+    scope: "read",
+    annotations: { readOnlyHint: true },
+    handler: async (args, ctx) =>
+      listarPagosMcm(ctx.admin, {
+        delegaciones: lista(args, "delegaciones") ?? null,
+        estados: lista(args, "estados"),
+        limite: numero(args, "limite"),
+        offset: numero(args, "offset"),
+      }),
+  },
+]
+
+export const HERRAMIENTAS_POR_NOMBRE = new Map(HERRAMIENTAS.map((h) => [h.name, h]))
+
+/** Definiciones tal y como las espera `tools/list` del protocolo MCP. */
+export function definicionesDeHerramientas() {
+  return HERRAMIENTAS.map((h) => ({
+    name: h.name,
+    title: h.title,
+    description: h.description,
+    inputSchema: h.inputSchema,
+    ...(h.annotations ? { annotations: { title: h.title, ...h.annotations } } : {}),
+  }))
+}
+
+export function permisoDe(herramienta: HerramientaMcp, args: Args): ApiScope {
+  return typeof herramienta.scope === "function" ? herramienta.scope(args) : herramienta.scope
+}

--- a/lib/services/aviso-notificaciones.ts
+++ b/lib/services/aviso-notificaciones.ts
@@ -1,0 +1,254 @@
+import type { createAdminClient } from "@/lib/supabase/admin"
+import { ApiError } from "@/lib/api/errors"
+import { AVISO_DESTINATARIO_LABELS } from "@/lib/types/avisos"
+import type { AvisoDestinatario, AvisoTipo } from "@/lib/types/avisos"
+
+type AdminClient = ReturnType<typeof createAdminClient>
+
+/**
+ * Envío por correo (Resend) de un aviso o tarea.
+ *
+ * Vive fuera de la ruta HTTP porque hay dos caminos que llegan aquí: la app
+ * (`POST /api/avisos/notificar`, con sesión de usuario y sus comprobaciones de
+ * permisos) y la API externa / servidor MCP (con clave de API). El "a quién se
+ * le manda" y el aspecto del correo deben ser idénticos en ambos; la
+ * autorización, no, y por eso se queda en cada llamador.
+ *
+ * Destinatarios:
+ *   - `delegacion`      → tesoreros de esa delegación
+ *   - `oficina_tecnica` → gestores centrales
+ * Nunca se envía a quien escribió el aviso.
+ */
+
+const REMITENTE = "MCM Bank <no-reply@movimientoconsolacion.com>"
+
+export interface AvisoNotificable {
+  id: string
+  delegacion_id: string
+  tipo: string
+  contenido: string
+  referencia: string | null
+  destinatario: string
+  creado_por: string
+}
+
+export interface ResultadoNotificacion {
+  destinatarios: string[]
+}
+
+export async function enviarNotificacionAviso(
+  admin: AdminClient,
+  aviso: AvisoNotificable,
+  options: { marcarNotificadoPor?: string } = {},
+): Promise<ResultadoNotificacion> {
+  const resendApiKey = process.env.RESEND_API_KEY
+  if (!resendApiKey) {
+    throw new ApiError(
+      503,
+      "El servicio de correo no está configurado (falta RESEND_API_KEY). El aviso se ha guardado igualmente.",
+    )
+  }
+
+  const destinatario = aviso.destinatario as AvisoDestinatario
+
+  let membresiasQuery = (admin as any).from("membresia").select("usuario_id, rol")
+  membresiasQuery =
+    destinatario === "delegacion"
+      ? membresiasQuery.eq("delegacion_id", aviso.delegacion_id).eq("rol", "tesorero")
+      : membresiasQuery.eq("rol", "gestor_central")
+
+  const { data: destinatarios, error: destError } = await membresiasQuery
+  if (destError) {
+    throw new ApiError(500, `No se pudieron resolver los destinatarios: ${destError.message}`)
+  }
+
+  const idsDestino = Array.from(
+    new Set<string>((destinatarios ?? []).map((m: any) => String(m.usuario_id))),
+  ).filter((id) => id !== aviso.creado_por)
+
+  if (idsDestino.length === 0) {
+    throw new ApiError(
+      409,
+      destinatario === "delegacion"
+        ? "Esta delegación no tiene ningún tesorero al que avisar."
+        : "No hay nadie en la oficina técnica a quien avisar.",
+    )
+  }
+
+  const { data: usuarios, error: usuariosError } = await admin.auth.admin.listUsers({ perPage: 1000 })
+  if (usuariosError) {
+    throw new ApiError(500, `No se pudieron obtener los correos: ${usuariosError.message}`)
+  }
+
+  const emailPorId = new Map<string, string>()
+  for (const u of usuarios?.users ?? []) {
+    if (u.email) emailPorId.set(u.id, u.email)
+  }
+
+  const emails = idsDestino.map((id) => emailPorId.get(id)).filter(Boolean) as string[]
+  if (emails.length === 0) {
+    throw new ApiError(409, "Los destinatarios no tienen correo configurado.")
+  }
+
+  const [{ data: delegacion }, { data: perfilAutor }] = await Promise.all([
+    (admin as any).from("delegacion").select("nombre").eq("id", aviso.delegacion_id).maybeSingle(),
+    (admin as any).from("perfil").select("nombre_completo").eq("usuario_id", aviso.creado_por).maybeSingle(),
+  ])
+
+  const autor = perfilAutor?.nombre_completo?.trim() || emailPorId.get(aviso.creado_por) || "Alguien"
+  const delegacionNombre = delegacion?.nombre || "MCM"
+  const tipo = aviso.tipo as AvisoTipo
+  const contenido = String(aviso.contenido ?? "")
+  const referencia = aviso.referencia ? String(aviso.referencia) : null
+
+  const asunto = `${tipo === "tarea" ? "Nueva tarea" : "Aviso"} · ${delegacionNombre} — ${resumen(contenido)}`
+  const enlace = (process.env.NEXT_PUBLIC_SITE_URL || "https://banco.movimientoconsolacion.com").replace(
+    /\/$/,
+    "",
+  )
+
+  const html = renderEmail({
+    tipo,
+    contenido,
+    referencia,
+    autor,
+    delegacionNombre,
+    destinatario,
+    enlace,
+  })
+
+  try {
+    const response = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${resendApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        from: REMITENTE,
+        to: emails,
+        subject: asunto,
+        html,
+        text: renderTexto({ tipo, contenido, referencia, autor, delegacionNombre, enlace }),
+        ...(emailPorId.get(aviso.creado_por) ? { reply_to: [emailPorId.get(aviso.creado_por)] } : {}),
+      }),
+    })
+
+    if (!response.ok) {
+      const detalle = await response.text()
+      console.error("Resend rechazó la notificación del aviso:", detalle)
+      throw new ApiError(502, "El correo no se pudo enviar.")
+    }
+  } catch (err) {
+    if (err instanceof ApiError) throw err
+    console.error("Error enviando la notificación del aviso:", (err as any)?.message || err)
+    throw new ApiError(502, "El correo no se pudo enviar.")
+  }
+
+  const { error: updateError } = await (admin as any)
+    .from("aviso")
+    .update({
+      notificado_en: new Date().toISOString(),
+      notificado_por: options.marcarNotificadoPor ?? aviso.creado_por,
+    })
+    .eq("id", aviso.id)
+
+  if (updateError) {
+    // El correo ya salió: no se hace fallar la operación por el sello.
+    console.warn("Aviso notificado pero no se pudo sellar notificado_en:", updateError.message)
+  }
+
+  return { destinatarios: emails }
+}
+
+function resumen(texto: string, max = 70): string {
+  const limpio = texto.replace(/\s+/g, " ").trim()
+  return limpio.length > max ? `${limpio.slice(0, max - 1)}…` : limpio
+}
+
+function escapeHtml(texto: string): string {
+  return texto
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;")
+}
+
+interface EmailData {
+  tipo: AvisoTipo
+  contenido: string
+  referencia: string | null
+  autor: string
+  delegacionNombre: string
+  destinatario: AvisoDestinatario
+  enlace: string
+}
+
+function renderEmail({ tipo, contenido, referencia, autor, delegacionNombre, destinatario, enlace }: EmailData) {
+  const esTarea = tipo === "tarea"
+  const etiqueta = esTarea ? "Tarea pendiente" : "Nota informativa"
+  const acento = esTarea ? "#b45309" : "#2563eb"
+  const acentoFondo = esTarea ? "#fffbeb" : "#eff6ff"
+
+  return `<!doctype html>
+<html lang="es">
+  <body style="margin:0;padding:32px 16px;background:#f6f7f9;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;color:#111827;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:520px;margin:0 auto;">
+      <tr>
+        <td style="background:#ffffff;border:1px solid #e5e7eb;border-radius:16px;padding:28px;">
+          <p style="margin:0 0 18px;font-size:12px;font-weight:600;letter-spacing:.04em;text-transform:uppercase;color:${acento};">
+            ${etiqueta}
+          </p>
+          <p style="margin:0 0 20px;font-size:17px;line-height:1.55;color:#111827;white-space:pre-wrap;">${escapeHtml(contenido)}</p>
+          ${
+            referencia
+              ? `<p style="margin:0 0 20px;"><span style="display:inline-block;background:${acentoFondo};color:${acento};border-radius:999px;padding:5px 12px;font-size:13px;">${escapeHtml(referencia)}</span></p>`
+              : ""
+          }
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border-top:1px solid #f3f4f6;margin-top:4px;">
+            <tr>
+              <td style="padding-top:16px;font-size:13px;line-height:1.6;color:#6b7280;">
+                <strong style="color:#374151;">${escapeHtml(autor)}</strong> lo ha anotado en
+                <strong style="color:#374151;">${escapeHtml(delegacionNombre)}</strong><br />
+                Dirigido a: ${escapeHtml(AVISO_DESTINATARIO_LABELS[destinatario])}
+              </td>
+            </tr>
+          </table>
+          <p style="margin:24px 0 0;">
+            <a href="${enlace}" style="display:inline-block;background:#2563eb;color:#ffffff;text-decoration:none;font-size:14px;font-weight:600;padding:11px 20px;border-radius:10px;">
+              Abrir en MCM Bank
+            </a>
+          </p>
+        </td>
+      </tr>
+      <tr>
+        <td style="padding:16px 4px 0;text-align:center;font-size:12px;color:#9ca3af;">
+          Avisos y tareas de MCM Bank · no respondas a este correo si no hace falta
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`
+}
+
+function renderTexto({
+  tipo,
+  contenido,
+  referencia,
+  autor,
+  delegacionNombre,
+  enlace,
+}: Omit<EmailData, "destinatario">) {
+  return [
+    tipo === "tarea" ? "TAREA PENDIENTE" : "NOTA INFORMATIVA",
+    "",
+    contenido,
+    referencia ? `\nReferencia: ${referencia}` : "",
+    "",
+    `${autor} · ${delegacionNombre}`,
+    enlace,
+  ]
+    .filter((linea) => linea !== "")
+    .join("\n")
+}

--- a/lib/utils/facturas-matching.ts
+++ b/lib/utils/facturas-matching.ts
@@ -1,0 +1,86 @@
+import type { FacturaConRelaciones, MovimientoConRelaciones } from "@/lib/types/database"
+
+/**
+ * Lógica pura de conciliación factura ↔ movimiento.
+ *
+ * Vive separada de `lib/utils/facturas.ts` (que arrastra iconos y clases de
+ * Tailwind para la interfaz) para que el servidor —la API externa y el servidor
+ * MCP— pueda puntuar candidatos sin importar nada de React.
+ */
+
+/** Suma de los movimientos ya vinculados a una factura (valor absoluto). */
+export function importePagadoFactura(factura: Pick<FacturaConRelaciones, "movimientos">): number {
+  return (factura.movimientos ?? []).reduce((sum, m) => sum + Math.abs(Number(m.importe)), 0)
+}
+
+/**
+ * Importe que le falta a la factura por cubrir (null si no tiene importe
+ * definido). Nunca negativo.
+ */
+export function importePendienteFactura(
+  factura: Pick<FacturaConRelaciones, "movimientos" | "importe">,
+): number | null {
+  if (factura.importe == null) return null
+  return Math.max(Number(factura.importe) - importePagadoFactura(factura), 0)
+}
+
+/**
+ * Margen de importe para buscar movimientos candidatos de una factura:
+ * un 2% del importe con un mínimo de 0,50 € ("un pelín de margen").
+ */
+export function margenImporteFactura(importe: number): number {
+  return Math.max(Math.abs(importe) * 0.02, 0.5)
+}
+
+export interface CandidatoScore {
+  score: number
+  importeExacto: boolean
+  fechaCercana: boolean
+  mismoContacto: boolean
+}
+
+/**
+ * Puntúa un movimiento como candidato para una factura. El precio manda:
+ * importe exacto pesa mucho más que la fecha; el contacto ayuda a desempatar.
+ */
+export function scoreCandidatoMovimiento(
+  factura: { importe?: number | null; fecha_emision?: string | null; contacto_id?: string | null },
+  movimiento: Pick<MovimientoConRelaciones, "importe" | "fecha" | "contacto_id">,
+): CandidatoScore {
+  let score = 0
+
+  const importeExacto =
+    factura.importe != null && Math.abs(Math.abs(Number(movimiento.importe)) - Math.abs(Number(factura.importe))) < 0.005
+  if (importeExacto) score += 4
+  else if (factura.importe != null) score += 1 // dentro del margen (la query ya filtró)
+
+  let fechaCercana = false
+  if (factura.fecha_emision && movimiento.fecha) {
+    const diffDias = Math.abs(
+      (new Date(movimiento.fecha).getTime() - new Date(factura.fecha_emision).getTime()) / 86400000,
+    )
+    if (diffDias <= 5) {
+      score += 2
+      fechaCercana = true
+    } else if (diffDias <= 20) {
+      score += 1
+    }
+  }
+
+  const mismoContacto = Boolean(factura.contacto_id && movimiento.contacto_id === factura.contacto_id)
+  if (mismoContacto) score += 2
+
+  return { score, importeExacto, fechaCercana, mismoContacto }
+}
+
+/**
+ * Un candidato es "match directo" si tiene importe exacto y destaca claramente
+ * sobre el segundo (o es el único).
+ */
+export function esMatchDirecto(scores: CandidatoScore[]): boolean {
+  if (scores.length === 0) return false
+  const [primero, segundo] = scores
+  if (!primero.importeExacto) return false
+  if (!segundo) return true
+  return primero.score >= segundo.score + 2
+}

--- a/lib/utils/facturas.ts
+++ b/lib/utils/facturas.ts
@@ -1,6 +1,18 @@
 import type { LucideIcon } from "lucide-react"
 import { BadgeCheck, CheckCircle2, Clock, ExternalLink, Inbox, Mail, PieChart, Upload } from "lucide-react"
-import type { FacturaConRelaciones, FacturaEstado, FacturaOrigen, MovimientoConRelaciones } from "@/lib/types/database"
+import type { FacturaEstado, FacturaOrigen } from "@/lib/types/database"
+
+// La lógica pura de conciliación vive en `facturas-matching.ts` para que el
+// servidor pueda usarla sin arrastrar iconos ni estilos. Se reexporta aquí para
+// no cambiar los imports que ya existen en la interfaz.
+export {
+  importePagadoFactura,
+  importePendienteFactura,
+  margenImporteFactura,
+  scoreCandidatoMovimiento,
+  esMatchDirecto,
+} from "@/lib/utils/facturas-matching"
+export type { CandidatoScore } from "@/lib/utils/facturas-matching"
 
 export interface FacturaEstadoInfo {
   value: FacturaEstado
@@ -80,22 +92,6 @@ export const FACTURA_ESTADO_ORDER: readonly FacturaEstado[] = [
   "pagada_fuera",
 ]
 
-/** Suma de los movimientos ya vinculados a una factura (valor absoluto). */
-export function importePagadoFactura(factura: Pick<FacturaConRelaciones, "movimientos">): number {
-  return (factura.movimientos ?? []).reduce((sum, m) => sum + Math.abs(Number(m.importe)), 0)
-}
-
-/**
- * Importe que le falta a la factura por cubrir (null si no tiene importe
- * definido). Nunca negativo.
- */
-export function importePendienteFactura(
-  factura: Pick<FacturaConRelaciones, "movimientos" | "importe">,
-): number | null {
-  if (factura.importe == null) return null
-  return Math.max(Number(factura.importe) - importePagadoFactura(factura), 0)
-}
-
 export interface FacturaOrigenInfo {
   value: FacturaOrigen
   label: string
@@ -106,65 +102,4 @@ export const FACTURA_ORIGEN_INFO: Record<FacturaOrigen, FacturaOrigenInfo> = {
   subida: { value: "subida", label: "Subida a mano", icon: Upload },
   movimiento: { value: "movimiento", label: "Creada desde un movimiento", icon: ExternalLink },
   email: { value: "email", label: "Recibida por email", icon: Mail },
-}
-
-/**
- * Margen de importe para buscar movimientos candidatos de una factura:
- * un 2% del importe con un mínimo de 0,50 € ("un pelín de margen").
- */
-export function margenImporteFactura(importe: number): number {
-  return Math.max(Math.abs(importe) * 0.02, 0.5)
-}
-
-export interface CandidatoScore {
-  score: number
-  importeExacto: boolean
-  fechaCercana: boolean
-  mismoContacto: boolean
-}
-
-/**
- * Puntúa un movimiento como candidato para una factura. El precio manda:
- * importe exacto pesa mucho más que la fecha; el contacto ayuda a desempatar.
- */
-export function scoreCandidatoMovimiento(
-  factura: { importe?: number | null; fecha_emision?: string | null; contacto_id?: string | null },
-  movimiento: Pick<MovimientoConRelaciones, "importe" | "fecha" | "contacto_id">,
-): CandidatoScore {
-  let score = 0
-
-  const importeExacto =
-    factura.importe != null && Math.abs(Math.abs(Number(movimiento.importe)) - Math.abs(Number(factura.importe))) < 0.005
-  if (importeExacto) score += 4
-  else if (factura.importe != null) score += 1 // dentro del margen (la query ya filtró)
-
-  let fechaCercana = false
-  if (factura.fecha_emision && movimiento.fecha) {
-    const diffDias = Math.abs(
-      (new Date(movimiento.fecha).getTime() - new Date(factura.fecha_emision).getTime()) / 86400000,
-    )
-    if (diffDias <= 5) {
-      score += 2
-      fechaCercana = true
-    } else if (diffDias <= 20) {
-      score += 1
-    }
-  }
-
-  const mismoContacto = Boolean(factura.contacto_id && movimiento.contacto_id === factura.contacto_id)
-  if (mismoContacto) score += 2
-
-  return { score, importeExacto, fechaCercana, mismoContacto }
-}
-
-/**
- * Un candidato es "match directo" si tiene importe exacto y destaca claramente
- * sobre el segundo (o es el único).
- */
-export function esMatchDirecto(scores: CandidatoScore[]): boolean {
-  if (scores.length === 0) return false
-  const [primero, segundo] = scores
-  if (!primero.importeExacto) return false
-  if (!segundo) return true
-  return primero.score >= segundo.score + 2
 }


### PR DESCRIPTION
## Qué hace

La API externa solo sabía devolver **un movimiento por su id** y sus archivos. Ahora cubre lo que la oficina técnica necesita para revisar las 18 delegaciones a la vez, por dos puertas sobre el mismo motor:

- **REST** en `/api/v1` — 21 rutas, 32 operaciones
- **MCP** en `/api/mcp` — 27 herramientas, para hablarle en lenguaje natural desde Claude

Toda la lógica vive en `lib/api/*`; los route handlers solo parsean, comprueban la clave y delegan. Añadir una capacidad una vez la deja disponible en las dos puertas.

## Los cuatro casos que motivaron esto

| Lo que se dice | Lo que lo resuelve |
|---|---|
| «movimientos de Mercadona de más de 50 € en todas las delegaciones» | `buscar_movimientos` / `GET /api/v1/movimientos` — sin indicar delegación busca en todas y devuelve el total del conjunto encontrado, no solo el de la página |
| «deja una nota a Sevilla y avísales» | `crear_aviso` / `POST /api/v1/avisos` con `notificar` |
| «sube esta factura y vincúlala al movimiento» | `subir_archivo` / `POST /api/v1/movimientos/{id}/archivos` — crea también la entidad factura ya conciliada, igual que la app |
| «toma estos 12 importes, dime de qué movimiento es cada uno» | `conciliar_facturas` / `POST /api/v1/conciliacion` — puntúa candidatos con motivos en texto |

## Dos correcciones de lo que ya había

- El campo `url` de los adjuntos **venía vacío** en todo lo subido desde que la app pasó a URLs firmadas: quien consumiera la API no podía descargar nada. Ahora hay `url_descarga` (endpoint autenticado que redirige a una URL firmada) y `/api/v1/archivos/{id}/url`.
- Los errores inesperados publicaban la **traza de pila** completa en la respuesta. Ahora se registra entera en el servidor y sale solo la primera línea, recortada.

## Decisiones que conviene conocer al revisar

- **Dos niveles de clave.** `MCM_API_KEY` escribe; `MCM_API_KEY_READONLY` y el histórico `CRON_SECRET` solo leen. `CRON_SECRET` nunca da escritura, así que las integraciones actuales siguen funcionando sin poder modificar nada.
- **Toda escritura se firma con un usuario real** (`usuario_email`, cabecera `x-mcm-usuario-email` o `MCM_API_USER_EMAIL`). Si no hay ninguno, la operación falla en vez de atribuirla a alguien al azar.
- **Importe, fecha, cuenta y delegación de un movimiento no se pueden cambiar** desde la API: vienen del banco.
- **Las RPC de agregación no sirven aquí.** `get_financial_summary`, `get_saldos_por_cuenta` y compañía llaman a `assert_delegacion_member`, que mira `auth.uid()` y por tanto siempre falla con service role. Los totales se agregan en JS, paginando por `id` (columna única) para que las páginas no se solapen.
- **Conciliación en bloque conservadora**: por defecto solo propone; con `aplicar: true` toca únicamente los casos claros (importe exacto y ventaja sobre el segundo candidato) y deja los dudosos para revisión humana.
- **Contactos y pagos MCM: solo lectura.** Sus altas tienen reglas propias (cálculo de gasolina, contacto obligatorio) que se hacen mejor desde la pantalla, y en la base de datos hay 1 contacto y 1 pago en total.

## Refactors de paso

- El envío de correo de avisos sale de `app/api/avisos/notificar/route.ts` a `lib/services/aviso-notificaciones.ts`, compartido con la API. La ruta conserva sus comprobaciones de permisos de sesión.
- La puntuación de conciliación se extrae a `lib/utils/facturas-matching.ts` (sin React) para que el servidor no arrastre iconos; `lib/utils/facturas.ts` la reexporta y ningún import existente cambia.

## Qué se ha verificado

- `pnpm lint`, `pnpm typecheck`, `pnpm build` en verde.
- **118 tests** (28 nuevos): protocolo MCP, catálogo de herramientas, resolución de delegaciones por nombre, escapado de filtros PostgREST y coerción de argumentos.
- Saludo MCP completo por HTTP contra el servidor construido: `initialize`, `tools/list`, notificaciones (202), método desconocido (-32601), `GET` (405), preflight CORS (204), y que una clave de solo lectura recibe un aviso claro al intentar escribir.
- Autenticación comprobada en las 9 rutas GET nuevas (401 sin clave) y el salto a 403 al escribir con clave de lectura.
- Spec OpenAPI: 21 rutas, 32 operaciones, sin referencias rotas.
- La sintaxis PostgREST de las consultas nuevas, **contra la base de datos de producción** con la clave anónima — incluido que dos `or` encadenados se combinan con AND (de ahí que la búsqueda multipalabra funcione) y que el filtro por importe absoluto compone con la búsqueda de texto.

**No verificado:** ninguna llamada end-to-end con datos reales, por no disponer de la `service_role_key` en el entorno de desarrollo. Lo que toca la base de datos está probado en sintaxis y lógica pura, pero no ejecutado contra los 2.285 movimientos reales. El primer `curl` a `/api/v1/delegaciones` tras desplegar es la comprobación pendiente.

## Configuración necesaria antes de usarlo

En Vercel: `MCM_API_KEY` y `MCM_API_USER_EMAIL` (y opcionalmente `MCM_API_KEY_READONLY`). Sin la segunda, las lecturas funcionan pero las escrituras fallan con un mensaje explicándolo.

Pasos completos en `docs/API_PRUEBA_RAPIDA.md`; manual de usuario en `docs/manual/22.-servidor-mcp.md` y `21.-api-externa-solo-pros.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114R4GqBvorLidhbU3uKx4Y

---
_Generated by [Claude Code](https://claude.ai/code/session_0114R4GqBvorLidhbU3uKx4Y)_