### PR TITLE
feat(mcp): OAuth 2.1 para conectar MCM Bank desde claude.ai

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,6 +245,40 @@ scoped explicitly in the query instead: `resolveAmbitoDelegaciones()` returns
 | `lib/api/errors.ts` | `ApiError` with HTTP status; unexpected errors are logged in full and truncated to one line in the response |
 | `lib/api/route-helpers.ts` | `conApi()` wrapper: auth + query parsing + `{ ok: true, ... }` shape |
 | `lib/mcp/tools.ts` | The 27 MCP tools, each a thin wrapper over `lib/api/` |
+| `lib/mcp/auth.ts` | Accepts either an API key or an OAuth access token; OAuth pins the acting user |
+| `lib/oauth/` | OAuth 2.1 authorization server: config, PKCE, DB-backed store, authorize-request validation |
+
+### OAuth for claude.ai connectors
+
+claude.ai custom connectors cannot send a static header, so `/api/mcp` is also
+an OAuth 2.1 authorization server (`scripts/058_mcp_oauth.sql` adds the three
+tables). The payoff is bigger than the web: each admin signs in as themselves,
+so writes are attributed to the real person and `MCM_API_USER_EMAIL` becomes
+unnecessary.
+
+The discovery chain is what makes a connector self-configure: `/api/mcp` answers
+401 with `WWW-Authenticate: ... resource_metadata=...` →
+`/.well-known/oauth-protected-resource` → `/.well-known/oauth-authorization-server`
+→ dynamic registration → consent → token. Those `.well-known` paths are
+**rewrites** in `next.config.mjs`: Next's router ignores dot-prefixed folders,
+so the handlers live under `app/api/well-known/`.
+
+Rules this code keeps, and that a change must not break:
+
+- **PKCE S256 only, no client secrets.** Clients are public apps; PKCE is the
+  only thing binding a code to whoever requested it.
+- **Exact `redirect_uri` match.** On a client/redirect failure the page renders
+  an error instead of redirecting — redirecting to an unvalidated destination is
+  the classic OAuth hole. `lib/oauth/autorizacion.ts` encodes that as
+  fatal-vs-redirigible, and both the page and the POST run the same validator.
+- **Only `gestor_central` may consent** — the MCP server bypasses RLS across all
+  delegations.
+- **Codes are single-use; refresh tokens rotate.** Reuse of either revokes every
+  token for that client+user.
+- **Only SHA-256 of codes/tokens is stored.** The three tables have RLS on with
+  no policies: service role only.
+- With an OAuth token, `actorForzado` pins the user and tool arguments cannot
+  override authorship. With an API key, `usuario_email` still applies.
 
 Conventions worth keeping:
 

--- a/app/api/admin/conexiones-mcp/route.ts
+++ b/app/api/admin/conexiones-mcp/route.ts
@@ -1,0 +1,135 @@
+import { NextResponse } from "next/server"
+import { createAdminClient } from "@/lib/supabase/admin"
+import { requireAdmin } from "@/lib/auth/require-admin"
+
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+
+/**
+ * Conexiones MCP activas: qué aplicaciones han recibido acceso por OAuth, de
+ * quién y desde cuándo.
+ *
+ * Existe para que la promesa de la pantalla de consentimiento —"puedes
+ * retirarle el acceso cuando quieras"— sea verdad sin abrir la base de datos.
+ * Solo para gestores centrales, igual que el resto de `/api/admin`.
+ */
+export async function GET() {
+  try {
+    const { error: authError } = await requireAdmin()
+    if (authError) return authError
+
+    const admin = createAdminClient()
+
+    const { data: tokens, error } = await (admin as any)
+      .from("mcp_oauth_token")
+      .select("client_id, usuario_id, scope, creado_en, ultimo_uso_en, expira_en, tipo")
+      .is("revocado_en", null)
+      .gt("expira_en", new Date().toISOString())
+      .order("creado_en", { ascending: false })
+      .limit(500)
+
+    if (error) {
+      console.error("conexiones MCP: error listando tokens:", error)
+      return NextResponse.json({ error: "Ha ocurrido un error. Inténtalo de nuevo." }, { status: 500 })
+    }
+
+    const filas = (tokens ?? []) as any[]
+    if (filas.length === 0) return NextResponse.json({ conexiones: [] })
+
+    const [{ data: clientes }, { data: usuarios }, { data: perfiles }] = await Promise.all([
+      (admin as any)
+        .from("mcp_oauth_cliente")
+        .select("client_id, nombre")
+        .in("client_id", [...new Set(filas.map((f) => f.client_id))]),
+      admin.auth.admin.listUsers({ perPage: 1000 }),
+      (admin as any)
+        .from("perfil")
+        .select("usuario_id, nombre_completo")
+        .in("usuario_id", [...new Set(filas.map((f) => f.usuario_id))]),
+    ])
+
+    const nombreCliente = new Map((clientes ?? []).map((c: any) => [c.client_id, c.nombre]))
+    const emailUsuario = new Map((usuarios?.users ?? []).map((u) => [u.id, u.email ?? null]))
+    const nombreUsuario = new Map(
+      (perfiles ?? []).map((p: any) => [p.usuario_id, p.nombre_completo?.trim() || null]),
+    )
+
+    // Una conexión = una aplicación autorizada por una persona. Se agrupan los
+    // tokens (acceso + refresco, y las renovaciones) para no enseñar una lista
+    // ilegible de secretos rotados.
+    const porConexion = new Map<string, any>()
+    for (const fila of filas) {
+      const clave = `${fila.client_id}::${fila.usuario_id}`
+      const previa = porConexion.get(clave)
+      const usoFila = fila.ultimo_uso_en ?? null
+
+      if (!previa) {
+        porConexion.set(clave, {
+          client_id: fila.client_id,
+          usuario_id: fila.usuario_id,
+          aplicacion: nombreCliente.get(fila.client_id) ?? "Aplicación desconocida",
+          usuario: nombreUsuario.get(fila.usuario_id) ?? emailUsuario.get(fila.usuario_id) ?? fila.usuario_id,
+          scope: fila.scope,
+          conectado_en: fila.creado_en,
+          ultimo_uso_en: usoFila,
+          tokens: 1,
+        })
+        continue
+      }
+
+      previa.tokens += 1
+      if (fila.creado_en < previa.conectado_en) previa.conectado_en = fila.creado_en
+      if (usoFila && (!previa.ultimo_uso_en || usoFila > previa.ultimo_uso_en)) {
+        previa.ultimo_uso_en = usoFila
+      }
+    }
+
+    return NextResponse.json({ conexiones: [...porConexion.values()] })
+  } catch (err) {
+    console.error("conexiones MCP: error inesperado:", err)
+    return NextResponse.json({ error: "Ha ocurrido un error. Inténtalo de nuevo." }, { status: 500 })
+  }
+}
+
+/**
+ * DELETE /api/admin/conexiones-mcp — retira el acceso de una aplicación.
+ *
+ * Revoca de golpe todos los tokens de ese cliente para ese usuario: el
+ * asistente deja de tener acceso en la siguiente llamada, sin esperar a que
+ * caduque nada.
+ */
+export async function DELETE(request: Request) {
+  try {
+    const { error: authError } = await requireAdmin()
+    if (authError) return authError
+
+    const { searchParams } = new URL(request.url)
+    const clientId = searchParams.get("client_id")
+    const usuarioId = searchParams.get("usuario_id")
+
+    if (!clientId || !usuarioId) {
+      return NextResponse.json(
+        { error: "Faltan 'client_id' y 'usuario_id'." },
+        { status: 400 },
+      )
+    }
+
+    const admin = createAdminClient()
+    const { error } = await (admin as any)
+      .from("mcp_oauth_token")
+      .update({ revocado_en: new Date().toISOString() })
+      .eq("client_id", clientId)
+      .eq("usuario_id", usuarioId)
+      .is("revocado_en", null)
+
+    if (error) {
+      console.error("conexiones MCP: error revocando:", error)
+      return NextResponse.json({ error: "Ha ocurrido un error. Inténtalo de nuevo." }, { status: 500 })
+    }
+
+    return NextResponse.json({ ok: true })
+  } catch (err) {
+    console.error("conexiones MCP: error inesperado al revocar:", err)
+    return NextResponse.json({ error: "Ha ocurrido un error. Inténtalo de nuevo." }, { status: 500 })
+  }
+}

--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server"
-import { verifyApiKey } from "@/lib/api/external-auth"
 import { JSONRPC_ERRORES, fallo, type JsonRpcRequest } from "@/lib/mcp/protocol"
+import { autorizarMcp } from "@/lib/mcp/auth"
 import { procesarMensaje, SERVIDOR } from "@/lib/mcp/server"
 
 export const runtime = "nodejs"
@@ -11,13 +11,14 @@ export const dynamic = "force-dynamic"
  *
  *   POST /api/mcp   →  mensajes JSON-RPC del protocolo MCP
  *
- * Autenticación: la misma clave que la API externa, en `Authorization: Bearer`
- * o en `x-api-key`. Una clave de solo lectura puede consultar pero no escribir.
+ * Dos formas de autenticarse (ver `lib/mcp/auth.ts`):
  *
- * Autoría de las escrituras: se puede fijar por conexión con las cabeceras
- * `x-mcm-usuario-email` o `x-mcm-usuario-id`, o por llamada con el argumento
- * `usuario_email` de cada herramienta. Si no llega ninguna, se usa la cuenta
- * configurada en el servidor (`MCM_API_USER_EMAIL` / `MCM_API_USER_ID`).
+ *   - **OAuth**, para el conector de claude.ai: cada persona entra con su
+ *     cuenta de MCM Bank y las escrituras se firman con ella. Cuando falta el
+ *     token se responde 401 con `WWW-Authenticate`, que es la señal con la que
+ *     el cliente descubre el servidor de autorización y arranca el flujo solo.
+ *   - **Clave de API** en `Authorization: Bearer` o `x-api-key`, para Claude
+ *     Code y los scripts.
  *
  * Para conectarlo desde Claude Code:
  *   claude mcp add --transport http mcm-bank https://TU-DOMINIO/api/mcp \
@@ -29,7 +30,7 @@ const CABECERAS_CORS = {
   "Access-Control-Allow-Methods": "POST, GET, DELETE, OPTIONS",
   "Access-Control-Allow-Headers":
     "Content-Type, Authorization, x-api-key, mcp-session-id, mcp-protocol-version, x-mcm-usuario-email, x-mcm-usuario-id",
-  "Access-Control-Expose-Headers": "mcp-session-id, mcp-protocol-version",
+  "Access-Control-Expose-Headers": "mcp-session-id, mcp-protocol-version, WWW-Authenticate",
   "Access-Control-Max-Age": "86400",
 }
 
