### PR TITLE
fix(avisos): el panel ya no se cierra al usar sus desplegables

### DIFF
--- a/components/avisos/aviso-item.tsx
+++ b/components/avisos/aviso-item.tsx
@@ -26,7 +26,6 @@ import {
   formatFechaLimiteCorta,
   formatRelativoCorto,
   ladoLabel,
-  primerNombre,
 } from "./utils"
 
 interface AvisoItemProps {
@@ -97,7 +96,6 @@ export function AvisoItem({
 
   const esTarea = aviso.tipo === "tarea"
   const hecha = aviso.estado === "hecha"
-  const autor = primerNombre(aviso.autorNombre)
   const notificado = Boolean(aviso.notificado_en)
   const vencida = !hecha && estaVencida(aviso.fecha_limite)
   const saliente = !aviso.esParaMi
@@ -326,9 +324,9 @@ export function AvisoItem({
             {aviso.referencia}
           </span>
         )}
-        <span className="font-medium text-foreground/75">{autor ?? "Alguien"}</span>
-        <span aria-hidden className="text-muted-foreground/40">·</span>
-        <span>{ladoLabel(origenLado, "origen", miLado, delegacionNombre)}</span>
+        <span className="font-medium text-foreground/75">
+          {ladoLabel(origenLado, "origen", miLado, delegacionNombre)}
+        </span>
         <ArrowRight className="h-3 w-3 shrink-0 text-muted-foreground/60" aria-hidden />
         <span>{ladoLabel(aviso.destinatario, "destino", miLado, delegacionNombre)}</span>
         <span aria-hidden className="text-muted-foreground/40">·</span>

--- a/components/avisos/avisos-widget.tsx
+++ b/components/avisos/avisos-widget.tsx
@@ -9,6 +9,7 @@ import { useDelegationContext } from "@/contexts/delegation-context"
 import { useAvisos } from "@/hooks/use-avisos"
 import { useLocalStorageState } from "@/hooks/use-local-storage"
 import { AVISO_DRAFT_VACIO, type AvisoDraft } from "./aviso-composer"
+import { clicCierraPanel } from "./utils"
 import { AvisosPanel } from "./avisos-panel"
 
 const CIERRE_MS = 160
@@ -125,10 +126,7 @@ export function AvisosWidget() {
   useEffect(() => {
     if (!open) return
     const onPointerDown = (event: PointerEvent) => {
-      const target = event.target as Node
-      if (panelRef.current?.contains(target)) return
-      if (botonRef.current?.contains(target)) return
-      cerrar()
+      if (clicCierraPanel(event.target as Node, panelRef.current, botonRef.current)) cerrar()
     }
     document.addEventListener("pointerdown", onPointerDown)
     return () => document.removeEventListener("pointerdown", onPointerDown)

--- a/components/avisos/utils.test.ts
+++ b/components/avisos/utils.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest"
+import { clicCierraPanel } from "./utils"
+
+/**
+ * Dobles mínimos del DOM: `clicCierraPanel` solo necesita `contains()` en el
+ * panel y el botón, y `closest()` en el objetivo del clic. Los tests corren en
+ * entorno node, sin DOM, así que se construyen a mano.
+ */
+function contenedor(hijos: object[]): HTMLElement {
+  return { contains: (n: Node) => hijos.includes(n) } as unknown as HTMLElement
+}
+
+function elemento({ dentroDePortal = false } = {}): Element {
+  return { closest: (sel: string) => (dentroDePortal && sel.includes("radix") ? {} : null) } as unknown as Element
+}
+
+/** Nodo de texto: no tiene closest(), hay que mirar a su elemento padre. */
+function nodoTexto(padre: Element | null): Node {
+  return { parentElement: padre } as unknown as Node
+}
+
+describe("clicCierraPanel", () => {
+  const vacio = contenedor([])
+
+  it("cierra cuando el clic cae de verdad fuera", () => {
+    expect(clicCierraPanel(elemento(), vacio, vacio)).toBe(true)
+  })
+
+  it("no cierra si el clic es dentro del panel", () => {
+    const dentro = elemento()
+    expect(clicCierraPanel(dentro, contenedor([dentro]), vacio)).toBe(false)
+  })
+
+  it("no cierra si el clic es en el botón flotante", () => {
+    const enBoton = elemento()
+    expect(clicCierraPanel(enBoton, vacio, contenedor([enBoton]))).toBe(false)
+  })
+
+  // El fallo que motivó esta función: los desplegables viven en un portal
+  // colgado del body, así que elegir un día del calendario cerraba el panel.
+  it("no cierra si el clic es en un desplegable en portal (calendario, responsable…)", () => {
+    expect(clicCierraPanel(elemento({ dentroDePortal: true }), vacio, vacio)).toBe(false)
+  })
+
+  it("resuelve un nodo de texto por su elemento padre", () => {
+    expect(clicCierraPanel(nodoTexto(elemento({ dentroDePortal: true })), vacio, vacio)).toBe(false)
+    expect(clicCierraPanel(nodoTexto(elemento()), vacio, vacio)).toBe(true)
+  })
+
+  it("cierra si no hay objetivo o el nodo ya no cuelga de nada", () => {
+    expect(clicCierraPanel(null, vacio, vacio)).toBe(true)
+    expect(clicCierraPanel(nodoTexto(null), vacio, vacio)).toBe(true)
+  })
+})

--- a/components/avisos/utils.ts
+++ b/components/avisos/utils.ts
@@ -62,12 +62,30 @@ export function formatFechaCompleta(value?: string | null): string {
   })
 }
 
-/** Primer nombre, para que la línea de meta no se haga larga. */
-export function primerNombre(nombre?: string | null): string | null {
-  if (!nombre) return null
-  const limpio = nombre.trim()
-  if (!limpio) return null
-  return limpio.split(/\s+/)[0]
+/**
+ * Los desplegables del panel (calendario, responsable, destinatario) los pinta
+ * Radix en un portal colgado del body, así que no cuelgan del panel.
+ */
+const SELECTOR_PORTAL = "[data-radix-popper-content-wrapper]"
+
+/**
+ * ¿Este clic debe cerrar el panel de avisos?
+ *
+ * Solo si cae de verdad fuera: ni en el panel, ni en el botón flotante, ni en
+ * uno de esos desplegables. Sin la última comprobación, elegir un día en el
+ * calendario se lee como clic fuera y cierra el panel entero.
+ */
+export function clicCierraPanel(
+  target: Node | null,
+  panel: HTMLElement | null,
+  boton: HTMLElement | null,
+): boolean {
+  if (!target) return true
+  if (panel?.contains(target)) return false
+  if (boton?.contains(target)) return false
+  // Un nodo de texto no tiene closest(); se pregunta a su elemento padre.
+  const elemento = "closest" in target ? (target as Element) : target.parentElement
+  return !elemento?.closest(SELECTOR_PORTAL)
 }
 
 /** "31 dic" (o "31 dic 2027" si no es este año). `fechaIso` es "yyyy-mm-dd". */

--- a/docs/manual/11.-avisos-y-tareas.md
+++ b/docs/manual/11.-avisos-y-tareas.md
@@ -95,7 +95,7 @@ Los avisos viven **dentro de una delegación**. Los tesoreros de MCM Nules solo 
 | Tesorero / Gestor central | Leer, escribir, marcar hecho, archivar y avisar por correo |
 | Solo lectura              | Leer los avisos de su delegación                           |
 
-Cada aviso muestra **quién lo escribió** y cuándo. Borrar solo puede hacerlo quien lo creó (dos toques en la papelera, para no borrar sin querer).
+Cada aviso muestra **de qué lado a qué lado va** y cuándo se escribió, no el nombre de quien lo puso: en el panel importa la dirección, y para eso ya está el responsable si hay que señalar a alguien. Borrar solo puede hacerlo quien lo creó (dos toques en la papelera, para no borrar sin querer).
 
 ### Hechas
 


### PR DESCRIPTION
Dos correcciones sobre el panel de avisos.

## El panel se cerraba al usar sus propios desplegables

Elegir un día en el calendario, una persona en el desplegable de responsable o cambiar el destinatario cerraba el panel entero en escritorio.

**Causa:** Radix pinta esos desplegables en un portal colgado del `body`, así que quedan fuera del nodo del panel. El detector de "clic fuera" del widget comprobaba solo `panelRef.contains(target)` y `botonRef.contains(target)`, de modo que cualquier clic en un desplegable se leía como clic externo.

**Arreglo:** la condición pasa a ser una función con nombre, `clicCierraPanel`, que además ignora lo que cuelgue de `[data-radix-popper-content-wrapper]`. Al extraerla se puede probar de verdad: `components/avisos/utils.test.ts` cubre los cinco casos, y el del portal es exactamente el que fallaba (con la lógica anterior devolvía `true`, o sea, cerraba).

## Fuera el nombre del autor

Los perfiles son genéricos ("gestor", "tesorero"), así que el nombre no aportaba nada en la línea de meta. Queda solo la dirección y el momento:

```
antes:  Marta · Oficina técnica → MCM Vila-real · hace 2 h
ahora:  Oficina técnica → MCM Vila-real · hace 2 h
```

Para señalar a alguien ya está el campo de responsable, que sí es una elección deliberada. El dato `autorNombre` se mantiene en el modelo y en la API/MCP; solo deja de pintarse en el panel. Actualizada la línea del manual que decía lo contrario.

## Verificación

- `pnpm test` 156/156 (6 nuevos).
- `pnpm lint` 0 errores, `tsc --noEmit` limpio, `pnpm build` completo.
- Comprobado el resultado renderizado: la línea de meta ya no muestra nombre.


---
_Generated by [Claude Code](https://claude.ai/code/session_016YV1x9uPXLyW3PHtWtTSyT)_