### PR TITLE
fix(avisos): fidelidad real al rediseño y desplegables que no abrían

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -37,6 +37,16 @@
   .scrollbar-thin::-webkit-scrollbar-track {
     background-color: #f3f4f6;
   }
+
+  /* Filas que se desplazan en horizontal sin enseñar la barra (filtros, chips) */
+  .scrollbar-none {
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+  }
+
+  .scrollbar-none::-webkit-scrollbar {
+    display: none;
+  }
 }
 
 @layer base {

--- a/components/avisos/aviso-composer.tsx
+++ b/components/avisos/aviso-composer.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useRef, useState } from "react"
+import { forwardRef, useEffect, useRef, useState } from "react"
 import { es } from "date-fns/locale"
 import {
   ArrowUp,
@@ -10,7 +10,9 @@ import {
   ChevronDown,
   Flag,
   Loader2,
+  MessageSquare,
   Plus,
+  SquareCheckBig,
   Tag,
   User,
   Users,
@@ -33,6 +35,12 @@ export interface AvisoDraft {
   referenciaAbierta: boolean
   /** Solo aplica a tareas. */
   responsable_id: string | null
+  /**
+   * Nombre del responsable elegido. Se guarda junto al id para que el chip lo
+   * muestre al instante (y tras recargar, con el borrador de localStorage) sin
+   * tener que ir a buscar la lista de asignables.
+   */
+  responsable_nombre: string | null
   /** Solo aplica a tareas. ISO "yyyy-mm-dd". */
   fecha_limite: string | null
   /** Solo aplica a tareas. */
@@ -47,6 +55,7 @@ export const AVISO_DRAFT_VACIO: AvisoDraft = {
   notificar: false,
   referenciaAbierta: false,
   responsable_id: null,
+  responsable_nombre: null,
   fecha_limite: null,
   urgente: false,
 }
@@ -56,6 +65,8 @@ interface AvisoComposerProps {
   onDraftChange: (cambios: Partial<AvisoDraft>) => void
   onSubmit: () => void
   enviando: boolean
+  /** Nombre del lado receptor, para el texto en reposo ("…a MCM Vila-real"). */
+  destinoNombre: string
   /** A quién avisaría el correo si se activa el interruptor, para el pie. */
   descripcionCorreo: string
   /** A quién se le puede asignar la tarea dirigida a `destinatario`. */
@@ -74,41 +85,40 @@ const DESTINATARIO_OPCIONES: { value: AvisoDestinatario; label: string; icono: t
   { value: "oficina_tecnica", label: "Para la oficina técnica", icono: Users },
 ]
 
-function Chip({
-  active,
-  dashed,
-  onClick,
-  children,
-  className,
-}: {
-  active?: boolean
-  dashed?: boolean
-  onClick?: () => void
-  children: React.ReactNode
-  className?: string
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={cn(
-        "inline-flex h-7 items-center gap-1.5 whitespace-nowrap rounded-lg px-2.5 text-[12px] font-medium transition-colors duration-150",
-        dashed ? "border border-dashed border-border text-muted-foreground hover:border-foreground/30 hover:text-foreground" : "",
-        !dashed && !active && "bg-muted text-muted-foreground hover:text-foreground",
-        active && "bg-primary/10 text-primary hover:bg-primary/15",
-        className,
-      )}
-    >
-      {children}
-    </button>
-  )
-}
+/**
+ * Chip de detalle del compositor (responsable, fecha, prioridad, referencia).
+ *
+ * Reenvía ref y props porque varios de estos chips son el `PopoverTrigger` de
+ * Radix con `asChild`: si no se propagan, el `onClick` que abre el desplegable
+ * nunca llega al botón y el chip se queda muerto.
+ */
+const Chip = forwardRef<
+  HTMLButtonElement,
+  React.ButtonHTMLAttributes<HTMLButtonElement> & { relleno?: boolean }
+>(({ relleno, className, children, ...props }, ref) => (
+  <button
+    ref={ref}
+    type="button"
+    {...props}
+    className={cn(
+      "inline-flex h-7 items-center gap-1.5 whitespace-nowrap rounded-lg px-2.5 text-[12px] transition-colors duration-150",
+      relleno
+        ? "bg-secondary text-muted-foreground hover:bg-secondary/80"
+        : "border border-dashed border-border text-muted-foreground hover:border-foreground/30 hover:text-foreground",
+      className,
+    )}
+  >
+    {children}
+  </button>
+))
+Chip.displayName = "Chip"
 
 export function AvisoComposer({
   draft,
   onDraftChange,
   onSubmit,
   enviando,
+  destinoNombre,
   descripcionCorreo,
   onCargarAsignables,
   textareaRef,
@@ -118,9 +128,8 @@ export function AvisoComposer({
   const referenciaRef = useRef<HTMLInputElement | null>(null)
   const contenedorRef = useRef<HTMLDivElement | null>(null)
 
-  // "Reposo" solo cuando no hay nada que perder: si hay texto o metadatos
-  // (por ejemplo, un borrador recuperado de localStorage tras hidratar) el
-  // compositor se muestra abierto sin esperar a que el usuario haga clic.
+  // "Reposo" solo cuando no hay nada que perder: si hay texto o detalles (por
+  // ejemplo un borrador recuperado de localStorage) se muestra ya desplegado.
   const [expandidoManual, setExpandidoManual] = useState(false)
   const [destinoAbierto, setDestinoAbierto] = useState(false)
   const [responsableAbierto, setResponsableAbierto] = useState(false)
@@ -130,8 +139,10 @@ export function AvisoComposer({
 
   const esTarea = draft.tipo === "tarea"
   const puedeEnviar = draft.contenido.trim().length > 0 && !enviando
-  const tieneMetadatos = Boolean(draft.referencia || draft.responsable_id || draft.fecha_limite || draft.urgente)
-  const expandido = expandidoManual || Boolean(draft.contenido.trim()) || tieneMetadatos
+  const tieneDetalles = Boolean(
+    draft.referencia || draft.responsable_id || draft.fecha_limite || draft.urgente,
+  )
+  const expandido = expandidoManual || Boolean(draft.contenido.trim()) || tieneDetalles
 
   // Autoajuste de altura: crece hasta 5 líneas y luego hace scroll.
   useEffect(() => {
@@ -145,9 +156,9 @@ export function AvisoComposer({
     if (draft.referenciaAbierta) referenciaRef.current?.focus()
   }, [draft.referenciaAbierta])
 
-  // Se carga al abrir el popover (no en un efecto): es una reacción directa al
-  // clic del usuario, no una sincronización con el render.
-  const abrirResponsablePicker = (siguiente: boolean) => {
+  // Se carga al abrir el desplegable, no en un efecto: es una reacción directa
+  // al clic del usuario, no una sincronización con el render.
+  const abrirResponsables = (siguiente: boolean) => {
     setResponsableAbierto(siguiente)
     if (!siguiente) return
     setCargandoAsignables(true)
@@ -168,115 +179,120 @@ export function AvisoComposer({
     }
   }
 
-  const handleBlurContenedor = () => {
-    // Los popovers (destinatario, responsable, fecha) se pintan en un portal
-    // fuera de este contenedor, así que el foco puede "salir" del DOM sin que
-    // el usuario haya abandonado el compositor. Se comprueba en el siguiente
-    // tick, cuando el nuevo elemento activo ya está asentado.
+  const handleBlur = () => {
+    // Los desplegables se pintan en un portal fuera de este contenedor, así que
+    // el foco puede salir del árbol sin que el usuario haya abandonado el
+    // compositor. Se comprueba en el siguiente tick, ya asentado el foco.
     setTimeout(() => {
       if (destinoAbierto || responsableAbierto || fechaAbierta) return
       if (contenedorRef.current?.contains(document.activeElement)) return
-      if (draft.contenido.trim() || tieneMetadatos) return
+      if (draft.contenido.trim() || tieneDetalles) return
       setExpandidoManual(false)
     }, 0)
   }
 
-  const responsableActual = draft.responsable_id
-    ? asignables.find((a) => a.id === draft.responsable_id)?.nombre
-    : null
-
+  // ── Reposo: el compositor plegado, la lista manda ──────────────────────────
   if (!expandido) {
     return (
-      <div className="px-2.5 pb-2.5">
+      <div className="px-4 pb-3.5">
         <button
           type="button"
           onClick={abrir}
           className={cn(
-            "flex w-full items-center gap-2.5 rounded-2xl border border-dashed border-border px-3.5 py-3 text-left text-[13.5px] text-muted-foreground",
-            "transition-colors duration-150 hover:border-foreground/25 hover:text-foreground",
+            // Móvil: acción principal de la barra inferior, sólida y a 48px.
+            "flex w-full items-center justify-center gap-2.5 rounded-[14px]",
+            "h-12 bg-primary text-[15px] font-semibold text-primary-foreground",
+            "transition-colors duration-150 hover:bg-primary/90",
+            // Escritorio: discreta, la lista manda.
+            "sm:h-auto sm:justify-start sm:rounded-[14px] sm:border sm:border-dashed sm:border-border",
+            "sm:bg-background sm:px-3.5 sm:py-3 sm:text-left sm:text-[13.5px] sm:font-normal sm:text-muted-foreground",
+            "sm:hover:border-foreground/25 sm:hover:bg-background sm:hover:text-foreground",
           )}
         >
-          <Plus className="h-4 w-4 shrink-0" aria-hidden />
-          Escribir un aviso…
+          <Plus className="h-[18px] w-[18px] shrink-0 sm:h-4 sm:w-4" aria-hidden />
+          <span className="truncate sm:hidden">Escribir un aviso</span>
+          <span className="hidden truncate sm:inline">Escribir un aviso a {destinoNombre}…</span>
         </button>
       </div>
     )
   }
 
+  // ── Escribiendo ────────────────────────────────────────────────────────────
   return (
-    <div className="px-2.5 pb-2.5" ref={contenedorRef} onBlur={handleBlurContenedor}>
-      <div
-        className={cn(
-          "rounded-2xl border border-primary/45 bg-background/70",
-          "shadow-[0_0_0_3.5px_hsl(var(--primary)/0.10)]",
-        )}
-      >
+    <div className="px-4 pb-3.5" ref={contenedorRef} onBlur={handleBlur}>
+      <div className="rounded-2xl border border-primary/45 bg-card shadow-[0_0_0_3.5px_hsl(var(--primary)/0.10)]">
         {/* Tipo + destinatario */}
         <div className="flex items-center gap-1 px-2.5 pt-2.5">
-          <div className="flex rounded-lg bg-muted/70 p-[2px]">
-            <button
-              type="button"
-              onClick={() => onDraftChange({ tipo: "tarea" })}
-              aria-pressed={draft.tipo === "tarea"}
-              className={cn(
-                "inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 text-[11.5px] font-semibold",
-                "transition-[background-color,color] duration-150",
-                draft.tipo === "tarea"
-                  ? "bg-amber-500/15 text-amber-700 dark:text-amber-400"
-                  : "text-muted-foreground hover:text-foreground",
-              )}
-            >
-              Tarea
-            </button>
-            <button
-              type="button"
-              onClick={() => onDraftChange({ tipo: "nota" })}
-              aria-pressed={draft.tipo === "nota"}
-              className={cn(
-                "inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 text-[11.5px] font-semibold",
-                "transition-[background-color,color] duration-150",
-                draft.tipo === "nota"
-                  ? "bg-primary/15 text-primary"
-                  : "text-muted-foreground hover:text-foreground",
-              )}
-            >
-              Nota
-            </button>
-          </div>
+          {(
+            [
+              { tipo: "tarea" as const, label: "Tarea", Icono: SquareCheckBig },
+              { tipo: "nota" as const, label: "Nota", Icono: MessageSquare },
+            ]
+          ).map(({ tipo, label, Icono }) => {
+            const activo = draft.tipo === tipo
+            return (
+              <button
+                key={tipo}
+                type="button"
+                onClick={() => onDraftChange({ tipo })}
+                aria-pressed={activo}
+                className={cn(
+                  "inline-flex h-7 items-center gap-1.5 rounded-lg px-[11px] text-[12px]",
+                  "transition-colors duration-150",
+                  activo
+                    ? tipo === "tarea"
+                      ? "bg-amber-500/[0.14] font-semibold text-amber-800 dark:text-amber-300"
+                      : "bg-primary/[0.14] font-semibold text-blue-700 dark:text-blue-300"
+                    : "font-medium text-muted-foreground hover:text-foreground",
+                )}
+              >
+                <Icono className="h-[13px] w-[13px]" aria-hidden />
+                {label}
+              </button>
+            )
+          })}
 
-          <div className="flex-1" />
+          <span className="flex-1" />
 
           <Popover open={destinoAbierto} onOpenChange={setDestinoAbierto}>
             <PopoverTrigger asChild>
               <button
                 type="button"
-                className="inline-flex h-7 items-center gap-1.5 whitespace-nowrap rounded-lg border border-border px-2 text-[11.5px] font-medium text-foreground transition-colors duration-150 hover:bg-muted"
+                className={cn(
+                  "inline-flex h-7 items-center gap-1.5 whitespace-nowrap rounded-lg border border-border px-2.5",
+                  "text-[11.5px] font-medium text-foreground transition-colors duration-150 hover:bg-muted",
+                )}
               >
                 {DESTINATARIO_OPCIONES.find((o) => o.value === draft.destinatario)?.label}
                 <ChevronDown className="h-3 w-3 text-muted-foreground" aria-hidden />
               </button>
             </PopoverTrigger>
-            <PopoverContent align="end" className="w-56 p-1">
-              {DESTINATARIO_OPCIONES.map((opcion) => {
-                const Icono = opcion.icono
-                const activo = draft.destinatario === opcion.value
+            <PopoverContent align="end" className="w-60 p-1">
+              {DESTINATARIO_OPCIONES.map(({ value, label, icono: Icono }) => {
+                const activo = draft.destinatario === value
                 return (
                   <button
-                    key={opcion.value}
+                    key={value}
                     type="button"
                     onClick={() => {
-                      onDraftChange({ destinatario: opcion.value })
+                      // El responsable se elige entre la gente del lado que
+                      // recibe: si cambia el destinatario, deja de ser válido.
+                      onDraftChange({
+                        destinatario: value,
+                        responsable_id: null,
+                        responsable_nombre: null,
+                      })
                       setDestinoAbierto(false)
                     }}
                     className={cn(
-                      "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px]",
+                      "flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-[13px]",
                       "transition-colors duration-150 hover:bg-muted",
                       activo && "font-medium text-foreground",
                     )}
                   >
-                    <Icono className="h-3.5 w-3.5 text-muted-foreground" aria-hidden />
-                    <span className="flex-1">{opcion.label}</span>
-                    {activo && <Check className="h-3.5 w-3.5 text-primary" aria-hidden />}
+                    <Icono className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden />
+                    <span className="flex-1">{label}</span>
+                    {activo && <Check className="h-3.5 w-3.5 shrink-0 text-primary" aria-hidden />}
                   </button>
                 )
               })}
@@ -284,6 +300,7 @@ export function AvisoComposer({
           </Popover>
         </div>
 
+        {/* Texto */}
         <textarea
           ref={ref}
           rows={1}
@@ -292,16 +309,15 @@ export function AvisoComposer({
           onChange={(event) => onDraftChange({ contenido: event.target.value })}
           onKeyDown={handleKeyDown}
           placeholder={PLACEHOLDERS[draft.tipo]}
-          aria-label={draft.tipo === "tarea" ? "Nueva tarea" : "Nueva nota"}
+          aria-label={esTarea ? "Nueva tarea" : "Nueva nota"}
           className={cn(
-            "block w-full resize-none bg-transparent px-3 pt-2 text-[13.5px] leading-[1.5]",
-            "outline-none placeholder:text-muted-foreground/60",
-            "scrollbar-thin",
+            "scrollbar-thin block w-full resize-none bg-transparent px-3.5 pb-0.5 pt-2",
+            "text-[13.5px] leading-[1.55] outline-none placeholder:text-muted-foreground/60",
           )}
         />
 
         {draft.referenciaAbierta && (
-          <div className="flex items-center gap-1.5 px-3 pt-1.5">
+          <div className="flex items-center gap-1.5 px-3.5 pt-1.5">
             <Tag className="h-3 w-3 shrink-0 text-muted-foreground/70" aria-hidden />
             <input
               ref={referenciaRef}
@@ -338,31 +354,30 @@ export function AvisoComposer({
           </div>
         )}
 
-        {/* Chips opcionales: solo tienen sentido en tareas */}
-        <div className="flex flex-wrap items-center gap-1.5 px-2.5 pt-2">
+        {/* Detalles opcionales: solo tienen sentido en una tarea */}
+        <div className="flex flex-wrap items-center gap-1.5 px-3 pt-2.5">
           {esTarea && (
-            <Popover open={responsableAbierto} onOpenChange={abrirResponsablePicker}>
+            <Popover open={responsableAbierto} onOpenChange={abrirResponsables}>
               <PopoverTrigger asChild>
-                <Chip active={Boolean(draft.responsable_id)} dashed={!draft.responsable_id}>
-                  <User className="h-3 w-3" aria-hidden />
-                  {draft.responsable_id ? (
-                    <>
-                      Responsable <span className="font-semibold">{responsableActual ?? "…"}</span>
-                    </>
-                  ) : (
-                    "Responsable"
+                <Chip relleno={Boolean(draft.responsable_id)}>
+                  <User className="h-[13px] w-[13px]" aria-hidden />
+                  Responsable
+                  {draft.responsable_id && (
+                    <span className="font-semibold text-foreground">
+                      {draft.responsable_nombre ?? "Asignado"}
+                    </span>
                   )}
                 </Chip>
               </PopoverTrigger>
-              <PopoverContent align="start" className="w-56 p-1">
+              <PopoverContent align="start" className="w-60 p-1">
                 {cargandoAsignables ? (
                   <div className="flex items-center justify-center gap-2 py-4 text-[12px] text-muted-foreground">
                     <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
                     Cargando…
                   </div>
                 ) : asignables.length === 0 ? (
-                  <p className="px-2 py-3 text-[12px] text-muted-foreground">
-                    No hay nadie a quien asignar todavía.
+                  <p className="px-2 py-3 text-[12px] leading-snug text-muted-foreground">
+                    No hay nadie a quien asignar en ese lado todavía.
                   </p>
                 ) : (
                   <>
@@ -371,18 +386,21 @@ export function AvisoComposer({
                         key={persona.id}
                         type="button"
                         onClick={() => {
-                          onDraftChange({ responsable_id: persona.id })
+                          onDraftChange({
+                            responsable_id: persona.id,
+                            responsable_nombre: persona.nombre,
+                          })
                           setResponsableAbierto(false)
                         }}
                         className={cn(
-                          "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px]",
+                          "flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-[13px]",
                           "transition-colors duration-150 hover:bg-muted",
                           draft.responsable_id === persona.id && "font-medium",
                         )}
                       >
                         <span className="flex-1 truncate">{persona.nombre}</span>
                         {draft.responsable_id === persona.id && (
-                          <Check className="h-3.5 w-3.5 text-primary" aria-hidden />
+                          <Check className="h-3.5 w-3.5 shrink-0 text-primary" aria-hidden />
                         )}
                       </button>
                     ))}
@@ -390,10 +408,10 @@ export function AvisoComposer({
                       <button
                         type="button"
                         onClick={() => {
-                          onDraftChange({ responsable_id: null })
+                          onDraftChange({ responsable_id: null, responsable_nombre: null })
                           setResponsableAbierto(false)
                         }}
-                        className="mt-0.5 flex w-full items-center gap-2 rounded-md border-t border-border px-2 py-1.5 pt-2 text-left text-[12.5px] text-muted-foreground transition-colors duration-150 hover:bg-muted hover:text-foreground"
+                        className="mt-1 w-full rounded-md border-t border-border px-2 pb-1.5 pt-2 text-left text-[12.5px] text-muted-foreground transition-colors duration-150 hover:bg-muted hover:text-foreground"
                       >
                         Quitar responsable
                       </button>
@@ -407,16 +425,27 @@ export function AvisoComposer({
           {esTarea && (
             <Popover open={fechaAbierta} onOpenChange={setFechaAbierta}>
               <PopoverTrigger asChild>
-                <Chip active={Boolean(draft.fecha_limite)} dashed={!draft.fecha_limite}>
-                  <CalendarIcon className="h-3 w-3" aria-hidden />
-                  {draft.fecha_limite ? `Antes del ${formatFechaLimiteCorta(draft.fecha_limite)}` : "Fecha límite"}
+                <Chip relleno={Boolean(draft.fecha_limite)}>
+                  <CalendarIcon className="h-[13px] w-[13px]" aria-hidden />
+                  {draft.fecha_limite ? (
+                    <>
+                      Antes del{" "}
+                      <span className="font-semibold text-foreground">
+                        {formatFechaLimiteCorta(draft.fecha_limite)}
+                      </span>
+                    </>
+                  ) : (
+                    "Fecha límite"
+                  )}
                 </Chip>
               </PopoverTrigger>
               <PopoverContent align="start" className="w-auto p-0">
                 <Calendar
                   mode="single"
                   selected={draft.fecha_limite ? new Date(`${draft.fecha_limite}T12:00:00`) : undefined}
-                  defaultMonth={draft.fecha_limite ? new Date(`${draft.fecha_limite}T12:00:00`) : new Date()}
+                  defaultMonth={
+                    draft.fecha_limite ? new Date(`${draft.fecha_limite}T12:00:00`) : new Date()
+                  }
                   locale={es}
                   onSelect={(date) => {
                     if (!date) return
@@ -429,7 +458,7 @@ export function AvisoComposer({
                   autoFocus
                 />
                 {draft.fecha_limite && (
-                  <div className="border-t p-2">
+                  <div className="border-t border-border p-2">
                     <button
                       type="button"
                       onClick={() => {
@@ -448,46 +477,54 @@ export function AvisoComposer({
 
           {esTarea && (
             <Chip
-              active={draft.urgente}
-              dashed={!draft.urgente}
+              relleno={draft.urgente}
               onClick={() => onDraftChange({ urgente: !draft.urgente })}
-              className={draft.urgente ? "bg-destructive/10 text-destructive hover:bg-destructive/15" : undefined}
+              aria-pressed={draft.urgente}
+              className={
+                draft.urgente
+                  ? "bg-destructive/[0.12] font-semibold text-red-700 hover:bg-destructive/[0.18] dark:text-red-400"
+                  : undefined
+              }
             >
-              <Flag className="h-3 w-3" aria-hidden />
+              <Flag className="h-[13px] w-[13px]" aria-hidden />
               Urgente
             </Chip>
           )}
 
           {!draft.referenciaAbierta && (
-            <Chip dashed onClick={() => onDraftChange({ referenciaAbierta: true })}>
-              <Tag className="h-3 w-3" aria-hidden />
+            <Chip onClick={() => onDraftChange({ referenciaAbierta: true })}>
+              <Tag className="h-[13px] w-[13px]" aria-hidden />
               Referencia
             </Chip>
           )}
         </div>
 
-        {/* Pie: avisar por correo + enviar */}
-        <div className="mt-2.5 flex items-center gap-2.5 rounded-b-2xl border-t border-border/70 bg-primary/[0.03] px-3 py-2.5">
+        {/* Pie: a qué buzón va y enviar */}
+        <div
+          className={cn(
+            "mt-3 flex items-center gap-2.5 rounded-b-[15px] border-t border-border bg-primary/[0.04] px-3 py-2.5",
+          )}
+        >
           <Switch
             checked={draft.notificar}
             onCheckedChange={(checked) => onDraftChange({ notificar: checked })}
             aria-label="Avisar por correo al enviar"
           />
-          <span className="min-w-0 text-[11.5px] leading-[1.35] text-muted-foreground">
+          <span className="min-w-0 text-[12px] leading-[1.35] text-muted-foreground">
             Avisar por correo a
             <br />
             <span className="font-semibold text-foreground">{descripcionCorreo}</span>
           </span>
-          <div className="flex-1" />
+          <span className="flex-1" />
           <button
             type="button"
             onClick={onSubmit}
             disabled={!puedeEnviar}
             title="Enviar (Intro)"
             className={cn(
-              "inline-flex h-[34px] items-center gap-1.5 rounded-[10px] bg-primary px-3.5 text-[13px] font-semibold text-primary-foreground",
-              "transition-[background-color,opacity] duration-150 hover:bg-primary/90",
-              "disabled:pointer-events-none disabled:bg-muted disabled:text-muted-foreground/50",
+              "inline-flex h-[34px] shrink-0 items-center gap-1.5 rounded-[10px] px-3.5 text-[13px] font-semibold",
+              "bg-primary text-primary-foreground transition-colors duration-150 hover:bg-primary/90",
+              "disabled:pointer-events-none disabled:bg-muted disabled:text-muted-foreground/60",
             )}
           >
             {enviando ? (

--- a/components/avisos/aviso-item.tsx
+++ b/components/avisos/aviso-item.tsx
@@ -11,7 +11,7 @@ import {
   Check,
   Flag,
   Loader2,
-  Mail,
+  MailCheck,
   Trash2,
   User,
   UserPlus,
@@ -43,42 +43,18 @@ interface AvisoItemProps {
   onCargarAsignables: (destinatario: AvisoDestinatario) => Promise<AvisoAsignable[]>
 }
 
-/** Botón de icono discreto con área de pulsación de 40×40 vía pseudoelemento. */
-function AccionIcono({
-  label,
-  onClick,
-  children,
-  className,
-  disabled,
-}: {
-  label: string
-  onClick: () => void
-  children: React.ReactNode
-  className?: string
-  disabled?: boolean
-}) {
+/** Insignia corta en mayúsculas de la fila superior de la tarjeta. */
+function Insignia({ className, children }: { className?: string; children: React.ReactNode }) {
   return (
-    <button
-      type="button"
-      title={label}
-      aria-label={label}
-      disabled={disabled}
-      onClick={(event) => {
-        event.stopPropagation()
-        onClick()
-      }}
+    <span
       className={cn(
-        "relative flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground/70",
-        "before:absolute before:-inset-1 before:content-['']",
-        "transition-[color,background-color,transform] duration-150",
-        "hover:bg-muted hover:text-foreground active:scale-[0.96]",
-        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background",
-        "disabled:pointer-events-none disabled:opacity-40",
+        "inline-flex h-5 shrink-0 items-center gap-1 rounded-md px-2",
+        "text-[10.5px] font-bold uppercase leading-none tracking-[0.05em]",
         className,
       )}
     >
       {children}
-    </button>
+    </span>
   )
 }
 
@@ -108,9 +84,9 @@ export function AvisoItem({
     }
   }, [])
 
-  // Se carga al abrir el popover (no en un efecto): es una reacción directa al
-  // clic del usuario, no una sincronización con el render.
-  const abrirAsignarPicker = (siguiente: boolean) => {
+  // Se carga al abrir el desplegable, no en un efecto: es una reacción directa
+  // al clic del usuario, no una sincronización con el render.
+  const abrirAsignar = (siguiente: boolean) => {
     setAsignarAbierto(siguiente)
     if (!siguiente) return
     setCargandoAsignables(true)
@@ -120,12 +96,13 @@ export function AvisoItem({
   }
 
   const esTarea = aviso.tipo === "tarea"
-  const esNota = !esTarea
   const hecha = aviso.estado === "hecha"
   const autor = primerNombre(aviso.autorNombre)
   const notificado = Boolean(aviso.notificado_en)
   const vencida = !hecha && estaVencida(aviso.fecha_limite)
-  const origenLado: AvisoDestinatario = aviso.destinatario === "delegacion" ? "oficina_tecnica" : "delegacion"
+  const saliente = !aviso.esParaMi
+  const origenLado: AvisoDestinatario =
+    aviso.destinatario === "delegacion" ? "oficina_tecnica" : "delegacion"
 
   const pedirBorrado = () => {
     if (confirmandoBorrado) {
@@ -138,19 +115,10 @@ export function AvisoItem({
     confirmTimer.current = setTimeout(() => setConfirmandoBorrado(false), 3000)
   }
 
-  const completar = async () => {
-    setOcupado("completar")
+  const ejecutar = async (accion: "completar" | "notificar", fn: () => Promise<void> | void) => {
+    setOcupado(accion)
     try {
-      await onCompletar(aviso.id)
-    } finally {
-      setOcupado(null)
-    }
-  }
-
-  const notificar = async () => {
-    setOcupado("notificar")
-    try {
-      await onNotificar(aviso.id)
+      await fn()
     } finally {
       setOcupado(null)
     }
@@ -166,117 +134,110 @@ export function AvisoItem({
     }
   }
 
+  const listaAsignables = (
+    <PopoverContent align="end" className="w-60 p-1">
+      {cargandoAsignables ? (
+        <div className="flex items-center justify-center gap-2 py-4 text-[12px] text-muted-foreground">
+          <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+          Cargando…
+        </div>
+      ) : asignables.length === 0 ? (
+        <p className="px-2 py-3 text-[12px] leading-snug text-muted-foreground">
+          No hay nadie a quien asignar en ese lado todavía.
+        </p>
+      ) : (
+        <>
+          {asignables.map((persona) => (
+            <button
+              key={persona.id}
+              type="button"
+              onClick={() => void asignar(persona.id)}
+              className={cn(
+                "flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-[13px]",
+                "transition-colors duration-150 hover:bg-muted",
+                persona.id === aviso.responsable_id && "font-medium",
+              )}
+            >
+              <span className="flex-1 truncate">{persona.nombre}</span>
+              {persona.id === aviso.responsable_id && (
+                <Check className="h-3.5 w-3.5 shrink-0 text-primary" aria-hidden />
+              )}
+            </button>
+          ))}
+          {aviso.responsable_id && (
+            <button
+              type="button"
+              onClick={() => void asignar(null)}
+              className="mt-1 w-full rounded-md border-t border-border px-2 pb-1.5 pt-2 text-left text-[12.5px] text-muted-foreground transition-colors duration-150 hover:bg-muted hover:text-foreground"
+            >
+              Quitar responsable
+            </button>
+          )}
+        </>
+      )}
+    </PopoverContent>
+  )
+
   return (
     <div
-      onClick={aviso.noLeido && esTarea ? () => onMarcarLeido(aviso.id) : undefined}
+      onClick={aviso.noLeido ? () => onMarcarLeido(aviso.id) : undefined}
       className={cn(
-        "group relative flex flex-col gap-2.5 rounded-2xl border p-3.5 transition-colors duration-150",
+        "relative flex flex-col gap-[11px] rounded-[18px] border p-[15px] transition-colors duration-150",
+        "sm:gap-2.5 sm:rounded-2xl sm:p-3.5",
         hecha
-          ? "border-border/60 bg-muted/20 opacity-75"
+          ? "border-border bg-muted/25"
           : aviso.noLeido
-            ? cn("border-primary/30 bg-primary/[0.045] dark:bg-primary/[0.08]", esTarea && "cursor-pointer")
-            : "border-border/70 bg-card/40 hover:border-border",
+            ? "cursor-pointer border-primary/30 bg-primary/[0.045] dark:bg-primary/[0.07]"
+            : "border-border bg-card",
       )}
     >
-      {/* Badges */}
-      <div className="flex items-center gap-1.5">
-        <span
-          className={cn(
-            "inline-flex h-5 items-center rounded-md px-2 text-[10.5px] font-bold uppercase tracking-wide",
-            esTarea ? "bg-amber-500/15 text-amber-700 dark:text-amber-400" : "bg-primary/12 text-primary",
+      {/* Insignias a la izquierda (envuelven si no caben), estado fijo a la derecha */}
+      <div className="flex items-start gap-2">
+        <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-[7px] gap-y-1.5">
+          {esTarea ? (
+            <Insignia className="bg-amber-500/[0.16] text-amber-800 dark:text-amber-300">Tarea</Insignia>
+          ) : (
+            <Insignia className="bg-primary/[0.14] text-blue-700 dark:text-blue-300">Nota</Insignia>
           )}
-        >
-          {esTarea ? "Tarea" : "Nota"}
-        </span>
 
-        {esTarea && aviso.urgente && !hecha && (
-          <span className="inline-flex h-5 items-center gap-1 rounded-md bg-destructive/12 px-2 text-[10.5px] font-bold uppercase tracking-wide text-destructive">
-            <Flag className="h-2.5 w-2.5" aria-hidden />
-            Urgente
-          </span>
-        )}
+          {esTarea && aviso.urgente && !hecha && (
+            <Insignia className="bg-destructive/[0.12] text-red-700 dark:text-red-400">
+              <Flag className="h-[11px] w-[11px]" aria-hidden />
+              Urgente
+            </Insignia>
+          )}
 
-        <div className="flex-1" />
+          {/* Solo si no lo va a decir ya el indicador "Esperando" de la derecha */}
+          {saliente && !hecha && !esTarea && (
+            <Insignia className="bg-muted font-semibold tracking-[0.04em] text-muted-foreground">
+              Enviada por nosotros
+            </Insignia>
+          )}
+        </div>
 
-        {esNota && !hecha && (
-          <button
-            type="button"
-            onClick={(event) => {
-              event.stopPropagation()
-              if (aviso.noLeido) void onMarcarLeido(aviso.id)
-            }}
-            className={cn(
-              "inline-flex h-6 items-center gap-1.5 rounded-lg border px-2 text-[11.5px] font-medium transition-colors duration-150",
-              aviso.noLeido
-                ? "border-primary/40 text-primary hover:bg-primary/10"
-                : "border-border/70 text-muted-foreground",
-            )}
-          >
-            <Check className="h-3 w-3" aria-hidden />
-            Leído
-          </button>
-        )}
-
-        {esTarea && !hecha && aviso.noLeido && (
-          <span className="inline-flex items-center gap-1.5 text-[11px] font-semibold text-primary">
+        {/* Estado a la derecha: sin leer / esperando / leído */}
+        {aviso.noLeido && !hecha ? (
+          <span className="inline-flex h-5 shrink-0 items-center gap-1.5 text-[11px] font-semibold leading-none text-blue-600 dark:text-blue-300">
             <span aria-hidden className="h-1.5 w-1.5 rounded-full bg-primary" />
             Sin leer
           </span>
-        )}
-
-        {/* Acciones discretas de nota: visibles al pasar por encima */}
-        {esNota && puedeEscribir && (
-          <div
-            className={cn(
-              "flex shrink-0 items-center gap-0.5",
-              "opacity-100 transition-opacity duration-150",
-              "sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100",
-            )}
-          >
-            {hecha ? (
-              <AccionIcono label="Volver a pendiente" onClick={() => void onReabrir(aviso.id)}>
-                <ArrowUpLeft className="h-3.5 w-3.5" aria-hidden />
-              </AccionIcono>
-            ) : (
-              <AccionIcono label="Archivar nota" onClick={() => void completar()} disabled={ocupado === "completar"}>
-                {ocupado === "completar" ? (
-                  <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
-                ) : (
-                  <Archive className="h-3.5 w-3.5" aria-hidden />
-                )}
-              </AccionIcono>
-            )}
-            <AccionIcono
-              label={notificado ? "Volver a avisar por correo" : "Avisar por correo"}
-              onClick={() => void notificar()}
-              disabled={ocupado === "notificar"}
-              className={notificado ? "text-primary/70" : undefined}
-            >
-              {ocupado === "notificar" ? (
-                <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
-              ) : notificado ? (
-                <BellRing className="h-3.5 w-3.5" aria-hidden />
-              ) : (
-                <Bell className="h-3.5 w-3.5" aria-hidden />
-              )}
-            </AccionIcono>
-            {aviso.esMio && (
-              <AccionIcono
-                label={confirmandoBorrado ? "Pulsa otra vez para borrar" : "Borrar"}
-                onClick={pedirBorrado}
-                className={confirmandoBorrado ? "bg-destructive/10 text-destructive hover:bg-destructive/15 hover:text-destructive" : undefined}
-              >
-                {confirmandoBorrado ? <Check className="h-3.5 w-3.5" aria-hidden /> : <Trash2 className="h-3.5 w-3.5" aria-hidden />}
-              </AccionIcono>
-            )}
-          </div>
-        )}
+        ) : saliente && esTarea && !hecha ? (
+          <span className="inline-flex h-5 shrink-0 items-center gap-1.5 text-[11px] font-medium leading-none text-muted-foreground">
+            <span aria-hidden className="h-1.5 w-1.5 rounded-full bg-amber-500" />
+            Esperando
+          </span>
+        ) : !esTarea && !hecha ? (
+          <span className="inline-flex h-7 shrink-0 items-center gap-1.5 rounded-lg border border-border px-2.5 text-[12px] font-medium text-muted-foreground sm:h-7">
+            <Check className="h-[13px] w-[13px]" aria-hidden />
+            Leído
+          </span>
+        ) : null}
       </div>
 
       {/* Contenido */}
       <p
         className={cn(
-          "whitespace-pre-wrap break-words text-[13.5px] leading-[1.5] text-pretty",
+          "whitespace-pre-wrap break-words text-[15px] leading-[1.5] text-pretty sm:text-[14px]",
           aviso.noLeido && !hecha ? "font-medium text-foreground" : "text-foreground/90",
           hecha && "text-muted-foreground line-through decoration-muted-foreground/40",
         )}
@@ -284,136 +245,82 @@ export function AvisoItem({
         {aviso.contenido}
       </p>
 
-      {/* Responsable / asignar (solo tareas) */}
+      {/* Responsable y fecha límite (solo tareas) */}
       {esTarea && aviso.responsable_id && (
         <div
           className={cn(
-            "flex items-center gap-2.5 rounded-xl border p-2.5",
-            aviso.esParaMi ? "border-primary/30 bg-primary/[0.06]" : "border-border/70 bg-muted/30",
+            "flex items-center gap-2.5 rounded-xl border p-2.5 sm:gap-2.5 sm:rounded-[11px] sm:px-[11px] sm:py-[9px]",
+            aviso.esParaMi && !hecha ? "border-primary/35 bg-card" : "border-border bg-card",
           )}
         >
           <span
             className={cn(
-              "flex h-[26px] w-[26px] shrink-0 items-center justify-center rounded-full",
-              aviso.esParaMi ? "bg-primary/15 text-primary" : "bg-muted text-muted-foreground",
+              "flex h-7 w-7 shrink-0 items-center justify-center rounded-full sm:h-[26px] sm:w-[26px]",
+              aviso.esParaMi && !hecha
+                ? "bg-primary/[0.12] text-blue-700 dark:text-blue-300"
+                : "bg-muted text-muted-foreground",
             )}
           >
-            <User className="h-3.5 w-3.5" aria-hidden />
+            <User className="h-[15px] w-[15px] sm:h-3.5 sm:w-3.5" aria-hidden />
           </span>
-          <span className="flex min-w-0 flex-col gap-0.5">
+          <span className="flex min-w-0 flex-1 flex-col gap-0.5">
             <span
               className={cn(
-                "text-[10px] font-semibold uppercase tracking-wide",
-                aviso.esParaMi ? "text-primary" : "text-muted-foreground",
+                "truncate text-[10.5px] font-semibold uppercase leading-none tracking-[0.05em]",
+                aviso.esParaMi && !hecha
+                  ? "text-blue-700 dark:text-blue-300"
+                  : "text-muted-foreground",
               )}
             >
-              {aviso.esParaMi ? "Os lo han asignado a" : "Responsable"}
+              {aviso.esParaMi && !hecha ? "Os lo han asignado a" : "Responsable"}
             </span>
-            <span className="truncate text-[13px] font-semibold leading-tight">{aviso.responsableNombre ?? "—"}</span>
+            <span className="truncate text-[13.5px] font-semibold leading-[1.1] sm:text-[13px]">
+              {aviso.responsableNombre ?? "—"}
+            </span>
           </span>
-          <div className="flex-1" />
           {aviso.fecha_limite && (
             <span
               className={cn(
-                "inline-flex shrink-0 items-center gap-1.5 rounded-full px-2 text-[11.5px] font-semibold",
-                vencida || aviso.urgente ? "bg-destructive/10 text-destructive" : "bg-muted text-muted-foreground",
+                "inline-flex h-6 shrink-0 items-center gap-1.5 rounded-full px-2.5 text-[11.5px] font-semibold",
+                vencida || aviso.urgente
+                  ? "bg-destructive/[0.10] text-red-700 dark:text-red-400"
+                  : "bg-muted text-muted-foreground",
               )}
             >
               <Calendar className="h-3 w-3" aria-hidden />
-              {hecha ? formatFechaLimiteCorta(aviso.fecha_limite) : `Antes del ${formatFechaLimiteCorta(aviso.fecha_limite)}`}
+              <span className="hidden sm:inline">{hecha ? "" : "Antes del "}</span>
+              {formatFechaLimiteCorta(aviso.fecha_limite)}
             </span>
           )}
         </div>
       )}
 
+      {/* Sin responsable: invitación a asignar */}
       {esTarea && !aviso.responsable_id && !hecha && puedeEscribir && (
-        <Popover open={asignarAbierto} onOpenChange={abrirAsignarPicker}>
-          <div className="flex items-center gap-2.5 rounded-xl border border-dashed border-border p-2.5">
-            <span className="flex h-[26px] w-[26px] shrink-0 items-center justify-center rounded-full border border-border text-muted-foreground">
-              <UserPlus className="h-3.5 w-3.5" aria-hidden />
+        <Popover open={asignarAbierto} onOpenChange={abrirAsignar}>
+          <div className="flex items-center gap-2.5 rounded-xl border border-dashed border-border bg-secondary/60 p-2.5 sm:rounded-[11px] sm:px-[11px] sm:py-[9px]">
+            <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-border bg-card text-muted-foreground sm:h-[26px] sm:w-[26px]">
+              <UserPlus className="h-[15px] w-[15px] sm:h-3.5 sm:w-3.5" aria-hidden />
             </span>
             <span className="text-[12.5px] text-muted-foreground">Sin responsable asignado</span>
-            <div className="flex-1" />
+            <span className="flex-1" />
             <PopoverTrigger asChild>
               <button
                 type="button"
                 disabled={ocupado === "asignar"}
-                className="shrink-0 text-[12px] font-semibold text-primary hover:underline disabled:opacity-50"
+                onClick={(event) => event.stopPropagation()}
+                className="shrink-0 text-[12px] font-semibold text-blue-600 transition-colors hover:text-blue-700 disabled:opacity-50 dark:text-blue-300"
               >
                 {ocupado === "asignar" ? "Asignando…" : "Asignar"}
               </button>
             </PopoverTrigger>
           </div>
-          <PopoverContent align="end" className="w-56 p-1">
-            {cargandoAsignables ? (
-              <div className="flex items-center justify-center gap-2 py-4 text-[12px] text-muted-foreground">
-                <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
-                Cargando…
-              </div>
-            ) : asignables.length === 0 ? (
-              <p className="px-2 py-3 text-[12px] text-muted-foreground">No hay nadie a quien asignar todavía.</p>
-            ) : (
-              asignables.map((persona) => (
-                <button
-                  key={persona.id}
-                  type="button"
-                  onClick={() => void asignar(persona.id)}
-                  className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] transition-colors duration-150 hover:bg-muted"
-                >
-                  {persona.nombre}
-                </button>
-              ))
-            )}
-          </PopoverContent>
-        </Popover>
-      )}
-      {esTarea && aviso.responsable_id && !hecha && puedeEscribir && (
-        <Popover open={asignarAbierto} onOpenChange={abrirAsignarPicker}>
-          <PopoverTrigger asChild>
-            <button
-              type="button"
-              className="self-start text-[11.5px] font-medium text-muted-foreground hover:text-foreground hover:underline"
-            >
-              Cambiar responsable
-            </button>
-          </PopoverTrigger>
-          <PopoverContent align="start" className="w-56 p-1">
-            {cargandoAsignables ? (
-              <div className="flex items-center justify-center gap-2 py-4 text-[12px] text-muted-foreground">
-                <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
-                Cargando…
-              </div>
-            ) : (
-              <>
-                {asignables.map((persona) => (
-                  <button
-                    key={persona.id}
-                    type="button"
-                    onClick={() => void asignar(persona.id)}
-                    className={cn(
-                      "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] transition-colors duration-150 hover:bg-muted",
-                      persona.id === aviso.responsable_id && "font-medium",
-                    )}
-                  >
-                    <span className="flex-1 truncate">{persona.nombre}</span>
-                    {persona.id === aviso.responsable_id && <Check className="h-3.5 w-3.5 text-primary" aria-hidden />}
-                  </button>
-                ))}
-                <button
-                  type="button"
-                  onClick={() => void asignar(null)}
-                  className="mt-0.5 flex w-full items-center gap-2 rounded-md border-t border-border px-2 py-1.5 pt-2 text-left text-[12.5px] text-muted-foreground transition-colors duration-150 hover:bg-muted hover:text-foreground"
-                >
-                  Quitar responsable
-                </button>
-              </>
-            )}
-          </PopoverContent>
+          {listaAsignables}
         </Popover>
       )}
 
-      {/* Meta: autor, dirección, tiempo */}
-      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11.5px] leading-none text-muted-foreground">
+      {/* Meta: autor, dirección y cuándo */}
+      <div className="flex flex-wrap items-center gap-x-[7px] gap-y-1.5 text-[12px] leading-none text-muted-foreground sm:text-[11.5px]">
         {aviso.referencia && (
           <span className="inline-flex max-w-[160px] items-center truncate rounded-md bg-muted px-1.5 py-[3px] font-medium text-foreground/70">
             {aviso.referencia}
@@ -422,81 +329,129 @@ export function AvisoItem({
         <span className="font-medium text-foreground/75">{autor ?? "Alguien"}</span>
         <span aria-hidden className="text-muted-foreground/40">·</span>
         <span>{ladoLabel(origenLado, "origen", miLado, delegacionNombre)}</span>
-        <ArrowRight className="h-3 w-3 text-muted-foreground/50" aria-hidden />
+        <ArrowRight className="h-3 w-3 shrink-0 text-muted-foreground/60" aria-hidden />
         <span>{ladoLabel(aviso.destinatario, "destino", miLado, delegacionNombre)}</span>
         <span aria-hidden className="text-muted-foreground/40">·</span>
-        <span title={formatFechaCompleta(aviso.creado_en)} className="tabular-nums">
+        {/* El tiempo relativo y el formato largo dependen del reloj y del ICU
+            de cada entorno: difieren entre el render del servidor y el del
+            navegador, y esa diferencia es esperada. */}
+        <span
+          suppressHydrationWarning
+          title={formatFechaCompleta(aviso.creado_en)}
+          className="tabular-nums"
+        >
           {formatRelativoCorto(aviso.creado_en)}
         </span>
       </div>
 
+      {/* Rastro del correo enviado */}
       {notificado && (
-        <div className="flex items-center gap-1.5 rounded-lg bg-muted/50 px-2.5 py-1.5 text-[11.5px] text-muted-foreground">
-          <Mail className="h-3 w-3 shrink-0" aria-hidden />
-          <span className="min-w-0 truncate">
+        <div className="flex items-center gap-1.5 rounded-[10px] bg-secondary px-2.5 py-2 text-[11.5px] leading-[1.35] text-muted-foreground sm:rounded-[9px] sm:px-2.5 sm:py-[7px]">
+          <MailCheck className="h-[13px] w-[13px] shrink-0" aria-hidden />
+          <span className="min-w-0" suppressHydrationWarning>
             Avisado a{" "}
-            <span className="font-semibold text-foreground/80">
+            <span className="font-semibold text-foreground">
               {descripcionDestinoCorreo(aviso.destinatario, delegacionNombre)}
-            </span>
-            {" · "}
-            {formatRelativoCorto(aviso.notificado_en)}
+            </span>{" "}
+            · {formatRelativoCorto(aviso.notificado_en)}
           </span>
         </div>
       )}
 
-      {/* Acciones de tarea */}
-      {esTarea && puedeEscribir && (
-        <div className="flex items-center gap-1.5">
+      {/* Acciones */}
+      {puedeEscribir && (
+        <div className="flex items-center gap-2 sm:gap-1.5">
           {hecha ? (
             <button
               type="button"
-              onClick={() => void onReabrir(aviso.id)}
-              className="inline-flex h-8 items-center gap-1.5 rounded-lg border border-border px-2.5 text-[12px] font-medium text-foreground/80 transition-colors duration-150 hover:bg-muted"
+              onClick={(event) => {
+                event.stopPropagation()
+                void onReabrir(aviso.id)
+              }}
+              className="inline-flex h-11 items-center gap-2 rounded-xl border border-border px-3 text-[13px] font-medium text-foreground/80 transition-colors duration-150 hover:bg-muted sm:h-8 sm:rounded-[9px] sm:px-3 sm:text-[12.5px]"
             >
-              <ArrowUpLeft className="h-3.5 w-3.5" aria-hidden />
-              Reabrir
+              <ArrowUpLeft className="h-4 w-4 sm:h-3.5 sm:w-3.5" aria-hidden />
+              Volver a pendiente
             </button>
           ) : (
             <>
               <button
                 type="button"
-                onClick={() => void completar()}
+                onClick={(event) => {
+                  event.stopPropagation()
+                  void ejecutar("completar", () => onCompletar(aviso.id))
+                }}
                 disabled={ocupado === "completar"}
-                className="inline-flex h-8 items-center gap-1.5 rounded-lg bg-foreground px-3 text-[12.5px] font-semibold text-background transition-colors duration-150 hover:bg-foreground/90 disabled:pointer-events-none disabled:opacity-60"
+                className={cn(
+                  "inline-flex h-11 flex-1 items-center justify-center gap-2 rounded-xl px-3.5 text-[14px] font-semibold",
+                  "sm:h-8 sm:flex-none sm:justify-start sm:gap-1.5 sm:rounded-[9px] sm:px-[13px] sm:text-[12.5px]",
+                  "bg-foreground text-background transition-colors duration-150 hover:bg-foreground/90",
+                  "disabled:pointer-events-none disabled:opacity-60",
+                )}
               >
                 {ocupado === "completar" ? (
-                  <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+                  <Loader2 className="h-4 w-4 animate-spin sm:h-3.5 sm:w-3.5" aria-hidden />
+                ) : esTarea ? (
+                  <Check className="h-4 w-4 sm:h-3.5 sm:w-3.5" aria-hidden />
                 ) : (
-                  <Check className="h-3.5 w-3.5" aria-hidden />
+                  <Archive className="h-4 w-4 sm:h-3.5 sm:w-3.5" aria-hidden />
                 )}
-                Marcar hecha
+                {esTarea ? "Marcar hecha" : "Archivar"}
               </button>
+
               <button
                 type="button"
-                onClick={() => void notificar()}
+                onClick={(event) => {
+                  event.stopPropagation()
+                  void ejecutar("notificar", () => onNotificar(aviso.id))
+                }}
                 disabled={ocupado === "notificar"}
-                className="inline-flex h-8 items-center gap-1.5 rounded-lg border border-border px-2.5 text-[12px] font-medium text-foreground/80 transition-colors duration-150 hover:bg-muted disabled:pointer-events-none disabled:opacity-60"
+                title={notificado ? "Volver a avisar por correo" : "Avisar por correo"}
+                aria-label={notificado ? "Volver a avisar por correo" : "Avisar por correo"}
+                className={cn(
+                  "inline-flex h-11 w-11 items-center justify-center gap-2 rounded-xl border border-border text-foreground/80",
+                  "sm:h-8 sm:w-auto sm:rounded-[9px] sm:px-3 sm:text-[12.5px] sm:font-medium",
+                  "transition-colors duration-150 hover:bg-muted disabled:pointer-events-none disabled:opacity-60",
+                  notificado && "text-blue-600 dark:text-blue-300",
+                )}
               >
                 {ocupado === "notificar" ? (
-                  <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+                  <Loader2 className="h-4 w-4 animate-spin sm:h-3.5 sm:w-3.5" aria-hidden />
                 ) : notificado ? (
-                  <BellRing className="h-3.5 w-3.5" aria-hidden />
+                  <BellRing className="h-[17px] w-[17px] sm:h-3.5 sm:w-3.5" aria-hidden />
                 ) : (
-                  <Bell className="h-3.5 w-3.5" aria-hidden />
+                  <Bell className="h-[17px] w-[17px] sm:h-3.5 sm:w-3.5" aria-hidden />
                 )}
-                Recordar
+                <span className="hidden sm:inline">Recordar</span>
               </button>
             </>
           )}
-          <div className="flex-1" />
+
+          <span className="hidden flex-1 sm:block" />
+
           {aviso.esMio && (
-            <AccionIcono
-              label={confirmandoBorrado ? "Pulsa otra vez para borrar" : "Borrar"}
-              onClick={pedirBorrado}
-              className={confirmandoBorrado ? "bg-destructive/10 text-destructive hover:bg-destructive/15 hover:text-destructive" : undefined}
+            <button
+              type="button"
+              onClick={(event) => {
+                event.stopPropagation()
+                pedirBorrado()
+              }}
+              title={confirmandoBorrado ? "Pulsa otra vez para borrar" : "Borrar"}
+              aria-label={confirmandoBorrado ? "Pulsa otra vez para borrar" : "Borrar"}
+              className={cn(
+                "inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border border-border text-muted-foreground",
+                "sm:h-8 sm:w-8 sm:rounded-[9px] sm:border-transparent",
+                "transition-colors duration-150 hover:bg-muted hover:text-foreground",
+                confirmandoBorrado &&
+                  "border-destructive/30 bg-destructive/10 text-destructive hover:bg-destructive/15 hover:text-destructive",
+              )}
             >
-              {confirmandoBorrado ? <Check className="h-4 w-4" aria-hidden /> : <Trash2 className="h-4 w-4" aria-hidden />}
-            </AccionIcono>
+              {confirmandoBorrado ? (
+                <Check className="h-[17px] w-[17px] sm:h-[15px] sm:w-[15px]" aria-hidden />
+              ) : (
+                <Trash2 className="h-[17px] w-[17px] sm:h-[15px] sm:w-[15px]" aria-hidden />
+              )}
+            </button>
           )}
         </div>
       )}

--- a/components/avisos/avisos-panel.tsx
+++ b/components/avisos/avisos-panel.tsx
@@ -3,7 +3,13 @@
 import { useCallback, useMemo, useState } from "react"
 import { ArrowLeftRight, CheckCheck, ChevronLeft, ClipboardList, Loader2, X } from "lucide-react"
 import { cn } from "@/lib/utils"
-import type { Aviso, AvisoAsignable, AvisoCambios, AvisoContadores, AvisoDestinatario } from "@/lib/types/avisos"
+import type {
+  Aviso,
+  AvisoAsignable,
+  AvisoCambios,
+  AvisoContadores,
+  AvisoDestinatario,
+} from "@/lib/types/avisos"
 import { descripcionDestinoCorreo } from "./utils"
 import { AvisoComposer, type AvisoDraft } from "./aviso-composer"
 import { AvisoItem } from "./aviso-item"
@@ -12,7 +18,7 @@ type Pestana = "para_delegacion" | "para_oficina" | "hechas"
 
 interface AvisosPanelProps {
   delegacionNombre: string
-  /** Lado del usuario en esta delegación: define el lenguaje de cabecera y pestañas. */
+  /** Lado del usuario en esta delegación: define el lenguaje de cabecera y filtros. */
   miLado: AvisoDestinatario
   avisos: Aviso[]
   hechos: Aviso[]
@@ -74,15 +80,15 @@ export function AvisosPanel({
     [onCargarHechos],
   )
 
+  // Sin leer arriba; luego lo urgente; luego de más reciente a más antiguo.
   const ordenar = (lista: Aviso[]) =>
     [...lista].sort((a, b) => {
       if (a.noLeido !== b.noLeido) return a.noLeido ? -1 : 1
+      if (a.urgente !== b.urgente) return a.urgente ? -1 : 1
       return new Date(b.creado_en).getTime() - new Date(a.creado_en).getTime()
     })
 
-  // "Para vosotros/nosotros": lo dirigido a la delegación. "Enviados"/"Pedido a
-  // la oficina": lo dirigido a la oficina técnica. Da igual quién lo escribió:
-  // es la dirección del aviso la que decide en qué pestaña vive.
+  // Los filtros separan por la dirección del aviso, no por quién lo escribió.
   const paraDelegacion = useMemo(
     () => ordenar(avisos.filter((a) => a.destinatario === "delegacion")),
     [avisos],
@@ -92,33 +98,35 @@ export function AvisosPanel({
     [avisos],
   )
 
-  const etiquetas =
-    miLado === "oficina_tecnica"
-      ? { paraDelegacion: "Para vosotros", paraOficina: "Enviados" }
-      : { paraDelegacion: "Para nosotros", paraOficina: "Pedido a la oficina" }
-
-  const tabs: { id: Pestana; label: string; count: number }[] = [
-    { id: "para_delegacion", label: etiquetas.paraDelegacion, count: paraDelegacion.length },
-    { id: "para_oficina", label: etiquetas.paraOficina, count: paraOficina.length },
-    { id: "hechas", label: "Hechas", count: 0 },
+  const soyOficina = miLado === "oficina_tecnica"
+  const tabs: { id: Pestana; label: string; count: number | null }[] = [
+    {
+      id: "para_delegacion",
+      label: soyOficina ? "Para vosotros" : "Para nosotros",
+      count: paraDelegacion.length,
+    },
+    {
+      id: "para_oficina",
+      label: soyOficina ? "Enviados" : "Pedido a la oficina",
+      count: paraOficina.length,
+    },
+    { id: "hechas", label: "Hechas", count: null },
   ]
 
-  const lista = pestana === "para_delegacion" ? paraDelegacion : pestana === "para_oficina" ? paraOficina : hechos
+  const lista =
+    pestana === "para_delegacion" ? paraDelegacion : pestana === "para_oficina" ? paraOficina : hechos
   const cargando = pestana === "hechas" ? loadingHechos : loading
 
-  const miLadoLabel = miLado === "oficina_tecnica" ? "Oficina técnica" : delegacionNombre
-  const otroLadoLabel = miLado === "oficina_tecnica" ? delegacionNombre : "Oficina técnica"
+  const miLadoLabel = soyOficina ? "Oficina técnica" : delegacionNombre
+  const otroLadoLabel = soyOficina ? delegacionNombre : "Oficina técnica"
+  const destinoNombre =
+    draft.destinatario === "delegacion" ? delegacionNombre : "la oficina técnica"
 
   const asignar = useCallback(
-    (id: string, responsableId: string | null) => onActualizarCambios(id, { responsable_id: responsableId }),
+    (id: string, responsableId: string | null) =>
+      onActualizarCambios(id, { responsable_id: responsableId }),
     [onActualizarCambios],
   )
-
-  const vacioTitulo = pestana === "hechas" ? "Todavía no hay nada hecho" : "Nada por aquí"
-  const vacioTexto =
-    pestana === "hechas"
-      ? "Lo que marquéis como hecho aparecerá aquí."
-      : "Cuando haya algo en esta dirección, aparecerá aquí."
 
   return (
     <div
@@ -126,42 +134,42 @@ export function AvisosPanel({
       aria-label="Avisos y tareas"
       className={cn(
         "flex h-full w-full flex-col overflow-hidden bg-card",
-        "sm:h-auto sm:max-h-[min(78vh,620px)] sm:rounded-3xl sm:border sm:border-border/60 sm:bg-card/95 sm:backdrop-blur-2xl",
-        "sm:shadow-[0_1px_2px_rgba(0,0,0,0.04),0_12px_28px_-8px_rgba(0,0,0,0.16),0_32px_60px_-24px_rgba(0,0,0,0.22)]",
+        "sm:h-auto sm:max-h-[min(80vh,680px)] sm:rounded-3xl sm:border sm:border-border",
+        "sm:shadow-[0_1px_2px_rgba(0,0,0,0.04),0_18px_40px_-12px_rgba(0,0,0,0.18),0_40px_80px_-32px_rgba(0,0,0,0.26)]",
       )}
     >
       {/* Cabecera */}
-      <div className="flex items-start justify-between gap-2 border-b border-border/60 px-4 py-3.5 duration-200 animate-in fade-in-0 sm:border-b-0 sm:pb-1 sm:pt-3.5">
+      <div className="flex shrink-0 items-start justify-between gap-3 border-b border-border px-4 py-3.5 sm:px-5 sm:pb-3.5 sm:pt-[18px]">
         <div className="flex min-w-0 items-center gap-1 sm:gap-0">
           <button
             type="button"
             onClick={onClose}
             aria-label="Cerrar"
-            title="Cerrar (Esc)"
-            className="relative -ml-2 mr-1 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-foreground transition-colors duration-150 hover:bg-muted sm:hidden"
+            className="-ml-2.5 flex h-11 w-11 shrink-0 items-center justify-center rounded-xl text-foreground transition-colors duration-150 hover:bg-muted sm:hidden"
           >
-            <ChevronLeft className="h-5 w-5" aria-hidden />
+            <ChevronLeft className="h-[22px] w-[22px]" aria-hidden />
           </button>
-          <div className="min-w-0">
-            <h2 className="text-[14px] font-semibold leading-none tracking-tight text-balance sm:text-[13px]">
+          <div className="flex min-w-0 flex-col gap-1.5">
+            <h2 className="text-[17px] font-semibold leading-[1.1] tracking-[-0.01em] sm:text-[16px] sm:leading-[1.2]">
               Avisos y tareas
             </h2>
-            <div className="mt-1.5 flex items-center gap-1.5 text-[11.5px] leading-none text-muted-foreground sm:mt-1">
-              <span className="truncate font-medium text-foreground/80">{miLadoLabel}</span>
-              <ArrowLeftRight className="h-3 w-3 shrink-0" aria-hidden />
-              <span className="truncate font-medium text-foreground/80">{otroLadoLabel}</span>
+            <div className="flex items-center gap-[7px] text-[12px] leading-none text-muted-foreground">
+              <span className="truncate font-medium text-foreground">{miLadoLabel}</span>
+              <ArrowLeftRight className="h-[13px] w-[13px] shrink-0" aria-hidden />
+              <span className="truncate font-medium text-foreground">{otroLadoLabel}</span>
             </div>
           </div>
         </div>
-        <div className="flex shrink-0 items-center gap-0.5">
+
+        <div className="flex shrink-0 items-center gap-1">
           {contadores.noLeidos > 0 && (
             <button
               type="button"
               onClick={() => void onMarcarTodoLeido()}
               title="Marcar todo como leído"
               className={cn(
-                "relative inline-flex items-center gap-1 rounded-lg px-1.5 py-1 text-[11px] font-medium text-muted-foreground",
-                "transition-[background-color,color] duration-150 hover:bg-muted hover:text-foreground",
+                "inline-flex h-7 items-center gap-1.5 rounded-lg px-2.5 text-[12px] font-medium text-muted-foreground",
+                "transition-colors duration-150 hover:bg-muted hover:text-foreground",
               )}
             >
               <CheckCheck className="h-3.5 w-3.5" aria-hidden />
@@ -174,9 +182,9 @@ export function AvisosPanel({
             title="Cerrar (Esc)"
             aria-label="Cerrar"
             className={cn(
-              "relative hidden h-7 w-7 items-center justify-center rounded-lg text-muted-foreground/70 sm:flex",
+              "relative hidden h-7 w-7 items-center justify-center rounded-lg text-muted-foreground sm:flex",
               "before:absolute before:-inset-[6.5px] before:content-['']",
-              "transition-[background-color,color,transform] duration-150 hover:bg-muted hover:text-foreground active:scale-[0.96]",
+              "transition-colors duration-150 hover:bg-muted hover:text-foreground active:scale-[0.96]",
             )}
           >
             <X className="h-4 w-4" aria-hidden />
@@ -184,38 +192,56 @@ export function AvisosPanel({
         </div>
       </div>
 
-      {/* Pestañas */}
-      <div className="flex items-center gap-1 overflow-x-auto px-3 pb-1.5 pt-2 duration-200 animate-in fade-in-0 slide-in-from-bottom-1">
-        {tabs.map((tab) => (
-          <button
-            key={tab.id}
-            type="button"
-            onClick={() => cambiarPestana(tab.id)}
-            aria-pressed={pestana === tab.id}
-            className={cn(
-              "inline-flex shrink-0 items-center gap-1 rounded-lg px-2.5 py-1.5 text-[12px] font-medium sm:px-2 sm:py-1 sm:text-[11.5px]",
-              "transition-[background-color,color] duration-150",
-              pestana === tab.id
-                ? "bg-muted text-foreground"
-                : "text-muted-foreground hover:bg-muted/60 hover:text-foreground",
-            )}
-          >
-            {tab.label}
-            {tab.id !== "hechas" && tab.count > 0 && (
-              <span className="tabular-nums text-muted-foreground/70">{tab.count}</span>
-            )}
-          </button>
-        ))}
+      {/* Filtros por dirección */}
+      <div className="scrollbar-none flex shrink-0 items-center gap-1.5 overflow-x-auto px-4 pb-2.5 pt-3">
+        {tabs.map((tab) => {
+          const activa = pestana === tab.id
+          return (
+            <button
+              key={tab.id}
+              type="button"
+              onClick={() => cambiarPestana(tab.id)}
+              aria-pressed={activa}
+              className={cn(
+                "inline-flex h-[34px] shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full px-3.5 text-[13px]",
+                "transition-colors duration-150 sm:h-[30px] sm:px-3 sm:text-[12.5px]",
+                activa
+                  ? "bg-foreground font-medium text-background"
+                  : "bg-muted font-medium text-muted-foreground hover:text-foreground",
+              )}
+            >
+              {tab.label}
+              {tab.count !== null && tab.count > 0 && (
+                <span
+                  className={cn(
+                    "inline-flex h-[17px] min-w-[17px] items-center justify-center rounded-full px-1.5",
+                    "text-[11px] font-semibold tabular-nums leading-none",
+                    activa ? "bg-background/25 text-background" : "text-muted-foreground/70",
+                  )}
+                >
+                  {tab.count}
+                </span>
+              )}
+            </button>
+          )
+        })}
       </div>
 
-      {/* Compositor */}
+      {/* Compositor: en móvil se ancla abajo, en escritorio va sobre la lista */}
       {puedeEscribir && (
-        <div className="duration-200 animate-in fade-in-0 slide-in-from-bottom-1 delay-75 fill-mode-backwards">
+        <div
+          className={cn(
+            "order-last shrink-0 border-t border-border bg-background pt-3.5",
+            "pb-[max(1rem,env(safe-area-inset-bottom))]",
+            "sm:order-none sm:border-t-0 sm:bg-transparent sm:pb-0 sm:pt-0",
+          )}
+        >
           <AvisoComposer
             draft={draft}
             onDraftChange={onDraftChange}
             onSubmit={onSubmit}
             enviando={enviando}
+            destinoNombre={destinoNombre}
             descripcionCorreo={descripcionDestinoCorreo(draft.destinatario, delegacionNombre)}
             onCargarAsignables={onCargarAsignables}
             textareaRef={textareaRef}
@@ -223,29 +249,33 @@ export function AvisosPanel({
         </div>
       )}
 
-      <div className="mx-3 h-px bg-border/60" aria-hidden />
-
       {/* Lista */}
-      <div className="scrollbar-thin flex-1 overflow-y-auto overscroll-contain px-2 py-2 duration-200 animate-in fade-in-0 delay-150 fill-mode-backwards sm:px-1.5 sm:py-1.5">
+      <div className="scrollbar-thin flex-1 overflow-y-auto overscroll-contain px-4 pb-4 pt-0.5 sm:pb-[18px]">
         {error && (
-          <p className="mx-2 my-3 rounded-xl bg-destructive/10 px-3 py-2 text-[12px] leading-snug text-destructive">
+          <p className="my-2 rounded-xl bg-destructive/10 px-3 py-2 text-[12px] leading-snug text-destructive">
             {error}
           </p>
         )}
 
         {cargando && lista.length === 0 ? (
-          <div className="flex items-center justify-center gap-2 py-10 text-[12px] text-muted-foreground">
+          <div className="flex items-center justify-center gap-2 py-12 text-[12.5px] text-muted-foreground">
             <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
             Cargando…
           </div>
         ) : lista.length === 0 ? (
-          <div className="flex flex-col items-center gap-1.5 px-6 py-10 text-center">
+          <div className="flex flex-col items-center gap-1.5 px-6 py-12 text-center">
             <ClipboardList className="h-5 w-5 text-muted-foreground/40" aria-hidden />
-            <p className="text-[12.5px] font-medium text-foreground/80">{vacioTitulo}</p>
-            <p className="text-pretty text-[11.5px] leading-snug text-muted-foreground">{vacioTexto}</p>
+            <p className="text-[13px] font-medium text-foreground/80">
+              {pestana === "hechas" ? "Todavía no hay nada hecho" : "Nada por aquí"}
+            </p>
+            <p className="text-pretty text-[12px] leading-snug text-muted-foreground">
+              {pestana === "hechas"
+                ? "Lo que marquéis como hecho aparecerá aquí."
+                : "Cuando haya algo en esta dirección, aparecerá aquí."}
+            </p>
           </div>
         ) : (
-          <div className="flex flex-col gap-2">
+          <div className="flex flex-col gap-2.5 sm:gap-2">
             {lista.map((aviso) => (
               <AvisoItem
                 key={aviso.id}

--- a/components/avisos/avisos-widget.tsx
+++ b/components/avisos/avisos-widget.tsx
@@ -74,6 +74,8 @@ export function AvisosWidget() {
     setDraft((prev) => ({
       ...prev,
       destinatario: miLado === "delegacion" ? "oficina_tecnica" : "delegacion",
+      responsable_id: null,
+      responsable_nombre: null,
     }))
   }, [miLado, rolConocido, draft.contenido, setDraft])
 
@@ -161,6 +163,7 @@ export function AvisosWidget() {
         referencia: "",
         referenciaAbierta: false,
         responsable_id: null,
+        responsable_nombre: null,
         fecha_limite: null,
         urgente: false,
       }))
@@ -224,17 +227,29 @@ export function AvisosWidget() {
   const atajo = esMac ? "⌘I" : "Ctrl+I"
 
   return (
-    <div className="pointer-events-none fixed bottom-4 right-4 z-40 flex flex-col items-end gap-2 sm:bottom-6 sm:right-6 print:hidden">
+    <div className="pointer-events-none fixed bottom-4 right-4 z-40 flex flex-col items-end gap-2.5 sm:bottom-6 sm:right-6 print:hidden">
+      {/* Velo solo en móvil: la hoja tapa la pantalla, pero sigues en la misma página */}
+      {montado && (
+        <div
+          aria-hidden
+          onClick={cerrar}
+          className={cn(
+            "pointer-events-auto fixed inset-0 z-40 bg-foreground/20 backdrop-blur-[2px] sm:hidden",
+            open ? "duration-200 animate-in fade-in-0" : "duration-150 animate-out fade-out-0",
+          )}
+        />
+      )}
+
       {montado && (
         <div
           ref={panelRef}
           className={cn(
             // Móvil: hoja a pantalla completa, sin salir de donde estabas (es
-            // una superposición, no una navegación). Desktop: panel flotante
-            // anclado junto al botón, como hasta ahora.
+            // una superposición, no una navegación). Escritorio: panel flotante
+            // anclado junto al botón.
             "pointer-events-auto fixed inset-0 z-50 sm:static sm:inset-auto sm:z-auto sm:w-[27.25rem]",
             open
-              ? "duration-200 ease-[cubic-bezier(0.2,0,0,1)] animate-in fade-in-0 slide-in-from-bottom-4 sm:zoom-in-[0.98] sm:slide-in-from-bottom-3"
+              ? "duration-200 ease-panel animate-in fade-in-0 slide-in-from-bottom-4 sm:zoom-in-[0.98] sm:slide-in-from-bottom-3"
               : "duration-150 ease-out animate-out fade-out-0 slide-out-to-bottom-4 sm:slide-out-to-bottom-1",
           )}
         >
@@ -275,11 +290,11 @@ export function AvisosWidget() {
         aria-label={`Avisos y tareas (${atajo})`}
         title={`Avisos y tareas · ${atajo}`}
         className={cn(
-          "pointer-events-auto relative flex h-11 w-11 items-center justify-center rounded-full",
-          "border border-border/60 bg-card/90 text-foreground/80 backdrop-blur-xl",
-          "shadow-[0_1px_2px_rgba(0,0,0,0.05),0_6px_16px_-4px_rgba(0,0,0,0.18)]",
+          "pointer-events-auto relative flex h-11 w-11 items-center justify-center rounded-full sm:h-12 sm:w-12",
+          "bg-foreground text-background",
+          "shadow-[0_1px_2px_rgba(0,0,0,0.05),0_10px_24px_-6px_rgba(0,0,0,0.32)]",
           "transition-[background-color,color,box-shadow,transform,opacity] duration-150",
-          "hover:text-foreground hover:shadow-[0_1px_2px_rgba(0,0,0,0.05),0_10px_24px_-6px_rgba(0,0,0,0.24)]",
+          "hover:shadow-[0_1px_2px_rgba(0,0,0,0.05),0_14px_30px_-8px_rgba(0,0,0,0.40)]",
           "active:scale-[0.96]",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
           // La hoja a pantalla completa en móvil ya tiene su propio botón de
@@ -291,14 +306,14 @@ export function AvisosWidget() {
         <ClipboardList
           aria-hidden
           className={cn(
-            "absolute h-[18px] w-[18px] transition-[opacity,transform,filter] duration-200 ease-[cubic-bezier(0.2,0,0,1)]",
+            "absolute h-[18px] w-[18px] transition-[opacity,transform,filter] duration-200 ease-panel sm:h-[19px] sm:w-[19px]",
             open ? "scale-[0.25] opacity-0 blur-[4px]" : "scale-100 opacity-100 blur-0",
           )}
         />
         <X
           aria-hidden
           className={cn(
-            "absolute h-[18px] w-[18px] transition-[opacity,transform,filter] duration-200 ease-[cubic-bezier(0.2,0,0,1)]",
+            "absolute h-[18px] w-[18px] transition-[opacity,transform,filter] duration-200 ease-panel sm:h-[19px] sm:w-[19px]",
             open ? "scale-100 opacity-100 blur-0" : "scale-[0.25] opacity-0 blur-[4px]",
           )}
         />
@@ -306,7 +321,7 @@ export function AvisosWidget() {
         {badge > 0 && !open && (
           <span
             className={cn(
-              "absolute -right-0.5 -top-0.5 flex h-[17px] min-w-[17px] items-center justify-center rounded-full px-1",
+              "absolute -right-0.5 -top-0.5 flex h-[18px] min-w-[18px] items-center justify-center rounded-full px-1",
               "text-[10px] font-semibold leading-none tabular-nums text-white",
               "ring-2 ring-background duration-200 animate-in fade-in-0 zoom-in-75",
               badgeNoLeidos ? "bg-primary" : "bg-amber-500",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -13,6 +13,12 @@ const config: Config = {
   ],
   theme: {
   	extend: {
+  		transitionTimingFunction: {
+  			// Curva de entrada/salida de paneles y hojas. Con nombre propio: la
+  			// forma arbitraria equivalente lleva comas y Tailwind la marca como
+  			// ambigua al escanear el contenido.
+  			panel: 'cubic-bezier(0.2, 0, 0, 1)',
+  		},
   		colors: {
   			background: 'hsl(var(--background))',
   			foreground: 'hsl(var(--foreground))',


### PR DESCRIPTION
Corrige el pase anterior (#171), que se quedó lejos del diseño y dejó piezas rotas.

## Por qué falló

No llegué a renderizar el resultado ni una vez: verifiqué que compilaba y di por buena la fidelidad. Esta vez se ha revisado la pantalla de verdad, en claro, oscuro y móvil, y se ha comprobado a mano que cada desplegable responde.

El export de Claude Design estaba perfecto. De hecho partía de **los tokens del propio tema**: `hsl(217 91% 60%)` es `--primary`, `hsl(220 14% 95%)` es `--muted`, `hsl(220 20% 12%)` es `--card` en oscuro… Era una traducción literal y en su lugar improvisé tamaños más pequeños.

## Fallos de funcionamiento corregidos

- **Los chips de responsable y fecha límite no abrían nada.** El componente `Chip` no reenviaba ref ni props, así que al usarse como `PopoverTrigger asChild` se tragaba el `onClick` que inyecta Radix. Ahora es un `forwardRef` que propaga.
- **El nombre del responsable se quedaba en "…"** hasta abrir el desplegable. Se guarda junto al id en el borrador, así el chip lo pinta al instante y sobrevive a una recarga.
- **Error de hidratación en las fechas.** El tiempo relativo y el formato largo difieren entre servidor y navegador (reloj distinto e ICU distinto: `"a las 20:52"` vs `", 20:54"`, `"hace 26 h"` vs `"ayer"`). Se declara como diferencia esperada.
- **Warning de Tailwind** por una curva de easing ambigua: pasa a ser una utilidad con nombre (`ease-panel`).

## Fidelidad recuperada

- Iconos en el selector de tipo (`SquareCheckBig` / `MessageSquare`) y en el rastro de correo (`MailCheck`), que faltaban.
- Píldoras de filtro redondeadas con el activo en `bg-foreground` y su contador, en vez de pestañas pequeñas.
- Tipografías y espaciados del diseño: cabecera 16px, tarjetas a 14px de padding y 16px de radio, insignias 10.5px, botones a 32px, compositor a 13.5px.
- Estado "Esperando" para lo que enviamos y sigue abierto, y el bloque de responsable en azul con "Os lo han asignado a" cuando es para tu lado.
- La fila de insignias envuelve en lugar de recortar "Sin leer", y el estado queda fijo arriba a la derecha.
- En móvil, el compositor en reposo es el botón sólido de la barra inferior que pedía el diseño.

## Verificación

Renderizado y revisado con Playwright:

- Claro y oscuro, en las dos vistas (gestor central y tesorería local).
- Móvil a 390×844, claro y oscuro.
- Interacción comprobada: el chip Urgente conmuta (`aria-pressed=true`), abren los desplegables de responsable y destinatario, y el calendario abre **y selecciona** (el chip pasa a "Antes del 30 nov").
- `pnpm lint` (0 errores), `tsc --noEmit` limpio, `pnpm test` 150/150, `pnpm build` completo. Sin warnings ni errores de hidratación en el log del servidor.

## Pendiente de tu revisión

Sigue sin probarse con sesión real contra la base de datos: la asignación de responsable y el envío de correo se han verificado con datos simulados, no de extremo a extremo.


---
_Generated by [Claude Code](https://claude.ai/code/session_016YV1x9uPXLyW3PHtWtTSyT)_