@@ -38,18 +39,13 @@ export async function OPTIONS() {
 }
 
 export async function POST(request: Request) {
-  const auth = verifyApiKey(request)
-  if (!auth.ok) {
-    return NextResponse.json(
-      fallo(null, JSONRPC_ERRORES.INVALID_REQUEST, auth.error),
-      {
-        status: auth.status,
-        headers: {
-          ...CABECERAS_CORS,
-          ...(auth.status === 401 ? { "WWW-Authenticate": 'Bearer realm="MCM Bank MCP"' } : {}),
-        },
-      },
-    )
+  const autorizacion = await autorizarMcp(request)
+  if (!autorizacion.ok) {
+    const { status, error, cabeceras } = autorizacion.rechazo
+    return NextResponse.json(fallo(null, JSONRPC_ERRORES.INVALID_REQUEST, error), {
+      status,
+      headers: { ...CABECERAS_CORS, ...cabeceras },
+    })
   }
 
   let cuerpo: unknown
@@ -63,13 +59,12 @@ export async function POST(request: Request) {
   }
 
   const url = new URL(request.url)
+  const { scope, actorHint, actorForzado } = autorizacion.auth
   const opciones = {
-    scope: auth.scope,
+    scope,
     baseUrl: `${url.protocol}//${url.host}`,
-    actorHint: {
-      usuario_email: request.headers.get("x-mcm-usuario-email"),
-      usuario_id: request.headers.get("x-mcm-usuario-id"),
-    },
+    actorHint,
+    actorForzado,
   }
 
   // Los lotes desaparecieron de la especificación en 2025-06-18, pero clientes

--- a/app/api/oauth/autorizar/route.ts
+++ b/app/api/oauth/autorizar/route.ts
@@ -1,0 +1,107 @@
+import { NextResponse } from "next/server"
+import { origenDe } from "@/lib/oauth/config"
+import {
+  urlDeError,
+  urlDeExito,
+  validarAutorizacion,
+  type ParametrosAutorizacion,
+} from "@/lib/oauth/autorizacion"
+import { usuarioActual } from "@/lib/oauth/sesion"
+import { crearCodigo } from "@/lib/oauth/store"
+
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+
+/**
+ * POST /api/oauth/autorizar — resuelve la pantalla de consentimiento.
+ *
+ * Vuelve a validar **todo** desde cero (parámetros, cliente, dirección de
+ * retorno, sesión y rol) en vez de fiarse de los campos ocultos del formulario:
+ * un formulario es solo una sugerencia del navegador.
+ *
+ * La protección contra peticiones desde otro sitio la da la cookie de sesión de
+ * Supabase, que es `SameSite=Lax` y por tanto no viaja en un POST cross-site.
+ */
+export async function POST(request: Request) {
+  const formulario = await request.formData()
+  const params: ParametrosAutorizacion = {}
+  for (const clave of [
+    "client_id",
+    "redirect_uri",
+    "response_type",
+    "code_challenge",
+    "code_challenge_method",
+    "scope",
+    "state",
+    "resource",
+  ] as const) {
+    const valor = formulario.get(clave)
+    if (typeof valor === "string" && valor) params[clave] = valor
+  }
+
+  const validacion = await validarAutorizacion(params, origenDe(request))
+
+  if (!validacion.ok && validacion.tipo === "fatal") {
+    return NextResponse.json({ ok: false, error: validacion.mensaje }, { status: 400 })
+  }
+  if (!validacion.ok) {
+    return NextResponse.redirect(urlDeError(validacion), 303)
+  }
+
+  const usuario = await usuarioActual()
+  if (!usuario) {
+    return NextResponse.redirect(
+      urlDeError({
+        ok: false,
+        tipo: "redirigible",
+        redirectUri: validacion.redirectUri,
+        error: "access_denied",
+        descripcion: "La sesión de MCM Bank ha caducado. Vuelve a intentarlo.",
+        state: validacion.state,
+      }),
+      303,
+    )
+  }
+
+  if (!usuario.esGestorCentral) {
+    return NextResponse.redirect(
+      urlDeError({
+        ok: false,
+        tipo: "redirigible",
+        redirectUri: validacion.redirectUri,
+        error: "access_denied",
+        descripcion: "Esa cuenta no es de la oficina técnica y no puede autorizar este conector.",
+        state: validacion.state,
+      }),
+      303,
+    )
+  }
+
+  if (formulario.get("decision") !== "aprobar") {
+    return NextResponse.redirect(
+      urlDeError({
+        ok: false,
+        tipo: "redirigible",
+        redirectUri: validacion.redirectUri,
+        error: "access_denied",
+        descripcion: "La conexión se ha cancelado.",
+        state: validacion.state,
+      }),
+      303,
+    )
+  }
+
+  const codigo = await crearCodigo({
+    clientId: validacion.cliente.client_id,
+    usuarioId: usuario.id,
+    redirectUri: validacion.redirectUri,
+    codeChallenge: validacion.codeChallenge,
+    scopes: validacion.scopes,
+    resource: validacion.resource,
+  })
+
+  return NextResponse.redirect(
+    urlDeExito(validacion.redirectUri, codigo, validacion.state),
+    303,
+  )
+}

--- a/app/api/oauth/registro/route.ts
+++ b/app/api/oauth/registro/route.ts
@@ -1,0 +1,79 @@
+import { errorOAuth, redirectUriAceptable, registrarCliente } from "@/lib/oauth/store"
+import {
+  creadoOAuth,
+  errorRespuestaOAuth,
+  preflightOAuth,
+  cuerpoOAuth,
+} from "@/lib/oauth/respuestas"
+
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+
+const MAX_REDIRECT_URIS = 10
+
+/**
+ * POST /api/oauth/registro — Registro dinámico de clientes (RFC 7591).
+ *
+ * Claude no sabe nada de MCM Bank hasta que alguien añade el conector: se
+ * registra solo llamando aquí y recibe un `client_id`. El endpoint es abierto
+ * porque así lo exige el flujo, y no es un agujero: **registrarse no da acceso
+ * a nada**. Para obtener un token hace falta que una persona de la oficina
+ * técnica inicie sesión en MCM Bank y apruebe la conexión en pantalla.
+ *
+ * No se emiten secretos de cliente: son aplicaciones públicas, que no pueden
+ * guardarlos. Lo que ata el código a quien lo pidió es PKCE.
+ */
+export async function POST(request: Request) {
+  try {
+    const cuerpo = await cuerpoOAuth(request)
+
+    const redirectUrisBruto = (cuerpo as any).redirect_uris
+    const redirectUris: string[] = Array.isArray(redirectUrisBruto)
+      ? redirectUrisBruto.map(String)
+      : typeof redirectUrisBruto === "string" && redirectUrisBruto
+        ? [redirectUrisBruto]
+        : []
+
+    if (redirectUris.length === 0) {
+      throw errorOAuth("invalid_request", "Falta 'redirect_uris'.")
+    }
+    if (redirectUris.length > MAX_REDIRECT_URIS) {
+      throw errorOAuth(
+        "invalid_request",
+        `Demasiadas 'redirect_uris' (${redirectUris.length}); el máximo son ${MAX_REDIRECT_URIS}.`,
+      )
+    }
+
+    const invalidas = redirectUris.filter((uri) => !redirectUriAceptable(uri))
+    if (invalidas.length > 0) {
+      throw errorOAuth(
+        "invalid_request",
+        `Estas redirect_uris no valen: ${invalidas.join(", ")}. Se admite https, http solo en localhost, o un esquema propio de aplicación.`,
+      )
+    }
+
+    const nombre = String(cuerpo.client_name ?? "").trim() || "Aplicación sin nombre"
+
+    const cliente = await registrarCliente({
+      nombre,
+      redirectUris,
+      metadata: cuerpo,
+    })
+
+    return creadoOAuth({
+      client_id: cliente.client_id,
+      client_id_issued_at: Math.floor(new Date(cliente.creado_en).getTime() / 1000),
+      client_name: cliente.nombre,
+      redirect_uris: cliente.redirect_uris,
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+      token_endpoint_auth_method: "none",
+    })
+  } catch (err) {
+    return errorRespuestaOAuth(err)
+  }
+}
+
+export async function OPTIONS() {
+  return preflightOAuth()
+}

--- a/app/api/oauth/revocar/route.ts
+++ b/app/api/oauth/revocar/route.ts
@@ -1,0 +1,27 @@
+import { revocarToken } from "@/lib/oauth/store"
+import { cuerpoOAuth, errorRespuestaOAuth, okOAuth, preflightOAuth } from "@/lib/oauth/respuestas"
+
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+
+/**
+ * POST /api/oauth/revocar — revocación de tokens (RFC 7009).
+ *
+ * Responde 200 siempre, incluso si el token no existía: el estándar lo exige
+ * así a propósito, para no convertir el endpoint en un oráculo que confirme si
+ * un token es válido.
+ */
+export async function POST(request: Request) {
+  try {
+    const cuerpo = await cuerpoOAuth(request)
+    const token = cuerpo.token?.trim()
+    if (token) await revocarToken(token)
+    return okOAuth({})
+  } catch (err) {
+    return errorRespuestaOAuth(err)
+  }
+}
+
+export async function OPTIONS() {
+  return preflightOAuth()
+}

--- a/app/api/oauth/token/route.ts
+++ b/app/api/oauth/token/route.ts
@@ -1,0 +1,105 @@
+import {
+  canjearCodigo,
+  emitirTokens,
+  errorOAuth,
+  limpiarCaducado,
+  obtenerCliente,
+  refrescarTokens,
+} from "@/lib/oauth/store"
+import { cuerpoOAuth, errorRespuestaOAuth, okOAuth, preflightOAuth } from "@/lib/oauth/respuestas"
+
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+
+/**
+ * POST /api/oauth/token — canje de código y refresco (RFC 6749, OAuth 2.1).
+ *
+ * Dos flujos:
+ *   - `authorization_code`: el código que devolvió la pantalla de
+ *     autorización, con su `code_verifier` de PKCE.
+ *   - `refresh_token`: renovación. El refresco se **rota**: el viejo queda
+ *     revocado, de modo que una copia robada deja de valer en cuanto el
+ *     legítimo renueve.
+ *
+ * Sin autenticación de cliente: son aplicaciones públicas y quien manda es PKCE.
+ */
+export async function POST(request: Request) {
+  try {
+    const cuerpo = await cuerpoOAuth(request)
+    const grantType = cuerpo.grant_type
+    const clientId = cuerpo.client_id?.trim()
+
+    // El tipo de concesión se comprueba antes de tocar la base de datos: si no
+    // lo soportamos, el cliente merece leer 'unsupported_grant_type' y no un
+    // error de infraestructura que no le dice nada.
+    if (grantType !== "authorization_code" && grantType !== "refresh_token") {
+      throw errorOAuth(
+        "unsupported_grant_type",
+        `'${grantType ?? "(vacío)"}' no está soportado. Usa 'authorization_code' o 'refresh_token'.`,
+      )
+    }
+
+    if (!clientId) throw errorOAuth("invalid_client", "Falta 'client_id'.")
+    const cliente = await obtenerCliente(clientId)
+    if (!cliente) {
+      throw errorOAuth(
+        "invalid_client",
+        "Esa aplicación no está registrada. Vuelve a conectar el servidor desde cero.",
+        401,
+      )
+    }
+
+    // Aprovechamos el paso por aquí para tirar lo caducado: sale gratis y
+    // evita depender de un cron para algo que solo es higiene.
+    void limpiarCaducado()
+
+    if (grantType === "authorization_code") {
+      const codigo = cuerpo.code
+      const redirectUri = cuerpo.redirect_uri
+      const codeVerifier = cuerpo.code_verifier
+
+      if (!codigo) throw errorOAuth("invalid_request", "Falta 'code'.")
+      if (!redirectUri) throw errorOAuth("invalid_request", "Falta 'redirect_uri'.")
+      if (!codeVerifier) throw errorOAuth("invalid_request", "Falta 'code_verifier' (PKCE es obligatorio).")
+
+      const canjeado = await canjearCodigo({ codigo, clientId, redirectUri, codeVerifier })
+      const tokens = await emitirTokens({
+        clientId: canjeado.clientId,
+        usuarioId: canjeado.usuarioId,
+        scope: canjeado.scopes,
+        resource: canjeado.resource,
+      })
+
+      return okOAuth({
+        access_token: tokens.accessToken,
+        token_type: "Bearer",
+        expires_in: tokens.expiresIn,
+        refresh_token: tokens.refreshToken,
+        scope: tokens.scope,
+      })
+    }
+
+    const refreshToken = cuerpo.refresh_token
+    if (!refreshToken) throw errorOAuth("invalid_request", "Falta 'refresh_token'.")
+
+    const tokens = await refrescarTokens({
+      refreshToken,
+      clientId,
+      scopePedido: cuerpo.scope ?? null,
+    })
+
+    return okOAuth({
+      access_token: tokens.accessToken,
+      token_type: "Bearer",
+      expires_in: tokens.expiresIn,
+      refresh_token: tokens.refreshToken,
+      scope: tokens.scope,
+    })
+  } catch (err) {
+    return errorRespuestaOAuth(err)
+  }
+}
+
+export async function OPTIONS() {
+  return preflightOAuth()
+}

--- a/app/api/well-known/oauth-authorization-server/route.ts
+++ b/app/api/well-known/oauth-authorization-server/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from "next/server"
+import { RUTAS, SCOPES_SOPORTADOS, origenDe } from "@/lib/oauth/config"
+
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+
+/**
+ * Metadatos del servidor de autorización (RFC 8414).
+ *
+ * Se sirve en `/.well-known/oauth-authorization-server` mediante un rewrite
+ * (ver `next.config.mjs`): el enrutador de Next ignora las carpetas que empiezan
+ * por punto, así que la ruta real vive bajo `/api/well-known/`.
+ *
+ * Es lo primero que pide un cliente MCP —Claude incluido— al añadir el
+ * conector: de aquí saca a dónde mandar al usuario a autorizar y dónde canjear
+ * el código por un token. Público y sin secretos.
+ */
+export async function GET(request: Request) {
+  const origen = origenDe(request)
+
+  return NextResponse.json(
+    {
+      issuer: origen,
+      authorization_endpoint: `${origen}${RUTAS.autorizar}`,
+      token_endpoint: `${origen}${RUTAS.token}`,
+      registration_endpoint: `${origen}${RUTAS.registro}`,
+      revocation_endpoint: `${origen}${RUTAS.revocar}`,
+
+      scopes_supported: [...SCOPES_SOPORTADOS],
+      response_types_supported: ["code"],
+      response_modes_supported: ["query"],
+      grant_types_supported: ["authorization_code", "refresh_token"],
+
+      // OAuth 2.1: PKCE obligatorio y solo S256. No hay secreto de cliente
+      // porque los clientes son aplicaciones públicas (no pueden guardarlo).
+      code_challenge_methods_supported: ["S256"],
+      token_endpoint_auth_methods_supported: ["none"],
+      revocation_endpoint_auth_methods_supported: ["none"],
+
+      service_documentation: `${origen}/docs/api`,
+      ui_locales_supported: ["es"],
+    },
+    {
+      headers: {
+        "Cache-Control": "public, max-age=300",
+        "Access-Control-Allow-Origin": "*",
+      },
+    },
+  )
+}
+
+export async function OPTIONS() {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type, mcp-protocol-version",
+    },
+  })
+}

--- a/app/api/well-known/oauth-protected-resource/route.ts
+++ b/app/api/well-known/oauth-protected-resource/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server"
+import { RUTAS, SCOPES_SOPORTADOS, origenDe, urlRecurso } from "@/lib/oauth/config"
+
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+
+/**
+ * Metadatos del recurso protegido (RFC 9728).
+ *
+ * Cuando el servidor MCP responde `401`, su cabecera `WWW-Authenticate` apunta
+ * aquí. El cliente lee este documento para saber **qué servidor de
+ * autorización** le da tokens válidos para este recurso, y solo entonces
+ * arranca el baile de OAuth.
+ *
+ * Se sirve por rewrite en `/.well-known/oauth-protected-resource`, con y sin el
+ * sufijo de la ruta del MCP (algunos clientes piden
+ * `/.well-known/oauth-protected-resource/api/mcp`).
+ */
+export async function GET(request: Request) {
+  const origen = origenDe(request)
+
+  return NextResponse.json(
+    {
+      resource: urlRecurso(origen),
+      authorization_servers: [origen],
+      scopes_supported: [...SCOPES_SOPORTADOS],
+      bearer_methods_supported: ["header"],
+      resource_name: "MCM Bank",
+      resource_documentation: `${origen}/docs/api`,
+      authorization_server_metadata: `${origen}${RUTAS.metadatosServidor}`,
+    },
+    {
+      headers: {
+        "Cache-Control": "public, max-age=300",
+        "Access-Control-Allow-Origin": "*",
+      },
+    },
+  )
+}
+
+export async function OPTIONS() {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type, mcp-protocol-version",
+    },
+  })
+}

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -7,15 +7,21 @@ import { Skeleton } from "@/components/ui/skeleton"
 
 export const dynamic = "force-dynamic"
 
-export default async function LoginPage() {
+export default async function LoginPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ next?: string }>
+}) {
   const supabase = createClient()
   const {
     data: { session },
   } = await supabase.auth.getSession()
 
-  // If user is logged in, redirect to home page
+  // Si ya hay sesión, se va directo al destino. `next` solo admite rutas
+  // internas: con una URL absoluta esto sería un redirector abierto.
   if (session) {
-    redirect("/")
+    const { next } = await searchParams
+    redirect(next && next.startsWith("/") && !next.startsWith("//") ? next : "/")
   }
 
   return (

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -26,7 +26,11 @@ export async function GET(request: Request) {
 
 ## Autenticación
 
-Todas las peticiones requieren una clave de API en una cabecera:
+El servidor MCP admite **OAuth 2.1** (registro dinámico de clientes + PKCE): es lo que
+usan los conectores de claude.ai, y no necesita ninguna clave. El descubrimiento
+empieza en \`${origin}/.well-known/oauth-protected-resource\`.
+
+Para la API REST (y para el MCP desde Claude Code) se usa una clave en una cabecera:
 
 - \`Authorization: Bearer <clave>\`  — o bien
 - \`x-api-key: <clave>\`
@@ -46,6 +50,9 @@ Hay dos niveles: \`MCM_API_KEY\` da lectura y escritura; \`MCM_API_KEY_READONLY\
 claude mcp add --transport http mcm-bank ${origin}/api/mcp \\
   --header "Authorization: Bearer TU_CLAVE"
 \`\`\`
+
+Desde claude.ai basta con añadir \`${origin}/api/mcp\` como conector personalizado:
+el servidor responde 401 con \`WWW-Authenticate\` y el cliente arranca el flujo de OAuth solo.
 
 Herramientas disponibles: buscar_movimientos, obtener_movimiento,
 actualizar_movimiento, resumen_economico, listar_delegaciones, listar_cuentas,

--- a/app/oauth/autorizar/page.tsx
+++ b/app/oauth/autorizar/page.tsx
@@ -1,0 +1,178 @@
+import { redirect } from "next/navigation"
+import { headers } from "next/headers"
+import { AlertTriangle, KeyRound, Lock, PencilLine, Search, ShieldCheck } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { validarAutorizacion, urlDeError, type ParametrosAutorizacion } from "@/lib/oauth/autorizacion"
+import { SCOPES, RUTAS } from "@/lib/oauth/config"
+import { usuarioActual } from "@/lib/oauth/sesion"
+
+export const dynamic = "force-dynamic"
+
+/**
+ * Pantalla de consentimiento de OAuth.
+ *
+ * Es el único punto del flujo donde interviene una persona, y de él depende
+ * todo lo demás: aquí se comprueba que quien autoriza tiene sesión en MCM Bank
+ * y es de la oficina técnica. El formulario no decide nada por sí mismo — el
+ * POST vuelve a validarlo todo — así que da igual lo que alguien manipule en el
+ * HTML.
+ */
+
+const DESCRIPCION_SCOPES: Record<string, { titulo: string; detalle: string; icono: typeof Search }> = {
+  [SCOPES.LEER]: {
+    titulo: "Consultar",
+    detalle:
+      "Movimientos, facturas, cuentas, avisos y resúmenes económicos de todas las delegaciones.",
+    icono: Search,
+  },
+  [SCOPES.ESCRIBIR]: {
+    titulo: "Modificar",
+    detalle:
+      "Categorizar movimientos, subir y conciliar facturas, y dejar notas y tareas a las delegaciones.",
+    icono: PencilLine,
+  },
+}
+
+function origenActual(cabeceras: Headers): string {
+  const host = cabeceras.get("x-forwarded-host") ?? cabeceras.get("host") ?? ""
+  const protocolo = cabeceras.get("x-forwarded-proto") ?? "https"
+  return `${protocolo}://${host}`
+}
+
+function Aviso({ titulo, children }: { titulo: string; children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-muted/20 px-4 py-12">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <div className="mb-2 flex h-11 w-11 items-center justify-center rounded-full bg-amber-100 dark:bg-amber-950/50">
+            <AlertTriangle className="h-5 w-5 text-amber-600 dark:text-amber-400" />
+          </div>
+          <CardTitle>{titulo}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4 text-sm text-muted-foreground">{children}</CardContent>
+      </Card>
+    </div>
+  )
+}
+
+export default async function AutorizarPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>
+}) {
+  const sp = await searchParams
+  const params: ParametrosAutorizacion = Object.fromEntries(
+    Object.entries(sp).map(([clave, valor]) => [clave, Array.isArray(valor) ? valor[0] : valor]),
+  )
+
+  const cabeceras = await headers()
+  const origen = origenActual(cabeceras)
+  const validacion = await validarAutorizacion(params, origen)
+
+  // Falla el cliente o la dirección de retorno: no hay a dónde redirigir con
+  // seguridad, así que se cuenta en pantalla.
+  if (!validacion.ok && validacion.tipo === "fatal") {
+    return (
+      <Aviso titulo="No se puede continuar">
+        <p>{validacion.mensaje}</p>
+      </Aviso>
+    )
+  }
+
+  // La dirección de retorno ya está verificada: el error se devuelve por ella.
+  if (!validacion.ok) {
+    redirect(urlDeError(validacion))
+  }
+
+  const usuario = await usuarioActual()
+
+  if (!usuario) {
+    const query = new URLSearchParams()
+    for (const [clave, valor] of Object.entries(params)) {
+      if (valor) query.set(clave, valor)
+    }
+    redirect(`/auth/login?next=${encodeURIComponent(`${RUTAS.autorizar}?${query.toString()}`)}`)
+  }
+
+  if (!usuario.esGestorCentral) {
+    return (
+      <Aviso titulo="Tu cuenta no puede autorizar esto">
+        <p>
+          Has entrado como <strong>{usuario.email}</strong>, que no es una cuenta de la oficina
+          técnica.
+        </p>
+        <p>
+          Este conector da acceso a las cuentas de <strong>todas</strong> las delegaciones, así que
+          solo lo pueden autorizar los gestores centrales. Si crees que debería ser tu caso, pídelo
+          al equipo técnico.
+        </p>
+      </Aviso>
+    )
+  }
+
+  const quienAutoriza = usuario.nombre || usuario.email
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-muted/20 px-4 py-12">
+      <Card className="w-full max-w-lg">
+        <CardHeader>
+          <div className="mb-2 flex h-11 w-11 items-center justify-center rounded-full bg-primary/10">
+            <KeyRound className="h-5 w-5 text-primary" />
+          </div>
+          <CardTitle className="text-xl">
+            Conectar <span className="text-primary">{validacion.cliente.nombre}</span> con MCM Bank
+          </CardTitle>
+          <CardDescription>
+            Vas a darle acceso a la tesorería de todas las delegaciones. Firmará con tu cuenta:{" "}
+            <strong className="text-foreground">{quienAutoriza}</strong>.
+          </CardDescription>
+        </CardHeader>
+
+        <CardContent className="space-y-6">
+          <ul className="space-y-3">
+            {validacion.scopes.map((scope) => {
+              const info = DESCRIPCION_SCOPES[scope]
+              if (!info) return null
+              const Icono = info.icono
+              return (
+                <li key={scope} className="flex gap-3 rounded-lg border bg-card p-3">
+                  <Icono className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+                  <div className="space-y-0.5">
+                    <p className="text-sm font-medium">{info.titulo}</p>
+                    <p className="text-sm text-muted-foreground">{info.detalle}</p>
+                  </div>
+                </li>
+              )
+            })}
+          </ul>
+
+          <div className="flex gap-2 rounded-lg bg-muted/50 p-3 text-xs text-muted-foreground">
+            <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0" />
+            <p>
+              Todo lo que haga quedará registrado a tu nombre. No podrá cambiar el importe, la fecha
+              ni la cuenta de ningún movimiento: eso viene del banco. Puedes retirarle el acceso
+              cuando quieras desde la configuración de MCM Bank.
+            </p>
+          </div>
+
+          <form action="/api/oauth/autorizar" method="post" className="space-y-3">
+            {Object.entries(params).map(([clave, valor]) =>
+              valor ? <input key={clave} type="hidden" name={clave} value={valor} /> : null,
+            )}
+
+            <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+              <Button type="submit" name="decision" value="denegar" variant="outline" className="sm:w-auto">
+                Cancelar
+              </Button>
+              <Button type="submit" name="decision" value="aprobar" className="sm:w-auto">
+                <Lock className="mr-2 h-4 w-4" />
+                Autorizar conexión
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/components/auth/login-form.tsx
+++ b/components/auth/login-form.tsx
@@ -54,11 +54,19 @@ export default function LoginForm() {
   }
 
   // Handle successful login by redirecting
+  // `next` permite volver a donde se venía (p. ej. la pantalla de
+  // autorización de un conector MCP). Solo se aceptan rutas internas: un
+  // destino absoluto convertiría el login en un redirector abierto.
+  const destino = (() => {
+    const pedido = searchParams.get("next")
+    return pedido && pedido.startsWith("/") && !pedido.startsWith("//") ? pedido : "/"
+  })()
+
   useEffect(() => {
     if (state?.success) {
-      router.push("/")
+      router.push(destino)
     }
-  }, [state, router])
+  }, [state, router, destino])
 
   return (
     <div className="relative z-10 w-full max-w-md">

--- a/components/configuracion/conexiones-mcp-section.tsx
+++ b/components/configuracion/conexiones-mcp-section.tsx
@@ -1,0 +1,147 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import { Plug, RefreshCw, Trash2 } from "lucide-react"
+import { toast } from "sonner"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { EmptyState } from "@/components/ui/empty-state"
+import { LoadingSpinner } from "@/components/ui/loading-spinner"
+
+interface ConexionMcp {
+  client_id: string
+  usuario_id: string
+  aplicacion: string
+  usuario: string
+  scope: string
+  conectado_en: string
+  ultimo_uso_en: string | null
+}
+
+/**
+ * Aplicaciones conectadas al servidor MCP por OAuth (el conector de claude.ai,
+ * normalmente), con la opción de retirarles el acceso.
+ *
+ * La pantalla de consentimiento promete que se puede revocar cuando se quiera;
+ * esta sección es donde se cumple.
+ */
+export function ConexionesMcpSection() {
+  const [conexiones, setConexiones] = useState<ConexionMcp[]>([])
+  const [cargando, setCargando] = useState(true)
+  const [revocando, setRevocando] = useState<string | null>(null)
+
+  const cargar = useCallback(async () => {
+    setCargando(true)
+    try {
+      const res = await fetch("/api/admin/conexiones-mcp")
+      const datos = await res.json()
+      if (!res.ok) throw new Error(datos?.error || "No se pudieron cargar las conexiones")
+      setConexiones(datos.conexiones ?? [])
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "No se pudieron cargar las conexiones")
+    } finally {
+      setCargando(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    cargar()
+  }, [cargar])
+
+  const revocar = async (conexion: ConexionMcp) => {
+    const clave = `${conexion.client_id}::${conexion.usuario_id}`
+    setRevocando(clave)
+    try {
+      const res = await fetch(
+        `/api/admin/conexiones-mcp?client_id=${encodeURIComponent(conexion.client_id)}&usuario_id=${encodeURIComponent(conexion.usuario_id)}`,
+        { method: "DELETE" },
+      )
+      const datos = await res.json()
+      if (!res.ok) throw new Error(datos?.error || "No se pudo retirar el acceso")
+      toast.success(`${conexion.aplicacion} ya no tiene acceso`)
+      await cargar()
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "No se pudo retirar el acceso")
+    } finally {
+      setRevocando(null)
+    }
+  }
+
+  const formatear = (fecha: string | null) =>
+    fecha
+      ? new Date(fecha).toLocaleString("es-ES", {
+          day: "numeric",
+          month: "short",
+          year: "numeric",
+          hour: "2-digit",
+          minute: "2-digit",
+        })
+      : "—"
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <CardTitle className="flex items-center gap-2 text-base">
+              <Plug className="h-4 w-4" />
+              Conexiones con asistentes (MCP)
+            </CardTitle>
+            <CardDescription>
+              Aplicaciones que pueden consultar y modificar la tesorería en nombre de una persona de
+              la oficina técnica.
+            </CardDescription>
+          </div>
+          <Button variant="outline" size="sm" onClick={cargar} disabled={cargando}>
+            <RefreshCw className={`h-4 w-4 ${cargando ? "animate-spin" : ""}`} />
+            <span className="sr-only">Actualizar</span>
+          </Button>
+        </div>
+      </CardHeader>
+
+      <CardContent>
+        {cargando ? (
+          <div className="flex justify-center py-6">
+            <LoadingSpinner />
+          </div>
+        ) : conexiones.length === 0 ? (
+          <EmptyState
+            icon={<Plug className="h-5 w-5" />}
+            title="Ninguna aplicación conectada"
+            description="Cuando alguien añada MCM Bank como conector en Claude, aparecerá aquí."
+          />
+        ) : (
+          <ul className="divide-y">
+            {conexiones.map((conexion) => {
+              const clave = `${conexion.client_id}::${conexion.usuario_id}`
+              return (
+                <li key={clave} className="flex flex-wrap items-center gap-3 py-3">
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium">{conexion.aplicacion}</p>
+                    <p className="truncate text-sm text-muted-foreground">
+                      Autorizada por {conexion.usuario}
+                    </p>
+                    <p className="mt-0.5 text-xs text-muted-foreground">
+                      Conectada el {formatear(conexion.conectado_en)} · Último uso:{" "}
+                      {formatear(conexion.ultimo_uso_en)}
+                      {conexion.scope.includes("mcm:write") ? " · puede modificar" : " · solo lectura"}
+                    </p>
+                  </div>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => revocar(conexion)}
+                    disabled={revocando === clave}
+                  >
+                    <Trash2 className="mr-2 h-4 w-4" />
+                    {revocando === clave ? "Retirando…" : "Retirar acceso"}
+                  </Button>
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/configuracion/config-page.tsx
+++ b/components/configuracion/config-page.tsx
@@ -11,6 +11,7 @@ import type { Delegacion } from "@/lib/types/database"
 import { useIsAdmin } from "@/hooks/use-is-admin"
 import { PlantillaMemoriaSection } from "@/components/configuracion/plantilla-memoria-section"
 import { EnableBankingHealthSection } from "@/components/configuracion/enable-banking-health-section"
+import { ConexionesMcpSection } from "@/components/configuracion/conexiones-mcp-section"
 
 interface DelegacionWithCount extends Delegacion {
   movimientos?: number
@@ -124,6 +125,7 @@ export function ConfigPage() {
     <div className="space-y-10">
       <PlantillaMemoriaSection />
       <EnableBankingHealthSection />
+      <ConexionesMcpSection />
 
       {/* Delegaciones Section */}
       <section>

--- a/docs/manual/22.-servidor-mcp.md
+++ b/docs/manual/22.-servidor-mcp.md
@@ -17,7 +17,7 @@ Cosas que puedes pedirle tal cual:
 {% endhint %}
 
 {% hint style="warning" %}
-Es una herramienta de **oficina técnica**: ve y modifica **todas** las delegaciones. La clave que se use aquí da acceso completo, así que no se comparte con las delegaciones.
+Es una herramienta de **oficina técnica**: ve y modifica **todas** las delegaciones. Por eso solo pueden autorizarla los gestores centrales.
 {% endhint %}
 
 ## Qué es MCP, en dos líneas
@@ -26,50 +26,60 @@ MCP (*Model Context Protocol*) es un estándar para que un asistente de IA pueda
 
 ## Conectarlo
 
-La dirección del servidor es:
+La dirección del servidor, para todos los casos, es:
 
 ```
 https://TU-DOMINIO/api/mcp
 ```
 
-Y se autentica con la misma clave que la API externa (ver **[21. API externa](21.-api-externa-solo-pros.md)**).
-
 {% tabs %}
+{% tab title="Claude web y escritorio" %}
+Esta es la forma recomendada: **no hay ninguna clave que copiar ni que guardar**.
+
+{% stepper %}
+{% step %}
+### Añade el conector
+
+En Claude, ve a **Configuración → Conectores → Añadir conector personalizado** y pega la dirección:
+
+```
+https://TU-DOMINIO/api/mcp
+```
+{% endstep %}
+
+{% step %}
+### Inicia sesión en MCM Bank
+
+Claude te abrirá MCM Bank en el navegador. Si no tenías sesión, entra como siempre con tu correo y contraseña.
+{% endstep %}
+
+{% step %}
+### Autoriza la conexión
+
+Verás una pantalla que resume qué va a poder hacer y con qué cuenta va a firmar. Pulsa **Autorizar conexión** y volverás a Claude, ya conectado.
+{% endstep %}
+{% endstepper %}
+
+{% hint style="success" %}
+Todo lo que haga el asistente quedará **a tu nombre**: las notas que escriba, las facturas que suba y las conciliaciones que aplique aparecerán firmadas por ti, igual que si las hubieras hecho a mano.
+{% endhint %}
+{% endtab %}
+
 {% tab title="Claude Code" %}
+Desde la terminal, con la clave de API (ver [21. API externa](21.-api-externa-solo-pros.md)):
+
 ```bash
 claude mcp add --transport http mcm-bank https://TU-DOMINIO/api/mcp \
   --header "Authorization: Bearer TU_CLAVE"
 ```
 
-Para que las notas y facturas que cree salgan firmadas con tu cuenta, añade tu correo:
+Para que lo que cree salga firmado con tu cuenta y no con la cuenta técnica del servidor, añade tu correo:
 
 ```bash
 claude mcp add --transport http mcm-bank https://TU-DOMINIO/api/mcp \
   --header "Authorization: Bearer TU_CLAVE" \
   --header "x-mcm-usuario-email: tu.correo@movimientoconsolacion.com"
 ```
-{% endtab %}
-
-{% tab title="Claude Desktop" %}
-En la configuración de MCP servers (`claude_desktop_config.json`):
-
-```json
-{
-  "mcpServers": {
-    "mcm-bank": {
-      "command": "npx",
-      "args": [
-        "-y", "mcp-remote",
-        "https://TU-DOMINIO/api/mcp",
-        "--header", "Authorization: Bearer TU_CLAVE",
-        "--header", "x-mcm-usuario-email: tu.correo@movimientoconsolacion.com"
-      ]
-    }
-  }
-}
-```
-
-`mcp-remote` es un puente que traduce la conexión HTTP a lo que espera la aplicación de escritorio.
 {% endtab %}
 
 {% tab title="Comprobar que responde" %}
@@ -81,12 +91,22 @@ curl -s -X POST https://TU-DOMINIO/api/mcp \
 ```
 
 Si ves una lista de herramientas, está listo. Si ves `401`, la clave no es correcta.
+
+Sin ninguna clave, la respuesta debe ser `401` con una cabecera `WWW-Authenticate`: eso es justo lo que hace que el conector de Claude sepa a dónde mandarte a iniciar sesión.
 {% endtab %}
 {% endtabs %}
 
+### Quién puede autorizar
+
+Solo las cuentas con rol **gestor central**. Si intentas autorizar con una cuenta de tesorería, la pantalla te lo dirá y no continuará: este conector abre las cuentas de las dieciocho delegaciones, no solo las tuyas.
+
+### Retirar el acceso
+
+En **Configuración → Conexiones con asistentes (MCP)** aparece cada aplicación conectada, quién la autorizó, cuándo y cuándo se usó por última vez. El botón **Retirar acceso** la desconecta al instante, sin esperar a que caduque nada.
+
 ### Clave de solo lectura
 
-Si quieres conectarlo para consultar sin riesgo de que modifique nada, usa la clave de `MCM_API_KEY_READONLY`. Las herramientas de escritura seguirán apareciendo, pero al intentar usarlas el asistente recibirá un aviso claro de que su clave no puede escribir — y te lo dirá.
+Si prefieres conectarlo para consultar sin riesgo de que modifique nada, usa la clave de `MCM_API_KEY_READONLY` (solo en Claude Code y escritorio). Las herramientas de escritura seguirán apareciendo, pero al intentar usarlas el asistente recibirá un aviso claro de que su clave no puede escribir — y te lo dirá.
 
 ## Qué sabe hacer
 
@@ -142,12 +162,6 @@ En la conciliación en bloque, pídele primero las propuestas, míralas, y solo 
 {% endstep %}
 
 {% step %}
-### Firma con tu cuenta
-
-Si has configurado tu correo al conectarlo, las notas y facturas que cree aparecerán a tu nombre. Si no, saldrán a nombre de la cuenta técnica configurada en el servidor.
-{% endstep %}
-
-{% step %}
 ### Ojo con los borrados
 
 No hay papelera. Si le pides borrar algo, pregúntate antes si no bastaba con marcarlo como hecho o archivarlo.
@@ -156,19 +170,16 @@ No hay papelera. Si le pides borrar algo, pregúntate antes si no bastaba con ma
 
 ## Configuración en el servidor
 
-Todo esto se configura en las variables de entorno de Vercel:
+**Conectar desde Claude web o escritorio no necesita ninguna variable nueva**: el flujo de autorización usa el mismo login de Supabase que la aplicación.
+
+Las siguientes solo hacen falta para el resto de usos:
 
 | Variable | Para qué |
 | -------- | -------- |
-| `MCM_API_KEY` | La clave con permiso de lectura y escritura. **Obligatoria** para poder modificar nada. |
+| `MCM_API_KEY` | Clave de lectura y escritura, para Claude Code y los scripts. |
 | `MCM_API_KEY_READONLY` | Clave alternativa de solo consulta (opcional). |
-| `MCM_API_USER_EMAIL` | Correo de la cuenta de MCM Bank que firma las escrituras cuando quien llama no indica la suya. |
-| `MCM_API_USER_ID` | Alternativa a la anterior, con el UUID del usuario. |
+| `MCM_API_USER_EMAIL` | Con quién firmar cuando se entra por clave de API y quien llama no indica su correo. Innecesaria si se usa OAuth. |
 | `RESEND_API_KEY` | Necesaria para que `crear_aviso` pueda enviar el correo. |
-
-{% hint style="warning" %}
-Si no defines `MCM_API_USER_EMAIL` ni `MCM_API_USER_ID`, las herramientas de escritura fallarán con un mensaje explicándolo, salvo que quien llama indique `usuario_email` en cada operación. Es a propósito: preferimos no guardar una nota antes que firmarla con la persona equivocada.
-{% endhint %}
 
 ## Detalles técnicos
 
@@ -177,3 +188,25 @@ Si no defines `MCM_API_USER_EMAIL` ni `MCM_API_USER_ID`, las herramientas de esc
 * `GET` sobre `/api/mcp` responde `405`: el servidor no abre canal SSE porque no envía nada por su cuenta.
 * Los errores de una herramienta se devuelven como resultado con `isError`, no como error de protocolo, para que el asistente pueda leerlos y corregirse solo.
 * Por debajo usa exactamente las mismas funciones que la API REST (`lib/api/*`), así que lo que se puede hacer por un lado se puede hacer por el otro.
+
+### El flujo de OAuth, para quien quiera saberlo
+
+MCM Bank hace de servidor de autorización además de servidor de recursos:
+
+| Documento o endpoint | Qué es |
+| -------------------- | ------ |
+| `/.well-known/oauth-protected-resource` | Metadatos del recurso (RFC 9728). A esto apunta la cabecera `WWW-Authenticate` del `401`. |
+| `/.well-known/oauth-authorization-server` | Metadatos del servidor de autorización (RFC 8414). |
+| `POST /api/oauth/registro` | Registro dinámico de clientes (RFC 7591): Claude se da de alta solo. |
+| `GET /oauth/autorizar` | La pantalla de consentimiento. Exige sesión y rol de gestor central. |
+| `POST /api/oauth/token` | Canje del código y renovación. |
+| `POST /api/oauth/revocar` | Revocación (RFC 7009). |
+
+Decisiones que conviene conocer:
+
+* **PKCE obligatorio, solo `S256`.** No hay secretos de cliente (son aplicaciones públicas), así que lo único que ata el código a quien lo pidió es PKCE. El método `plain` se rechaza.
+* **`redirect_uri` con coincidencia exacta.** No basta con el mismo dominio. Si falla, no se redirige a ningún sitio: el error se enseña en pantalla, porque redirigir sin haber validado el destino es el agujero clásico de OAuth.
+* **Códigos de un solo uso y cinco minutos.** Reutilizar uno revoca todas las sesiones de esa aplicación: solo pasa si el código se ha filtrado.
+* **El token de refresco rota.** El anterior queda revocado en cuanto se usa, de modo que una copia robada deja de valer en la primera renovación del legítimo.
+* **De códigos y tokens se guarda solo el SHA-256**, nunca el valor. Quien lea la base de datos no puede suplantar a nadie.
+* **El registro de clientes está abierto**, como exige el flujo. No es un agujero: registrarse no da acceso a nada; hace falta que una persona de la oficina técnica entre y apruebe.

--- a/lib/mcp/auth.ts
+++ b/lib/mcp/auth.ts
@@ -1,0 +1,144 @@
+import type { ActorHint } from "@/lib/api/actor"
+import { verifyApiKey, type ApiScope } from "@/lib/api/external-auth"
+import { RUTAS, SCOPES, origenDe } from "@/lib/oauth/config"
+import { validarAccessToken } from "@/lib/oauth/store"
+
+/**
+ * Autenticación del servidor MCP. Dos caminos, misma puerta:
+ *
+ *   1. **Clave de API** (`MCM_API_KEY`): lo que usan Claude Code y los scripts.
+ *      Sencillo, pero la clave no es una persona, así que la autoría de las
+ *      escrituras hay que decirla aparte.
+ *
+ *   2. **Token OAuth**: lo que usa el conector de claude.ai. Cada persona entra
+ *      con su cuenta, y el token *es* su identidad: las escrituras se firman
+ *      solas con ella y no hay forma de suplantar a nadie desde la conversación.
+ *
+ * Se prueba primero la clave (no toca la base de datos) y luego el token.
+ */
+
+export type ViaAutenticacion = "clave" | "oauth"
+
+export interface AutorizacionMcp {
+  scope: ApiScope
+  actorHint: ActorHint
+  /**
+   * Con OAuth, el usuario del token manda y no se admiten pistas de autoría:
+   * si el modelo pudiera indicar otro correo, firmaría en nombre de terceros.
+   */
+  actorForzado: string | null
+  via: ViaAutenticacion
+}
+
+export interface RechazoMcp {
+  status: number
+  error: string
+  cabeceras: Record<string, string>
+}
+
+export type ResultadoAutorizacion =
+  | { ok: true; auth: AutorizacionMcp }
+  | { ok: false; rechazo: RechazoMcp }
+
+function tokenDe(request: Request): string | null {
+  const authHeader = request.headers.get("authorization") || ""
+  if (authHeader.toLowerCase().startsWith("bearer ")) {
+    return authHeader.slice(7).trim() || null
+  }
+  return request.headers.get("x-api-key")?.trim() || null
+}
+
+/**
+ * Cabecera que le dice al cliente dónde están los metadatos del recurso, para
+ * que sepa contra qué servidor de autorización pedir un token (RFC 9728 §5.1).
+ * Es lo que hace que un conector de claude.ai arranque el flujo de OAuth solo.
+ */
+function desafio(request: Request, descripcion?: string): Record<string, string> {
+  const origen = origenDe(request)
+  const partes = [
+    `Bearer realm="MCM Bank"`,
+    `resource_metadata="${origen}${RUTAS.metadatosRecurso}"`,
+  ]
+  if (descripcion) partes.push(`error="invalid_token"`, `error_description="${descripcion}"`)
+  return { "WWW-Authenticate": partes.join(", ") }
+}
+
+export async function autorizarMcp(request: Request): Promise<ResultadoAutorizacion> {
+  const token = tokenDe(request)
+
+  if (!token) {
+    return {
+      ok: false,
+      rechazo: {
+        status: 401,
+        error:
+          "Hace falta autenticarse. Conecta el servidor desde claude.ai (te llevará a iniciar sesión) o envía la clave de API en 'Authorization: Bearer <clave>'.",
+        cabeceras: desafio(request),
+      },
+    }
+  }
+
+  // 1) ¿Es una clave de API configurada?
+  const porClave = verifyApiKey(request)
+  if (porClave.ok) {
+    return {
+      ok: true,
+      auth: {
+        scope: porClave.scope,
+        actorHint: {
+          usuario_email: request.headers.get("x-mcm-usuario-email"),
+          usuario_id: request.headers.get("x-mcm-usuario-id"),
+        },
+        actorForzado: null,
+        via: "clave",
+      },
+    }
+  }
+
+  // 2) ¿Es un token OAuth vivo? Si la base de datos no contesta, eso no es
+  // "credencial inválida": decirlo así mandaría al cliente a repetir el login
+  // para nada. Se distingue el fallo de infraestructura del rechazo.
+  let porToken: Awaited<ReturnType<typeof validarAccessToken>>
+  try {
+    porToken = await validarAccessToken(token)
+  } catch (err) {
+    console.error("[mcp] No se pudo validar el token OAuth:", err)
+    return {
+      ok: false,
+      rechazo: {
+        status: 503,
+        error:
+          "No se ha podido comprobar la credencial contra la base de datos. Vuelve a intentarlo en un momento.",
+        cabeceras: {},
+      },
+    }
+  }
+
+  if (porToken) {
+    return {
+      ok: true,
+      auth: {
+        scope: porToken.scopes.includes(SCOPES.ESCRIBIR) ? "write" : "read",
+        actorHint: { usuario_id: porToken.usuarioId },
+        actorForzado: porToken.usuarioId,
+        via: "oauth",
+      },
+    }
+  }
+
+  // Ni una cosa ni la otra. Si el servidor no tiene ninguna clave configurada,
+  // eso es un fallo de despliegue y conviene decirlo tal cual.
+  if (porClave.status === 500) {
+    return { ok: false, rechazo: { status: 500, error: porClave.error, cabeceras: {} } }
+  }
+
+  return {
+    ok: false,
+    rechazo: {
+      status: 401,
+      error:
+        "La credencial no es válida o ha caducado. Si te conectaste desde claude.ai, vuelve a conectar el servidor; si usas una clave de API, revísala.",
+      cabeceras: desafio(request, "token invalido o caducado"),
+    },
+  }
+}

--- a/lib/mcp/server.ts
+++ b/lib/mcp/server.ts
@@ -57,6 +57,12 @@ export interface OpcionesMcp {
   scope: ApiScope
   baseUrl: string
   actorHint: ActorHint
+  /**
+   * Usuario impuesto por la credencial (token OAuth). Cuando viene, las
+   * herramientas no admiten pistas de autoría: si el modelo pudiera indicar
+   * otro correo, firmaría notas en nombre de terceros.
+   */
+  actorForzado?: string | null
 }
 
 /** Procesa un mensaje JSON-RPC. Devuelve `null` si era una notificación. */
@@ -159,6 +165,7 @@ async function ejecutarHerramienta(
       scope: opciones.scope,
       baseUrl: opciones.baseUrl,
       actorHint: opciones.actorHint,
+      actorForzado: opciones.actorForzado ?? null,
     }
 
     const resultado = await herramienta.handler(args, contexto)

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -72,6 +72,11 @@ export interface ContextoMcp {
   baseUrl: string
   /** Autoría por defecto (cabeceras de la petición o variables de entorno). */
   actorHint: ActorHint
+  /**
+   * Usuario impuesto por la credencial (token OAuth): manda sobre cualquier
+   * `usuario_email` que llegue en los argumentos.
+   */
+  actorForzado?: string | null
 }
 
 export interface HerramientaMcp {
@@ -113,6 +118,11 @@ function objetoSchema(propiedades: Record<string, unknown>, obligatorios: string
 }
 
 async function actorDe(args: Args, ctx: ContextoMcp): Promise<Actor> {
+  // Con OAuth la identidad la fija el token: se ignora lo que digan los
+  // argumentos, para que nadie pueda firmar en nombre de otra persona.
+  if (ctx.actorForzado) {
+    return resolveActor(ctx.admin, { usuario_id: ctx.actorForzado })
+  }
   return resolveActor(ctx.admin, {
     usuario_id: texto(args, "usuario_id") ?? ctx.actorHint.usuario_id,
     usuario_email: texto(args, "usuario_email") ?? ctx.actorHint.usuario_email,

--- a/lib/oauth/autorizacion.test.ts
+++ b/lib/oauth/autorizacion.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+// `validarAutorizacion` consulta el cliente registrado en la base de datos. Se
+// sustituye el almacén por uno de mentira para poder probar la validación sin
+// Supabase: lo que se comprueba aquí son las reglas, no el SQL.
+vi.mock("@/lib/oauth/store", async () => {
+  const real = await vi.importActual<typeof import("@/lib/oauth/store")>("@/lib/oauth/store")
+  return {
+    ...real,
+    obtenerCliente: vi.fn(),
+  }
+})
+
+import { validarAutorizacion, urlDeError, urlDeExito } from "@/lib/oauth/autorizacion"
+import { obtenerCliente } from "@/lib/oauth/store"
+import { challengeDe } from "@/lib/oauth/pkce"
+
+const ORIGEN = "https://banco.movimientoconsolacion.com"
+const REDIRECT = "https://claude.ai/api/mcp/auth_callback"
+
+const CLIENTE = {
+  client_id: "mcm-123",
+  nombre: "Claude",
+  redirect_uris: [REDIRECT],
+  creado_en: new Date().toISOString(),
+}
+
+function peticion(extra: Record<string, string | undefined> = {}) {
+  return {
+    client_id: CLIENTE.client_id,
+    redirect_uri: REDIRECT,
+    response_type: "code",
+    code_challenge: challengeDe("mi-verifier"),
+    code_challenge_method: "S256",
+    scope: "mcm:read mcm:write",
+    state: "xyz",
+    ...extra,
+  }
+}
+
+beforeEach(() => {
+  vi.mocked(obtenerCliente).mockResolvedValue(CLIENTE)
+})
+
+describe("validarAutorizacion", () => {
+  it("acepta una petición correcta", async () => {
+    const r = await validarAutorizacion(peticion(), ORIGEN)
+    expect(r.ok).toBe(true)
+    if (r.ok) {
+      expect(r.cliente.client_id).toBe("mcm-123")
+      expect(r.scopes).toEqual(["mcm:read", "mcm:write"])
+      expect(r.state).toBe("xyz")
+    }
+  })
+
+  // Los dos casos "fatales": no se puede redirigir porque no sabemos a dónde
+  // sería seguro. Redirigir aquí es exactamente el agujero clásico de OAuth.
+  it("es fatal si el cliente no existe", async () => {
+    vi.mocked(obtenerCliente).mockResolvedValue(null)
+    const r = await validarAutorizacion(peticion(), ORIGEN)
+    expect(r).toMatchObject({ ok: false, tipo: "fatal" })
+  })
+
+  it("es fatal si la redirect_uri no está registrada", async () => {
+    const r = await validarAutorizacion(
+      peticion({ redirect_uri: "https://sitio-del-atacante.example/robar" }),
+      ORIGEN,
+    )
+    expect(r).toMatchObject({ ok: false, tipo: "fatal" })
+  })
+
+  it("exige coincidencia exacta de redirect_uri (no basta el mismo dominio)", async () => {
+    const r = await validarAutorizacion(
+      peticion({ redirect_uri: `${REDIRECT}/otra-cosa` }),
+      ORIGEN,
+    )
+    expect(r).toMatchObject({ ok: false, tipo: "fatal" })
+  })
+
+  // El resto son errores que sí se devuelven por la redirección, ya validada.
+  it("rechaza response_type distinto de code", async () => {
+    const r = await validarAutorizacion(peticion({ response_type: "token" }), ORIGEN)
+    expect(r).toMatchObject({ ok: false, tipo: "redirigible", error: "invalid_request" })
+  })
+
+  it("exige PKCE", async () => {
+    const r = await validarAutorizacion(peticion({ code_challenge: undefined }), ORIGEN)
+    expect(r).toMatchObject({ ok: false, tipo: "redirigible" })
+    if (!r.ok && r.tipo === "redirigible") expect(r.descripcion).toMatch(/PKCE/)
+  })
+
+  it("rechaza el método plain de PKCE", async () => {
+    const r = await validarAutorizacion(peticion({ code_challenge_method: "plain" }), ORIGEN)
+    expect(r).toMatchObject({ ok: false, tipo: "redirigible" })
+    if (!r.ok && r.tipo === "redirigible") expect(r.descripcion).toMatch(/S256/)
+  })
+
+  it("rechaza un resource que apunta a otro servidor", async () => {
+    const r = await validarAutorizacion(
+      peticion({ resource: "https://otro.example/api/mcp" }),
+      ORIGEN,
+    )
+    expect(r).toMatchObject({ ok: false, tipo: "redirigible" })
+  })
+
+  it("rechaza cuando ningún scope pedido existe", async () => {
+    const r = await validarAutorizacion(peticion({ scope: "borrarlo:todo" }), ORIGEN)
+    expect(r).toMatchObject({ ok: false, tipo: "redirigible", error: "invalid_scope" })
+  })
+})
+
+describe("urls de vuelta", () => {
+  it("el error viaja con su descripción y el state", () => {
+    const url = new URL(
+      urlDeError({
+        ok: false,
+        tipo: "redirigible",
+        redirectUri: REDIRECT,
+        error: "access_denied",
+        descripcion: "La conexión se ha cancelado.",
+        state: "xyz",
+      }),
+    )
+    expect(url.searchParams.get("error")).toBe("access_denied")
+    expect(url.searchParams.get("error_description")).toBe("La conexión se ha cancelado.")
+    expect(url.searchParams.get("state")).toBe("xyz")
+  })
+
+  it("el éxito lleva el código y conserva el state", () => {
+    const url = new URL(urlDeExito(REDIRECT, "el-codigo", "xyz"))
+    expect(url.searchParams.get("code")).toBe("el-codigo")
+    expect(url.searchParams.get("state")).toBe("xyz")
+  })
+
+  it("sin state, no se inventa uno", () => {
+    const url = new URL(urlDeExito(REDIRECT, "el-codigo", null))
+    expect(url.searchParams.has("state")).toBe(false)
+  })
+})

--- a/lib/oauth/autorizacion.ts
+++ b/lib/oauth/autorizacion.ts
@@ -1,0 +1,170 @@
+import {
+  normalizarScopes,
+  resourceValido,
+  type ScopeOAuth,
+} from "@/lib/oauth/config"
+import {
+  obtenerCliente,
+  redirectUriRegistrada,
+  type ClienteOAuth,
+  type CodigoErrorOAuth,
+} from "@/lib/oauth/store"
+
+/**
+ * Validación de una petición de autorización, compartida entre la pantalla de
+ * consentimiento y el POST que la resuelve.
+ *
+ * Está en un solo sitio a propósito: si la pantalla validara una cosa y el POST
+ * otra, bastaría con manipular un campo oculto del formulario para saltarse la
+ * comprobación. El POST vuelve a validar desde cero con esta misma función.
+ *
+ * Hay dos clases de error, y la diferencia importa:
+ *
+ *   - **fatal**: falla el `client_id` o la `redirect_uri`. NO se puede
+ *     redirigir, porque no sabemos a dónde sería seguro hacerlo; se enseña el
+ *     error en pantalla.
+ *   - **redirigible**: la `redirect_uri` ya está verificada y el problema es
+ *     otro (falta PKCE, `response_type` raro…). Entonces sí se devuelve el
+ *     error al cliente por la redirección, como manda OAuth.
+ */
+
+export interface ParametrosAutorizacion {
+  client_id?: string
+  redirect_uri?: string
+  response_type?: string
+  code_challenge?: string
+  code_challenge_method?: string
+  scope?: string
+  state?: string
+  resource?: string
+}
+
+export interface AutorizacionValida {
+  ok: true
+  cliente: ClienteOAuth
+  redirectUri: string
+  codeChallenge: string
+  scopes: ScopeOAuth[]
+  state: string | null
+  resource: string | null
+}
+
+export interface AutorizacionFatal {
+  ok: false
+  tipo: "fatal"
+  mensaje: string
+}
+
+export interface AutorizacionRedirigible {
+  ok: false
+  tipo: "redirigible"
+  redirectUri: string
+  error: CodigoErrorOAuth
+  descripcion: string
+  state: string | null
+}
+
+export type ResultadoValidacion = AutorizacionValida | AutorizacionFatal | AutorizacionRedirigible
+
+export async function validarAutorizacion(
+  params: ParametrosAutorizacion,
+  origen: string,
+): Promise<ResultadoValidacion> {
+  const clientId = params.client_id?.trim()
+  const redirectUri = params.redirect_uri?.trim()
+  const state = params.state?.trim() || null
+
+  if (!clientId) {
+    return { ok: false, tipo: "fatal", mensaje: "La petición no indica qué aplicación pide acceso (falta 'client_id')." }
+  }
+
+  const cliente = await obtenerCliente(clientId)
+  if (!cliente) {
+    return {
+      ok: false,
+      tipo: "fatal",
+      mensaje:
+        "Esa aplicación no está registrada en MCM Bank. Si acabas de añadir el conector, quítalo y vuelve a añadirlo.",
+    }
+  }
+
+  if (!redirectUri) {
+    return { ok: false, tipo: "fatal", mensaje: "La petición no indica a dónde volver (falta 'redirect_uri')." }
+  }
+  if (!redirectUriRegistrada(cliente, redirectUri)) {
+    return {
+      ok: false,
+      tipo: "fatal",
+      mensaje:
+        "La dirección de retorno no coincide con ninguna de las que registró la aplicación. Por seguridad no se continúa.",
+    }
+  }
+
+  // A partir de aquí la redirect_uri es de fiar: los errores se devuelven por ella.
+  const redirigible = (error: CodigoErrorOAuth, descripcion: string): AutorizacionRedirigible => ({
+    ok: false,
+    tipo: "redirigible",
+    redirectUri,
+    error,
+    descripcion,
+    state,
+  })
+
+  if ((params.response_type ?? "").trim() !== "code") {
+    return redirigible("invalid_request", "Solo se admite response_type=code.")
+  }
+
+  const codeChallenge = params.code_challenge?.trim()
+  if (!codeChallenge) {
+    return redirigible("invalid_request", "Falta 'code_challenge': PKCE es obligatorio.")
+  }
+  const metodo = (params.code_challenge_method ?? "").trim()
+  if (metodo !== "S256") {
+    return redirigible(
+      "invalid_request",
+      "Solo se admite code_challenge_method=S256 (el método 'plain' no es seguro).",
+    )
+  }
+
+  if (!resourceValido(params.resource?.trim() || null, origen)) {
+    return redirigible(
+      "invalid_request",
+      "El parámetro 'resource' no apunta al servidor MCP de MCM Bank.",
+    )
+  }
+
+  const scopes = normalizarScopes(params.scope)
+  if (scopes.length === 0) {
+    return redirigible(
+      "invalid_scope",
+      "Ninguno de los permisos pedidos existe. Los válidos son mcm:read y mcm:write.",
+    )
+  }
+
+  return {
+    ok: true,
+    cliente,
+    redirectUri,
+    codeChallenge,
+    scopes,
+    state,
+    resource: params.resource?.trim() || null,
+  }
+}
+
+/** Monta la URL de vuelta al cliente con un error de OAuth. */
+export function urlDeError(datos: AutorizacionRedirigible): string {
+  const url = new URL(datos.redirectUri)
+  url.searchParams.set("error", datos.error)
+  url.searchParams.set("error_description", datos.descripcion)
+  if (datos.state) url.searchParams.set("state", datos.state)
+  return url.toString()
+}
+
+/** Monta la URL de vuelta al cliente con el código concedido. */
+export function urlDeExito(redirectUri: string, codigo: string, state: string | null): string {
+  const url = new URL(redirectUri)
+  url.searchParams.set("code", codigo)
+  if (state) url.searchParams.set("state", state)
+  return url.toString()
+}

--- a/lib/oauth/config.test.ts
+++ b/lib/oauth/config.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest"
+import { SCOPES, normalizarScopes, resourceValido, urlRecurso } from "@/lib/oauth/config"
+
+const ORIGEN = "https://banco.movimientoconsolacion.com"
+
+describe("normalizarScopes", () => {
+  it("sin nada pedido, concede todo lo que hay", () => {
+    expect(normalizarScopes(undefined)).toEqual([SCOPES.LEER, SCOPES.ESCRIBIR])
+    expect(normalizarScopes("  ")).toEqual([SCOPES.LEER, SCOPES.ESCRIBIR])
+  })
+
+  it("respeta lo que se pide", () => {
+    expect(normalizarScopes("mcm:read")).toEqual([SCOPES.LEER])
+  })
+
+  it("descarta los que no existen en vez de aceptarlos", () => {
+    expect(normalizarScopes("mcm:read admin:todo")).toEqual([SCOPES.LEER])
+    expect(normalizarScopes("inventado")).toEqual([])
+  })
+
+  it("no duplica ni cambia el orden aunque se repitan", () => {
+    expect(normalizarScopes("mcm:write mcm:read mcm:write")).toEqual([SCOPES.LEER, SCOPES.ESCRIBIR])
+  })
+})
+
+describe("resourceValido", () => {
+  it("acepta la URL del propio servidor MCP", () => {
+    expect(resourceValido(urlRecurso(ORIGEN), ORIGEN)).toBe(true)
+  })
+
+  it("tolera la barra final y las mayúsculas", () => {
+    expect(resourceValido(`${ORIGEN}/api/mcp/`, ORIGEN)).toBe(true)
+    expect(resourceValido(`${ORIGEN.toUpperCase()}/API/MCP`, ORIGEN)).toBe(true)
+  })
+
+  it("no exige el parámetro si no lo mandan", () => {
+    expect(resourceValido(null, ORIGEN)).toBe(true)
+  })
+
+  it("rechaza un recurso de otro servidor", () => {
+    // Lo que evita que un token emitido aquí valga para otro sitio, y al revés.
+    expect(resourceValido("https://otro-sitio.example/api/mcp", ORIGEN)).toBe(false)
+  })
+})

--- a/lib/oauth/config.ts
+++ b/lib/oauth/config.ts
@@ -1,0 +1,75 @@
+/**
+ * Constantes del servidor de autorización OAuth 2.1 que da acceso al MCP.
+ *
+ * MCM Bank hace aquí de servidor de autorización *y* de servidor de recursos:
+ * es una aplicación interna con su propio login (Supabase Auth), y montar un
+ * proveedor de identidad aparte para cinco personas de la oficina técnica sería
+ * desproporcionado. La pantalla de consentimiento reutiliza la sesión que ya
+ * tiene el navegador.
+ */
+
+/** Permisos que puede pedir un cliente. */
+export const SCOPES = {
+  LEER: "mcm:read",
+  ESCRIBIR: "mcm:write",
+} as const
+
+export const SCOPES_SOPORTADOS = [SCOPES.LEER, SCOPES.ESCRIBIR] as const
+export type ScopeOAuth = (typeof SCOPES_SOPORTADOS)[number]
+
+/** Lo que se concede si el cliente no pide nada en concreto. */
+export const SCOPE_POR_DEFECTO = `${SCOPES.LEER} ${SCOPES.ESCRIBIR}`
+
+/**
+ * Duraciones. El token de acceso es corto porque no hay forma de invalidarlo a
+ * mitad de vida sin consultar la base de datos en cada llamada (que es lo que
+ * hacemos, así que en realidad podría ser más largo; se queda en una hora por
+ * costumbre y porque abarata la limpieza).
+ */
+export const TTL_CODIGO_S = 300 // 5 minutos
+export const TTL_ACCESS_TOKEN_S = 60 * 60 // 1 hora
+export const TTL_REFRESH_TOKEN_S = 30 * 24 * 60 * 60 // 30 días
+
+/** Rutas del servidor de autorización, relativas al origen. */
+export const RUTAS = {
+  autorizar: "/oauth/autorizar",
+  token: "/api/oauth/token",
+  registro: "/api/oauth/registro",
+  revocar: "/api/oauth/revocar",
+  mcp: "/api/mcp",
+  metadatosRecurso: "/.well-known/oauth-protected-resource",
+  metadatosServidor: "/.well-known/oauth-authorization-server",
+} as const
+
+/** Origen público de la petición, respetando el proxy de Vercel. */
+export function origenDe(request: Request): string {
+  const reenviado = request.headers.get("x-forwarded-host")
+  const protocolo = request.headers.get("x-forwarded-proto") ?? "https"
+  if (reenviado) return `${protocolo}://${reenviado}`
+
+  const url = new URL(request.url)
+  return `${url.protocol}//${url.host}`
+}
+
+/** URL absoluta del recurso protegido (el propio servidor MCP). */
+export function urlRecurso(origen: string): string {
+  return `${origen}${RUTAS.mcp}`
+}
+
+/**
+ * Comprueba que el `resource` que pide el cliente (RFC 8707) apunta a este
+ * servidor MCP. Se compara sin barra final ni fragmento, que es lo que varía
+ * entre clientes.
+ */
+export function resourceValido(resource: string | null, origen: string): boolean {
+  if (!resource) return true // opcional: si no lo mandan, no se exige
+  const normalizar = (u: string) => u.replace(/\/+$/, "").split("#")[0].toLowerCase()
+  return normalizar(resource) === normalizar(urlRecurso(origen))
+}
+
+/** Reduce una lista de scopes a los soportados, sin duplicados y en orden. */
+export function normalizarScopes(pedido: string | null | undefined): ScopeOAuth[] {
+  if (!pedido?.trim()) return [...SCOPES_SOPORTADOS]
+  const pedidos = new Set(pedido.split(/[\s+]+/).filter(Boolean))
+  return SCOPES_SOPORTADOS.filter((s) => pedidos.has(s))
+}

--- a/lib/oauth/pkce.test.ts
+++ b/lib/oauth/pkce.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest"
+import { challengeDe, verificarPkce } from "@/lib/oauth/pkce"
+
+describe("verificarPkce", () => {
+  it("acepta el verifier que generó el challenge", () => {
+    const verifier = "un-verifier-larguito-de-los-que-genera-un-cliente-de-verdad"
+    expect(verificarPkce(verifier, challengeDe(verifier))).toBe(true)
+  })
+
+  it("rechaza otro verifier", () => {
+    expect(verificarPkce("otro-cualquiera", challengeDe("el-bueno"))).toBe(false)
+  })
+
+  it("rechaza el vector de ejemplo de la RFC 7636 con el challenge cambiado", () => {
+    // Vector oficial (RFC 7636, apéndice B).
+    const verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+    const challenge = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+    expect(verificarPkce(verifier, challenge)).toBe(true)
+    expect(verificarPkce(verifier, `${challenge.slice(0, -1)}X`)).toBe(false)
+  })
+
+  it("rechaza valores vacíos en vez de dejarlos pasar", () => {
+    expect(verificarPkce("", "algo")).toBe(false)
+    expect(verificarPkce("algo", "")).toBe(false)
+  })
+
+  it("no confunde un challenge de otra longitud con una coincidencia", () => {
+    expect(verificarPkce("hola", "corto")).toBe(false)
+  })
+})

--- a/lib/oauth/pkce.ts
+++ b/lib/oauth/pkce.ts
@@ -1,0 +1,30 @@
+import { createHash, timingSafeEqual } from "node:crypto"
+
+/**
+ * PKCE (RFC 7636), método S256.
+ *
+ * Es la pieza que sostiene todo el flujo: los clientes son aplicaciones
+ * públicas, sin secreto que guardar, así que lo único que demuestra que quien
+ * canjea el código es quien lo pidió es haber elegido antes un `code_verifier`
+ * y haber publicado su hash. Un código robado por el camino no sirve de nada
+ * sin él.
+ */
+
+/** Comprueba que SHA-256(verifier) en base64url coincide con el challenge. */
+export function verificarPkce(verifier: string, challenge: string): boolean {
+  if (!verifier || !challenge) return false
+
+  const calculado = createHash("sha256").update(verifier).digest("base64url")
+  const a = Buffer.from(calculado)
+  const b = Buffer.from(challenge)
+
+  // Longitudes distintas ⇒ no coinciden; `timingSafeEqual` además exige que
+  // sean iguales para poder comparar en tiempo constante.
+  if (a.length !== b.length) return false
+  return timingSafeEqual(a, b)
+}
+
+/** Genera el challenge de un verifier. Solo se usa en pruebas y ejemplos. */
+export function challengeDe(verifier: string): string {
+  return createHash("sha256").update(verifier).digest("base64url")
+}

--- a/lib/oauth/respuestas.ts
+++ b/lib/oauth/respuestas.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from "next/server"
+import { ErrorOAuth } from "@/lib/oauth/store"
+
+/**
+ * Respuestas de los endpoints OAuth.
+ *
+ * OAuth tiene su propio formato de error (`{ error, error_description }`), que
+ * no es el `{ ok: false, error }` del resto de la API: los clientes lo parsean
+ * y actúan según el código, así que aquí manda el estándar.
+ */
+
+export const CORS_OAUTH = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "POST, GET, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization, mcp-protocol-version",
+  "Access-Control-Max-Age": "86400",
+}
+
+/** Los endpoints OAuth no deben cachearse nunca (RFC 6749 §5.1). */
+const SIN_CACHE = { "Cache-Control": "no-store", Pragma: "no-cache" }
+
+export function okOAuth(datos: object): NextResponse {
+  return NextResponse.json(datos, { headers: { ...SIN_CACHE, ...CORS_OAUTH } })
+}
+
+export function creadoOAuth(datos: object): NextResponse {
+  return NextResponse.json(datos, { status: 201, headers: { ...SIN_CACHE, ...CORS_OAUTH } })
+}
+
+export function errorRespuestaOAuth(err: unknown): NextResponse {
+  if (err instanceof ErrorOAuth) {
+    return NextResponse.json(
+      { error: err.codigoOAuth, error_description: err.message },
+      { status: err.status, headers: { ...SIN_CACHE, ...CORS_OAUTH } },
+    )
+  }
+
+  console.error("[oauth] Error no controlado:", err)
+  const bruto = err instanceof Error ? err.message : String(err)
+  return NextResponse.json(
+    { error: "server_error", error_description: bruto.split("\n")[0].slice(0, 300) },
+    { status: 500, headers: { ...SIN_CACHE, ...CORS_OAUTH } },
+  )
+}
+
+export function preflightOAuth(): Response {
+  return new Response(null, { status: 204, headers: CORS_OAUTH })
+}
+
+/**
+ * Lee el cuerpo de una petición OAuth. El estándar manda
+ * `application/x-www-form-urlencoded`, pero varios clientes envían JSON; se
+ * aceptan los dos porque rechazar el segundo solo genera incidencias.
+ */
+export async function cuerpoOAuth(request: Request): Promise<Record<string, string>> {
+  const tipo = request.headers.get("content-type") ?? ""
+
+  if (tipo.includes("application/json")) {
+    const json = await request.json().catch(() => ({}))
+    const salida: Record<string, string> = {}
+    for (const [clave, valor] of Object.entries(json ?? {})) {
+      if (valor != null) salida[clave] = String(valor)
+    }
+    return salida
+  }
+
+  const texto = await request.text()
+  const params = new URLSearchParams(texto)
+  return Object.fromEntries(params.entries())
+}

--- a/lib/oauth/sesion.ts
+++ b/lib/oauth/sesion.ts
@@ -1,0 +1,45 @@
+import { createClient } from "@/lib/supabase/server"
+import { createAdminClient } from "@/lib/supabase/admin"
+
+/**
+ * Quién está autorizando la conexión.
+ *
+ * La pantalla de consentimiento reutiliza la sesión que el navegador ya tiene
+ * de MCM Bank: no hay un segundo login. Solo la **oficina técnica** puede
+ * autorizar, porque el servidor MCP ve todas las delegaciones y bypasea RLS —
+ * dárselo a un tesorero le abriría las cuentas de las otras diecisiete.
+ */
+
+export interface UsuarioAutorizador {
+  id: string
+  email: string | null
+  nombre: string | null
+  esGestorCentral: boolean
+}
+
+export async function usuarioActual(): Promise<UsuarioAutorizador | null> {
+  const supabase = createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) return null
+
+  const admin = createAdminClient()
+  const [{ data: membresias }, { data: perfil }] = await Promise.all([
+    (admin as any)
+      .from("membresia")
+      .select("rol")
+      .eq("usuario_id", user.id)
+      .eq("rol", "gestor_central")
+      .limit(1),
+    (admin as any).from("perfil").select("nombre_completo").eq("usuario_id", user.id).maybeSingle(),
+  ])
+
+  return {
+    id: user.id,
+    email: user.email ?? null,
+    nombre: perfil?.nombre_completo?.trim() || null,
+    esGestorCentral: Array.isArray(membresias) && membresias.length > 0,
+  }
+}

--- a/lib/oauth/store.redirect-uri.test.ts
+++ b/lib/oauth/store.redirect-uri.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest"
+import { redirectUriAceptable } from "@/lib/oauth/store"
+
+/**
+ * El registro de clientes es abierto (lo exige el flujo de MCP), así que la
+ * `redirect_uri` es la única barrera que impide que alguien registre un cliente
+ * cuyo "retorno" sea un servidor suyo en claro.
+ */
+describe("redirectUriAceptable", () => {
+  it("acepta https", () => {
+    expect(redirectUriAceptable("https://claude.ai/api/mcp/auth_callback")).toBe(true)
+  })
+
+  it("acepta http solo en localhost (clientes de escritorio)", () => {
+    expect(redirectUriAceptable("http://localhost:33418/oauth/callback")).toBe(true)
+    expect(redirectUriAceptable("http://127.0.0.1:8080/cb")).toBe(true)
+  })
+
+  it("rechaza http a un dominio externo: el código viajaría en claro", () => {
+    expect(redirectUriAceptable("http://sitio-del-atacante.example/cb")).toBe(false)
+  })
+
+  it("acepta esquemas propios de aplicaciones nativas", () => {
+    expect(redirectUriAceptable("cursor://anysphere.cursor-retrieval/oauth/callback")).toBe(true)
+  })
+
+  it("rechaza javascript: y data:", () => {
+    expect(redirectUriAceptable("javascript:alert(1)")).toBe(false)
+    expect(redirectUriAceptable("data:text/html,<script>alert(1)</script>")).toBe(false)
+  })
+
+  it("rechaza una URI con fragmento", () => {
+    // El fragmento no llega al servidor: si viene, algo se está usando mal.
+    expect(redirectUriAceptable("https://claude.ai/cb#trozo")).toBe(false)
+  })
+
+  it("rechaza lo que ni siquiera es una URL", () => {
+    expect(redirectUriAceptable("no soy una url")).toBe(false)
+    expect(redirectUriAceptable("")).toBe(false)
+  })
+})

--- a/lib/oauth/store.ts
+++ b/lib/oauth/store.ts
@@ -1,0 +1,423 @@
+import { createHash, randomBytes } from "node:crypto"
+import { createAdminClient } from "@/lib/supabase/admin"
+import { ApiError, unwrap, wrapSupabaseError } from "@/lib/api/errors"
+import { verificarPkce } from "@/lib/oauth/pkce"
+import {
+  TTL_ACCESS_TOKEN_S,
+  TTL_CODIGO_S,
+  TTL_REFRESH_TOKEN_S,
+  type ScopeOAuth,
+} from "@/lib/oauth/config"
+
+/**
+ * Almacén de clientes, códigos y tokens OAuth.
+ *
+ * De códigos y tokens solo se guarda su **SHA-256**, igual que se haría con una
+ * contraseña: si alguien se lleva una copia de la base de datos no puede
+ * suplantar a nadie. Un hash sin sal basta aquí porque el secreto son 32 bytes
+ * aleatorios, no algo adivinable por fuerza bruta.
+ *
+ * Las tres tablas tienen RLS activada y ninguna política: solo se llega con la
+ * service role key, desde el servidor.
+ */
+
+type AdminClient = ReturnType<typeof createAdminClient>
+
+function admin(): AdminClient {
+  return createAdminClient()
+}
+
+/** Secreto aleatorio en base64url (32 bytes ≈ 256 bits). */
+function nuevoSecreto(): string {
+  return randomBytes(32).toString("base64url")
+}
+
+function hash(valor: string): string {
+  return createHash("sha256").update(valor).digest("hex")
+}
+
+function enSegundos(segundos: number): string {
+  return new Date(Date.now() + segundos * 1000).toISOString()
+}
+
+// ---------------------------------------------------------------------------
+// Clientes (registro dinámico, RFC 7591)
+// ---------------------------------------------------------------------------
+
+export interface ClienteOAuth {
+  client_id: string
+  nombre: string
+  redirect_uris: string[]
+  creado_en: string
+}
+
+/**
+ * Comprueba que una `redirect_uri` es aceptable antes de registrarla.
+ *
+ * Se permite https en cualquier host y http **solo** en localhost (los clientes
+ * de escritorio abren un servidor local para recibir el código). También se
+ * aceptan esquemas propios tipo `claude://…`, que es como vuelven las apps
+ * nativas. Lo que no se acepta es `http://` a un dominio externo: ahí el código
+ * viajaría en claro.
+ */
+export function redirectUriAceptable(uri: string): boolean {
+  let url: URL
+  try {
+    url = new URL(uri)
+  } catch {
+    return false
+  }
+
+  if (url.hash) return false // el fragmento no se envía al servidor: señal de mal uso
+
+  if (url.protocol === "https:") return true
+  if (url.protocol === "http:") {
+    return url.hostname === "localhost" || url.hostname === "127.0.0.1" || url.hostname === "[::1]"
+  }
+  // Esquema propio de una app nativa (claude://, cursor://…).
+  return /^[a-z][a-z0-9+.-]*:$/.test(url.protocol) && url.protocol !== "javascript:" && url.protocol !== "data:"
+}
+
+export async function registrarCliente(params: {
+  nombre: string
+  redirectUris: string[]
+  metadata?: unknown
+}): Promise<ClienteOAuth> {
+  const clientId = `mcm-${randomBytes(16).toString("hex")}`
+
+  const fila = unwrap(
+    await (admin() as any)
+      .from("mcp_oauth_cliente")
+      .insert({
+        client_id: clientId,
+        nombre: params.nombre.slice(0, 200),
+        redirect_uris: params.redirectUris,
+        metadata: params.metadata ?? null,
+      })
+      .select("client_id, nombre, redirect_uris, creado_en")
+      .single(),
+  ) as ClienteOAuth
+
+  return fila
+}
+
+export async function obtenerCliente(clientId: string): Promise<ClienteOAuth | null> {
+  if (!clientId) return null
+  const fila = unwrap(
+    await (admin() as any)
+      .from("mcp_oauth_cliente")
+      .select("client_id, nombre, redirect_uris, creado_en")
+      .eq("client_id", clientId)
+      .maybeSingle(),
+  )
+  return (fila as ClienteOAuth) ?? null
+}
+
+/** La `redirect_uri` debe coincidir **exactamente** con una registrada. */
+export function redirectUriRegistrada(cliente: ClienteOAuth, redirectUri: string): boolean {
+  return cliente.redirect_uris.includes(redirectUri)
+}
+
+// ---------------------------------------------------------------------------
+// Códigos de autorización
+// ---------------------------------------------------------------------------
+
+export interface DatosCodigo {
+  clientId: string
+  usuarioId: string
+  redirectUri: string
+  codeChallenge: string
+  scopes: ScopeOAuth[]
+  resource: string | null
+}
+
+export async function crearCodigo(datos: DatosCodigo): Promise<string> {
+  const codigo = nuevoSecreto()
+
+  const { error } = await (admin() as any).from("mcp_oauth_codigo").insert({
+    codigo_hash: hash(codigo),
+    client_id: datos.clientId,
+    usuario_id: datos.usuarioId,
+    redirect_uri: datos.redirectUri,
+    code_challenge: datos.codeChallenge,
+    code_challenge_method: "S256",
+    scope: datos.scopes.join(" "),
+    resource: datos.resource,
+    expira_en: enSegundos(TTL_CODIGO_S),
+  })
+  if (error) throw wrapSupabaseError(error)
+
+  return codigo
+}
+
+export interface CodigoCanjeado {
+  clientId: string
+  usuarioId: string
+  scopes: string
+  resource: string | null
+}
+
+/**
+ * Canjea un código por su contenido, de una sola vez.
+ *
+ * Si alguien intenta reutilizar un código ya gastado se revocan **todos** los
+ * tokens de ese cliente y usuario: la reutilización solo ocurre cuando el
+ * código se ha filtrado, y en ese caso más vale obligar a volver a entrar que
+ * dejar viva una sesión que quizá no es de quien creemos (RFC 6819, §5.2.1.1).
+ */
+export async function canjearCodigo(params: {
+  codigo: string
+  clientId: string
+  redirectUri: string
+  codeVerifier: string
+}): Promise<CodigoCanjeado> {
+  const cliente = admin() as any
+  const codigoHash = hash(params.codigo)
+
+  const fila = unwrap(
+    await cliente.from("mcp_oauth_codigo").select("*").eq("codigo_hash", codigoHash).maybeSingle(),
+  ) as any
+
+  if (!fila) throw errorOAuth("invalid_grant", "El código de autorización no existe o ya caducó.")
+
+  if (fila.usado_en) {
+    await revocarTokensDe(fila.client_id, fila.usuario_id)
+    throw errorOAuth(
+      "invalid_grant",
+      "Ese código ya se había usado. Por seguridad se han cerrado las sesiones de esta aplicación: vuelve a conectarla.",
+    )
+  }
+  if (new Date(fila.expira_en).getTime() < Date.now()) {
+    throw errorOAuth("invalid_grant", "El código de autorización ha caducado (duran 5 minutos).")
+  }
+  if (fila.client_id !== params.clientId) {
+    throw errorOAuth("invalid_grant", "El código no pertenece a esta aplicación.")
+  }
+  if (fila.redirect_uri !== params.redirectUri) {
+    throw errorOAuth("invalid_grant", "La redirect_uri no coincide con la que se usó al autorizar.")
+  }
+  if (!params.codeVerifier || !verificarPkce(params.codeVerifier, fila.code_challenge)) {
+    throw errorOAuth("invalid_grant", "El code_verifier no corresponde al code_challenge (PKCE).")
+  }
+
+  // Marcar como usado solo si seguía sin usar: si dos peticiones llegan a la
+  // vez, únicamente una se lleva el código.
+  const { data: marcado, error } = await cliente
+    .from("mcp_oauth_codigo")
+    .update({ usado_en: new Date().toISOString() })
+    .eq("codigo_hash", codigoHash)
+    .is("usado_en", null)
+    .select("codigo_hash")
+  if (error) throw wrapSupabaseError(error)
+  if (!marcado || marcado.length === 0) {
+    throw errorOAuth("invalid_grant", "Ese código ya se había usado.")
+  }
+
+  return {
+    clientId: fila.client_id,
+    usuarioId: fila.usuario_id,
+    scopes: fila.scope,
+    resource: fila.resource ?? null,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tokens
+// ---------------------------------------------------------------------------
+
+export interface TokensEmitidos {
+  accessToken: string
+  refreshToken: string
+  expiresIn: number
+  scope: string
+}
+
+export async function emitirTokens(params: {
+  clientId: string
+  usuarioId: string
+  scope: string
+  resource: string | null
+}): Promise<TokensEmitidos> {
+  const accessToken = nuevoSecreto()
+  const refreshToken = nuevoSecreto()
+
+  const comun = {
+    client_id: params.clientId,
+    usuario_id: params.usuarioId,
+    scope: params.scope,
+    resource: params.resource,
+  }
+
+  const { error } = await (admin() as any).from("mcp_oauth_token").insert([
+    { ...comun, token_hash: hash(accessToken), tipo: "access", expira_en: enSegundos(TTL_ACCESS_TOKEN_S) },
+    { ...comun, token_hash: hash(refreshToken), tipo: "refresh", expira_en: enSegundos(TTL_REFRESH_TOKEN_S) },
+  ])
+  if (error) throw wrapSupabaseError(error)
+
+  return {
+    accessToken,
+    refreshToken,
+    expiresIn: TTL_ACCESS_TOKEN_S,
+    scope: params.scope,
+  }
+}
+
+export interface TokenValido {
+  usuarioId: string
+  clientId: string
+  scopes: string[]
+  resource: string | null
+}
+
+/**
+ * Valida un token de acceso. Devuelve `null` si no vale (no lanza: quien llama
+ * decide si eso es un 401 o simplemente "no era un token OAuth").
+ */
+export async function validarAccessToken(token: string): Promise<TokenValido | null> {
+  if (!token) return null
+
+  const fila = unwrap(
+    await (admin() as any)
+      .from("mcp_oauth_token")
+      .select("client_id, usuario_id, scope, resource, tipo, expira_en, revocado_en")
+      .eq("token_hash", hash(token))
+      .maybeSingle(),
+  ) as any
+
+  if (!fila) return null
+  if (fila.tipo !== "access") return null
+  if (fila.revocado_en) return null
+  if (new Date(fila.expira_en).getTime() < Date.now()) return null
+
+  // Sello de último uso, sin bloquear la respuesta si falla.
+  void (admin() as any)
+    .from("mcp_oauth_token")
+    .update({ ultimo_uso_en: new Date().toISOString() })
+    .eq("token_hash", hash(token))
+    .then(undefined, () => undefined)
+
+  return {
+    usuarioId: fila.usuario_id,
+    clientId: fila.client_id,
+    scopes: String(fila.scope ?? "").split(" ").filter(Boolean),
+    resource: fila.resource ?? null,
+  }
+}
+
+/**
+ * Canjea un token de refresco por uno nuevo. Se rota también el refresco (el
+ * viejo queda revocado): si alguien se lleva una copia, en cuanto el legítimo
+ * lo use el robado deja de valer.
+ */
+export async function refrescarTokens(params: {
+  refreshToken: string
+  clientId: string
+  scopePedido: string | null
+}): Promise<TokensEmitidos> {
+  const cliente = admin() as any
+  const tokenHash = hash(params.refreshToken)
+
+  const fila = unwrap(
+    await cliente.from("mcp_oauth_token").select("*").eq("token_hash", tokenHash).maybeSingle(),
+  ) as any
+
+  if (!fila || fila.tipo !== "refresh") {
+    throw errorOAuth("invalid_grant", "El token de refresco no existe.")
+  }
+  if (fila.revocado_en) {
+    // Refresco ya rotado: huele a copia robada. Se cierra todo.
+    await revocarTokensDe(fila.client_id, fila.usuario_id)
+    throw errorOAuth(
+      "invalid_grant",
+      "Ese token de refresco ya se había usado. Por seguridad se han cerrado las sesiones: vuelve a conectar la aplicación.",
+    )
+  }
+  if (new Date(fila.expira_en).getTime() < Date.now()) {
+    throw errorOAuth("invalid_grant", "El token de refresco ha caducado. Vuelve a conectar la aplicación.")
+  }
+  if (fila.client_id !== params.clientId) {
+    throw errorOAuth("invalid_grant", "El token de refresco no pertenece a esta aplicación.")
+  }
+
+  // El cliente puede pedir menos permisos, nunca más (RFC 6749 §6).
+  const concedidos = String(fila.scope ?? "").split(" ").filter(Boolean)
+  const scope = params.scopePedido
+    ? params.scopePedido
+        .split(/[\s+]+/)
+        .filter((s) => concedidos.includes(s))
+        .join(" ")
+    : fila.scope
+
+  if (!scope) throw errorOAuth("invalid_scope", "Los permisos pedidos no estaban concedidos.")
+
+  await cliente
+    .from("mcp_oauth_token")
+    .update({ revocado_en: new Date().toISOString() })
+    .eq("token_hash", tokenHash)
+
+  return emitirTokens({
+    clientId: fila.client_id,
+    usuarioId: fila.usuario_id,
+    scope,
+    resource: fila.resource ?? null,
+  })
+}
+
+/** Revoca un token concreto (RFC 7009). Idempotente y silencioso. */
+export async function revocarToken(token: string): Promise<void> {
+  await (admin() as any)
+    .from("mcp_oauth_token")
+    .update({ revocado_en: new Date().toISOString() })
+    .eq("token_hash", hash(token))
+    .is("revocado_en", null)
+}
+
+/** Revoca todo lo vivo de un cliente para un usuario. */
+export async function revocarTokensDe(clientId: string, usuarioId: string): Promise<void> {
+  await (admin() as any)
+    .from("mcp_oauth_token")
+    .update({ revocado_en: new Date().toISOString() })
+    .eq("client_id", clientId)
+    .eq("usuario_id", usuarioId)
+    .is("revocado_en", null)
+}
+
+/** Borra códigos y tokens caducados. Barato; se llama al emitir tokens. */
+export async function limpiarCaducado(): Promise<void> {
+  await (admin() as any)
+    .rpc("limpiar_mcp_oauth_caducado")
+    .then(undefined, () => undefined)
+}
+
+// ---------------------------------------------------------------------------
+// Errores en el formato que espera OAuth
+// ---------------------------------------------------------------------------
+
+/** Códigos de error de OAuth 2.1 (RFC 6749 §5.2). */
+export type CodigoErrorOAuth =
+  | "invalid_request"
+  | "invalid_client"
+  | "invalid_grant"
+  | "unauthorized_client"
+  | "unsupported_grant_type"
+  | "invalid_scope"
+  | "access_denied"
+  | "server_error"
+
+export class ErrorOAuth extends ApiError {
+  readonly codigoOAuth: CodigoErrorOAuth
+
+  constructor(codigo: CodigoErrorOAuth, descripcion: string, status = 400) {
+    super(status, descripcion)
+    this.name = "ErrorOAuth"
+    this.codigoOAuth = codigo
+  }
+}
+
+export function errorOAuth(
+  codigo: CodigoErrorOAuth,
+  descripcion: string,
+  status = 400,
+): ErrorOAuth {
+  return new ErrorOAuth(codigo, descripcion, status)
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -15,6 +15,36 @@ const nextConfig = {
     unoptimized: true,
   },
 
+  // El enrutador de Next ignora las carpetas que empiezan por punto, así que
+  // los documentos `.well-known` de OAuth viven bajo /api/well-known y se
+  // exponen desde aquí. Se publican también con el sufijo de la ruta del MCP
+  // porque hay clientes que preguntan por
+  // `/.well-known/oauth-protected-resource/api/mcp` (RFC 9728, §3.1).
+  async rewrites() {
+    return [
+      {
+        source: "/.well-known/oauth-authorization-server",
+        destination: "/api/well-known/oauth-authorization-server",
+      },
+      {
+        source: "/.well-known/oauth-authorization-server/:path*",
+        destination: "/api/well-known/oauth-authorization-server",
+      },
+      {
+        source: "/.well-known/openid-configuration",
+        destination: "/api/well-known/oauth-authorization-server",
+      },
+      {
+        source: "/.well-known/oauth-protected-resource",
+        destination: "/api/well-known/oauth-protected-resource",
+      },
+      {
+        source: "/.well-known/oauth-protected-resource/:path*",
+        destination: "/api/well-known/oauth-protected-resource",
+      },
+    ]
+  },
+
   // Cabeceras de seguridad básicas. No incluimos CSP a propósito: una política
   // estricta podría romper estilos/scripts y requiere un análisis aparte.
   async headers() {

--- a/scripts/058_mcp_oauth.sql
+++ b/scripts/058_mcp_oauth.sql
@@ -1,0 +1,130 @@
+-- =============================================================================
+-- 058: OAuth 2.1 para el servidor MCP (conectores de claude.ai)
+-- =============================================================================
+-- Los conectores personalizados de claude.ai no permiten pegar una cabecera con
+-- una clave de API: negocian el acceso por OAuth. Para que MCM Bank se pueda
+-- añadir desde la web hay que ser, además de servidor MCP, un servidor de
+-- autorización OAuth 2.1 con registro dinámico de clientes (RFC 7591) y PKCE.
+--
+-- El premio va más allá de la web: en vez de una clave compartida por toda la
+-- oficina técnica, cada persona entra con SU cuenta de MCM Bank (el mismo login
+-- de Supabase de siempre). Así las notas y facturas que cree el asistente salen
+-- firmadas por quien está al otro lado, sin depender de MCM_API_USER_EMAIL.
+--
+-- Tres tablas, todas efímeras salvo el registro de clientes:
+--   - mcp_oauth_cliente  : quién puede pedir acceso (lo crea el propio Claude)
+--   - mcp_oauth_codigo   : códigos de autorización, de un solo uso y 5 minutos
+--   - mcp_oauth_token    : tokens de acceso y de refresco vivos
+--
+-- Nunca se guarda un secreto en claro: de códigos y tokens solo se guarda su
+-- SHA-256, igual que se haría con una contraseña. Quien lea la base de datos no
+-- puede suplantar a nadie.
+--
+-- RLS activada y SIN políticas a propósito: estas tablas solo se tocan desde el
+-- servidor con la service role key. Ningún usuario autenticado tiene por qué
+-- leer tokens, ni los suyos.
+
+-- -----------------------------------------------------------------------------
+-- Clientes registrados dinámicamente (RFC 7591)
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.mcp_oauth_cliente (
+    client_id TEXT PRIMARY KEY,
+    nombre TEXT NOT NULL,
+    -- Coincidencia EXACTA obligatoria al autorizar: es lo único que impide que
+    -- un cliente malicioso se lleve el código a otro dominio.
+    redirect_uris TEXT[] NOT NULL CHECK (array_length(redirect_uris, 1) >= 1),
+    -- Metadatos tal cual los envió el cliente, por si hay que depurar.
+    metadata JSONB,
+    creado_en TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now()),
+    ultimo_uso_en TIMESTAMPTZ
+);
+
+COMMENT ON TABLE public.mcp_oauth_cliente IS
+    'Aplicaciones que pueden pedir acceso al servidor MCP. Se registran solas (RFC 7591): normalmente hay una fila por cada cliente de Claude que se conecta.';
+
+-- -----------------------------------------------------------------------------
+-- Códigos de autorización (un solo uso, 5 minutos)
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.mcp_oauth_codigo (
+    codigo_hash TEXT PRIMARY KEY,
+    client_id TEXT NOT NULL REFERENCES public.mcp_oauth_cliente(client_id) ON DELETE CASCADE,
+    usuario_id UUID NOT NULL,
+    redirect_uri TEXT NOT NULL,
+    -- PKCE obligatorio y solo S256: sin secreto de cliente, es lo que ata el
+    -- código a quien lo pidió.
+    code_challenge TEXT NOT NULL,
+    code_challenge_method TEXT NOT NULL DEFAULT 'S256' CHECK (code_challenge_method = 'S256'),
+    scope TEXT NOT NULL,
+    -- RFC 8707: para qué servidor se pidió el token. Evita que un token emitido
+    -- para otro recurso valga aquí.
+    resource TEXT,
+    expira_en TIMESTAMPTZ NOT NULL,
+    usado_en TIMESTAMPTZ,
+    creado_en TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS idx_mcp_oauth_codigo_expira
+    ON public.mcp_oauth_codigo(expira_en);
+
+COMMENT ON TABLE public.mcp_oauth_codigo IS
+    'Códigos de autorización OAuth, de un solo uso. Se guarda el SHA-256, nunca el código.';
+
+-- -----------------------------------------------------------------------------
+-- Tokens de acceso y de refresco
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.mcp_oauth_token (
+    token_hash TEXT PRIMARY KEY,
+    tipo TEXT NOT NULL CHECK (tipo IN ('access', 'refresh')),
+    client_id TEXT NOT NULL REFERENCES public.mcp_oauth_cliente(client_id) ON DELETE CASCADE,
+    usuario_id UUID NOT NULL,
+    scope TEXT NOT NULL,
+    resource TEXT,
+    expira_en TIMESTAMPTZ NOT NULL,
+    revocado_en TIMESTAMPTZ,
+    ultimo_uso_en TIMESTAMPTZ,
+    creado_en TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS idx_mcp_oauth_token_usuario
+    ON public.mcp_oauth_token(usuario_id, tipo)
+    WHERE revocado_en IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_mcp_oauth_token_expira
+    ON public.mcp_oauth_token(expira_en);
+
+COMMENT ON TABLE public.mcp_oauth_token IS
+    'Tokens vivos del servidor MCP. Se guarda el SHA-256, nunca el token. Revocar = poner revocado_en.';
+
+-- -----------------------------------------------------------------------------
+-- RLS: cerrada del todo. Solo la service role key (que la salta) entra aquí.
+-- -----------------------------------------------------------------------------
+ALTER TABLE public.mcp_oauth_cliente ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.mcp_oauth_codigo ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.mcp_oauth_token ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON public.mcp_oauth_cliente FROM anon, authenticated;
+REVOKE ALL ON public.mcp_oauth_codigo FROM anon, authenticated;
+REVOKE ALL ON public.mcp_oauth_token FROM anon, authenticated;
+
+-- -----------------------------------------------------------------------------
+-- Limpieza de lo caducado
+-- -----------------------------------------------------------------------------
+-- Los códigos duran 5 minutos y los tokens de refresco 30 días: sin limpiar,
+-- las tablas crecerían para siempre con basura inútil. Se llama desde el propio
+-- endpoint de token (cuesta milisegundos) para no depender de un cron.
+CREATE OR REPLACE FUNCTION public.limpiar_mcp_oauth_caducado()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+    DELETE FROM public.mcp_oauth_codigo
+     WHERE expira_en < timezone('utc', now()) - INTERVAL '1 day';
+
+    DELETE FROM public.mcp_oauth_token
+     WHERE expira_en < timezone('utc', now()) - INTERVAL '7 days';
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.limpiar_mcp_oauth_caducado() FROM PUBLIC, anon, authenticated;


### PR DESCRIPTION
## Por qué

Los conectores personalizados de claude.ai **no dejan pegar una cabecera** con una clave de API: negocian el acceso por OAuth. Sin esto, el servidor MCP que se añadió en #169 solo servía desde Claude Code y Claude Desktop.

Ahora MCM Bank es también servidor de autorización, y el conector se configura solo. La cadena de descubrimiento es lo que lo hace posible:

```
POST /api/mcp  →  401 + WWW-Authenticate: ... resource_metadata="..."
               →  /.well-known/oauth-protected-resource
               →  /.well-known/oauth-authorization-server
               →  POST /api/oauth/registro      (registro dinámico, RFC 7591)
               →  GET  /oauth/autorizar         (login + consentimiento)
               →  POST /api/oauth/token         (código + PKCE → token)
```

## El premio va más allá de la web

La pantalla de consentimiento **reutiliza el login de Supabase que ya existe**, así que cada persona entra con su cuenta. Eso arregla de raíz lo más de apaño de #169: con OAuth, las notas y facturas que cree el asistente salen firmadas por quien está al otro lado, y `MCM_API_USER_EMAIL` deja de hacer falta.

**Conectar desde claude.ai no necesita ninguna variable de entorno nueva.**

## Reglas que sostienen esto

- **PKCE S256 obligatorio, sin secretos de cliente.** Son aplicaciones públicas; PKCE es lo único que ata el código a quien lo pidió. El método `plain` se rechaza.
- **`redirect_uri` con coincidencia exacta.** Si falla el cliente o la redirect_uri **no se redirige a ningún sitio**: el error se enseña en pantalla. Redirigir a un destino sin validar es el agujero clásico de OAuth. La distinción fatal-vs-redirigible vive en `lib/oauth/autorizacion.ts`, y la pantalla y el POST usan **el mismo validador**, para que manipular un campo oculto del formulario no sirva de nada.
- **Solo `gestor_central` puede autorizar.** El servidor MCP bypasea RLS y ve las 18 delegaciones; dárselo a un tesorero le abriría las cuentas de las otras diecisiete.
- **Códigos de un solo uso (5 min) y refrescos que rotan.** Reutilizar cualquiera de los dos revoca todos los tokens de ese cliente y usuario: solo pasa si se han filtrado.
- **De códigos y tokens se guarda solo el SHA-256.** Quien lea la base de datos no puede suplantar a nadie.
- **Con token OAuth la identidad la fija el token** (`actorForzado`): los argumentos de las herramientas ya no pueden cambiar el autor. Con clave de API, `usuario_email` sigue funcionando como antes.
- **El registro de clientes está abierto**, como exige el flujo. No es un agujero: registrarse no da acceso a nada; hace falta que una persona entre y apruebe.

## Retirar el acceso

La pantalla de consentimiento promete que se puede revocar cuando se quiera, así que se añade **Configuración → Conexiones con asistentes (MCP)**: qué aplicaciones tienen acceso, quién las autorizó, cuándo se usaron por última vez, y un botón para retirárselo al instante.

## Base de datos

`scripts/058_mcp_oauth.sql` añade tres tablas (`mcp_oauth_cliente`, `mcp_oauth_codigo`, `mcp_oauth_token`), todas con RLS activada y **ninguna política**: solo se llega con la service role key. **La migración ya está aplicada en el proyecto de Supabase** y verificada (RLS on, 0 políticas, sin permisos para `anon` ni `authenticated`). Es aditiva: no toca ninguna tabla existente.

## Detalle de implementación que conviene saber

Los documentos `.well-known` se sirven por **rewrite** desde `app/api/well-known/`: el enrutador de Next ignora las carpetas que empiezan por punto. Están también con sufijo de ruta (`/.well-known/oauth-protected-resource/api/mcp`) porque hay clientes que preguntan así.

## Qué se ha verificado

- `pnpm lint`, `pnpm typecheck`, `pnpm build` en verde.
- **150 tests** (32 nuevos): PKCE contra el vector oficial de la RFC 7636 y sus casos límite, validación de `redirect_uri` (https, localhost, esquemas nativos, rechazo de `http://` externo, `javascript:`, `data:` y fragmentos), normalización de scopes, validación de `resource`, y la validación completa de la petición de autorización con el almacén simulado — incluida la distinción fatal/redirigible.
- Contra el servidor construido: los dos documentos `.well-known` (con y sin sufijo, y el alias `openid-configuration`), el `401` con la cabecera `WWW-Authenticate` correcta, que la clave de API sigue funcionando (27 herramientas), el rechazo de `redirect_uri` en claro antes de tocar la base de datos, `unsupported_grant_type`, la pantalla de error cuando falta `client_id`, y que revocar responde 200 siempre (RFC 7009).

**No verificado:** el ida y vuelta completo del flujo con un cliente real, por no disponer de la `service_role_key` en el entorno de desarrollo — todo lo que toca la base de datos está probado en lógica pura y en forma de respuesta, pero no ejecutado contra Supabase. La prueba pendiente es la de verdad: añadir el conector en claude.ai y ver si completa el baile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114R4GqBvorLidhbU3uKx4Y

---
_Generated by [Claude Code](https://claude.ai/code/session_0114R4GqBvorLidhbU3uKx4Y)_